### PR TITLE
Check and skip UTF-8 BOM in m3u file.

### DIFF
--- a/src/m3u.c
+++ b/src/m3u.c
@@ -910,7 +910,7 @@ int m3u_parse_and_create_services(const char *content, const char *source_url) {
   char proxy_url[MAX_URL_LENGTH];
   char transformed_line[MAX_M3U_LINE];
   
-  /* Check and skip UTF-8 BOM */  
+  /* Check and skip UTF-8 BOM */
   if (strncmp(content_ptr, "\xEF\xBB\xBF", 3) == 0) {
     content_ptr += 3;
     logger(LOG_DEBUG, "Detected and skipped UTF-8 BOM in M3U content");


### PR DESCRIPTION
If a file contains a BOM, the first line will technically start with \xEF\xBB\xBF#EXTM3U instead of just #EXTM3U. Because strncmp strictly compares the first 7 bytes, it will compare \xEF against #. The comparison will fail, and m3u_is_header() will return 0 (false). Thus EPG URL is Lost.