### PR TITLE
feat(web-ui): show date alongside time in log timestamps

### DIFF
--- a/web-ui/src/components/status/logs-section.tsx
+++ b/web-ui/src/components/status/logs-section.tsx
@@ -37,6 +37,23 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
     [options],
   );
 
+  const timestampFormatter = useMemo(() => {
+    const dateFormatter = new Intl.DateTimeFormat(locale, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    const timeFormatter = new Intl.DateTimeFormat(locale, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+    return {
+      format: (date: Date) => `${dateFormatter.format(date)} ${timeFormatter.format(date)}`,
+    };
+  }, [locale]);
+
   return (
     <section className="flex flex-col rounded-3xl border border-border/60 bg-card/90 p-5 shadow-sm">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -85,7 +102,7 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
                 key={`${log.timestamp}-${log.message}`}
                 className="rounded-lg border border-transparent bg-card/40 p-2 transition hover:border-border/60 text-sm text-card-foreground whitespace-pre-wrap"
               >
-                <span className="text-muted-foreground">{new Date(log.timestamp).toLocaleTimeString()}</span>{" "}
+                <span className="text-muted-foreground">{timestampFormatter.format(new Date(log.timestamp))}</span>{" "}
                 <span className="font-semibold uppercase tracking-wide text-primary">{log.levelName}</span>{" "}
                 {log.message}
               </div>


### PR DESCRIPTION
Status panel logs previously showed only `HH:MM:SS`, which is ambiguous once the daemon has been running for more than a day. Now display the full date as well.

Format date and time separately via `Intl.DateTimeFormat` with the active locale, then join with a space — keeps locale-aware ordering (e.g. `MM/DD/YYYY` for `en`, `YYYY/MM/DD` for `zh-Hans`) without the locale-default comma separator.

Output examples:
- en: `05/04/2026 21:48:55`
- zh-Hans: `2026/05/04 21:48:55`