### PR TITLE
chore: include missing headers for FreeBSD

### DIFF
--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -4,6 +4,7 @@
 #include <netinet/in.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 
 /* Buffer pool configuration - optimized for RTP packets with cache alignment */
 #define BUFFER_POOL_ALIGNMENT 64

--- a/src/service.h
+++ b/src/service.h
@@ -2,6 +2,7 @@
 #define SERVICE_H
 
 #include <netdb.h>
+#include <stdint.h>
 
 /* ========== HTTP/SERVICE BUFFER SIZE CONFIGURATION ========== */
 

--- a/src/stun.c
+++ b/src/stun.c
@@ -9,6 +9,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>


### PR DESCRIPTION
修复缺失的头文件，解决 FreeBSD 编译失败问题。

目前还有其他影响编译的问题，后续解决后再单独提交。