### PR TITLE
fix: platform_bind_to_device not running on FreeBSD

### DIFF
--- a/docs/en/reference/configuration.md
+++ b/docs/en/reference/configuration.md
@@ -22,11 +22,11 @@ rtp2httpd [options]
 
 #### Upstream Network Interface Configuration
 
-- `-i, --upstream-interface <interface>` - Default upstream interface (applies to all traffic types, lowest priority)
-- `-f, --upstream-interface-fcc <interface>` - FCC upstream interface (overrides `-i`)
-- `-t, --upstream-interface-rtsp <interface>` - RTSP upstream interface (overrides `-i`)
+- `-i, --upstream-interface <interface>` - Default upstream interface (applies to all traffic types, lowest priority, not for FreeBSD)
+- `-f, --upstream-interface-fcc <interface>` - FCC upstream interface (overrides `-i` , not for FreeBSD)
+- `-t, --upstream-interface-rtsp <interface>` - RTSP upstream interface (overrides `-i` , not for FreeBSD)
 - `-r, --upstream-interface-multicast <interface>` - Multicast upstream interface (overrides `-i`)
-- `-y, --upstream-interface-http <interface>` - HTTP proxy upstream interface (overrides `-i`)
+- `-y, --upstream-interface-http <interface>` - HTTP proxy upstream interface (overrides `-i` , not for FreeBSD)
 
 **Priority order**: `upstream-interface-{fcc,rtsp,multicast,http}` > `upstream-interface` > system routing table
 
@@ -132,10 +132,12 @@ player-page-path = /player
 # Upstream network interface configuration (optional)
 #
 # Simple configuration: Configure only one default interface for all traffic types
+# Simple configuration not applicable to FreeBSD environments
 upstream-interface = eth0
 #
 # Advanced configuration: Configure dedicated interfaces for different traffic types
-# Note: Dedicated interface configuration has higher priority than default interface
+# Note: Dedicated interface configuration has higher priority than default interface,
+# Only upstream-interface-multicast is supported in FreeBSD environments.
 # upstream-interface-multicast = eth0  # Multicast traffic (RTP/UDP)
 # upstream-interface-fcc = eth1        # FCC
 # upstream-interface-rtsp = eth2       # RTSP

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -22,11 +22,11 @@ rtp2httpd [选项]
 
 #### 上游网络接口配置
 
-- `-i, --upstream-interface <接口>` - 默认上游接口（作用于所有流量类型，优先级最低）
-- `-f, --upstream-interface-fcc <接口>` - FCC 上游接口（覆盖 `-i` 设置）
-- `-t, --upstream-interface-rtsp <接口>` - RTSP 上游接口（覆盖 `-i` 设置）
+- `-i, --upstream-interface <接口>` - 默认上游接口（作用于所有流量类型，优先级最低，不适用于 FreeBSD 环境）
+- `-f, --upstream-interface-fcc <接口>` - FCC 上游接口（覆盖 `-i` 设置，不适用于 FreeBSD 环境）
+- `-t, --upstream-interface-rtsp <接口>` - RTSP 上游接口（覆盖 `-i` 设置，不适用于 FreeBSD 环境）
 - `-r, --upstream-interface-multicast <接口>` - 组播上游接口（覆盖 `-i` 设置）
-- `-y, --upstream-interface-http <接口>` - HTTP 代理上游接口（覆盖 `-i` 设置）
+- `-y, --upstream-interface-http <接口>` - HTTP 代理上游接口（覆盖 `-i` 设置，不适用于 FreeBSD 环境）
 
 **优先级规则**：`upstream-interface-{fcc,rtsp,multicast,http}` > `upstream-interface` > 系统路由表
 
@@ -131,11 +131,11 @@ player-page-path = /player
 
 # 上游网络接口配置 (可选)
 #
-# 简单配置：只配置一个默认接口，所有流量类型都使用此接口
+# 简单配置：只配置一个默认接口，所有流量类型都使用此接口，不适用于 FreeBSD 环境
 upstream-interface = eth0
 #
 # 高级配置：为不同流量类型配置专用接口
-# 注意：专用接口配置优先级高于默认接口
+# 注意：专用接口配置优先级高于默认接口，FreeBSD 环境下仅支持 upstream-interface-multicast
 # upstream-interface-multicast = eth0  # 组播流量 (RTP/UDP)
 # upstream-interface-fcc = eth1        # FCC
 # upstream-interface-rtsp = eth2       # RTSP

--- a/src/platform_compat.h
+++ b/src/platform_compat.h
@@ -121,6 +121,24 @@ static inline int platform_bind_to_device(int sock, const char *ifname) {
     return -1;
   return setsockopt(sock, IPPROTO_IP, IP_BOUND_IF, &ifindex, sizeof(ifindex));
 }
+#elif defined(__FreeBSD__)
+#include "utils.h"
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <string.h>
+static inline int platform_bind_to_device(int sock, const char *ifname) {
+    unsigned int ifindex = if_nametoindex(ifname);
+    if (ifindex == 0) return -1;
+    struct ip_mreqn mreqn;
+    memset(&mreqn, 0, sizeof(mreqn));
+    mreqn.imr_ifindex = (int)ifindex;
+    if (setsockopt(sock, IPPROTO_IP, IP_MULTICAST_IF, &mreqn, sizeof(mreqn)) < 0) {
+        logger(LOG_ERROR, "Platform Compat: Failed to bind devices because FreeBSD does not support binding unicast socket to network devices.");
+        return -1;
+    }
+    return 0;
+}
 #else /* Linux */
 #include <net/if.h>
 #include <string.h>


### PR DESCRIPTION
根据我目前了解的情况，FreeBSD 不支持给单播报文绑定设备，单播报文只能在 bind 时绑定接口的 IP 地址。

基于目前的情况，目前按照裁剪功能方案实现 platform_bind_to_device 函数改造以便推进工作，后续是否要配合 FreeBSD 特性进行改造有待于进一步讨论。