### PR TITLE
fix(status): measure bandwidth at post-send, not at enqueue

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -625,6 +625,8 @@ connection_write_status_t connection_handle_write(connection_t *c) {
     size_t bytes_sent = 0;
     int ret = zerocopy_send(c->fd, &c->zc_queue, &bytes_sent);
     total_sent += bytes_sent;
+    /* Count post-send so per-client bandwidth reflects actual receive rate, not enqueue rate. */
+    c->stream.total_bytes_sent += (uint64_t)bytes_sent;
 
     if (ret < 0 && ret != -2) {
       c->state = CONN_CLOSING;

--- a/src/fcc.c
+++ b/src/fcc.c
@@ -454,10 +454,7 @@ int fcc_handle_unicast_media(stream_context_t *ctx, buffer_ref_t *buf_ref) {
   }
 
   /* Forward RTP payload to client (with reordering) */
-  int processed_bytes = stream_process_rtp_payload(ctx, buf_ref);
-  if (processed_bytes > 0) {
-    ctx->total_bytes_sent += (uint64_t)processed_bytes;
-  }
+  stream_process_rtp_payload(ctx, buf_ref);
 
   /* Check if we should terminate FCC based on reorder's delivered sequence.
    * base_seq - 1 is the last sequence number successfully delivered.
@@ -562,7 +559,6 @@ int fcc_handle_mcast_active(stream_context_t *ctx, buffer_ref_t *buf_ref) {
       buffer_ref_t *next = node->send_next;
       int processed_bytes = stream_process_rtp_payload(ctx, node);
       if (likely(processed_bytes > 0)) {
-        ctx->total_bytes_sent += (uint64_t)processed_bytes;
         flushed_bytes += (uint64_t)processed_bytes;
       }
       buffer_ref_put(node);
@@ -578,10 +574,7 @@ int fcc_handle_mcast_active(stream_context_t *ctx, buffer_ref_t *buf_ref) {
 
   /* Forward multicast data to client (true zero-copy) or capture I-frame
    * (snapshot) */
-  int processed_bytes = stream_process_rtp_payload(ctx, buf_ref);
-  if (likely(processed_bytes > 0)) {
-    ctx->total_bytes_sent += (uint64_t)processed_bytes;
-  }
+  stream_process_rtp_payload(ctx, buf_ref);
 
   return 0;
 }

--- a/src/multicast.c
+++ b/src/multicast.c
@@ -535,10 +535,7 @@ int mcast_session_handle_event(mcast_session_t *session, stream_context_t *ctx, 
     /* Handle based on FCC state (if FCC initialized) */
     if (!ctx->fcc.initialized) {
       /* Direct multicast without FCC - forward to client */
-      int processed_bytes = stream_process_rtp_payload(ctx, recv_buf);
-      if (processed_bytes > 0) {
-        ctx->total_bytes_sent += (uint64_t)processed_bytes;
-      }
+      stream_process_rtp_payload(ctx, recv_buf);
       buffer_ref_put(recv_buf);
       continue; /* Read next packet */
     }

--- a/src/stream.c
+++ b/src/stream.c
@@ -107,9 +107,6 @@ int stream_handle_fd_event(stream_context_t *ctx, int fd, uint32_t events, int64
       }
       return -1;
     }
-    if (result > 0) {
-      ctx->total_bytes_sent += (uint64_t)result;
-    }
     return 0;
   }
 
@@ -118,9 +115,6 @@ int stream_handle_fd_event(stream_context_t *ctx, int fd, uint32_t events, int64
     int result = rtsp_handle_udp_rtp_data(&ctx->rtsp, ctx->conn);
     if (result < 0) {
       return -1; /* Error */
-    }
-    if (result > 0) {
-      ctx->total_bytes_sent += (uint64_t)result;
     }
     return 0; /* Success - processed data, continue with other events */
   }
@@ -142,9 +136,6 @@ int stream_handle_fd_event(stream_context_t *ctx, int fd, uint32_t events, int64
     if (result < 0) {
       logger(LOG_ERROR, "HTTP Proxy: Socket event handling failed");
       return -1;
-    }
-    if (result > 0) {
-      ctx->total_bytes_sent += (uint64_t)result;
     }
     return 0;
   }


### PR DESCRIPTION
## Summary

Per-client bandwidth on the status page tracked the rate at which upstream data was *queued into the client send buffer*, not the rate at which it was *actually delivered to the client*. For slow clients, the displayed bandwidth stayed pinned at the upstream supply rate until the queue hit HWM and backpressure kicked in — overstating true client throughput.

## Fix

Move the byte counter from the three upstream-receive sites in `stream_handle_fd_event()` (`src/stream.c`) to inside `connection_handle_write()`'s `zerocopy_send()` loop (`src/connection.c`). The counter now advances only when the kernel TCP stack accepts bytes, so the 1s tick in `stream_tick()` reports the real client receive rate even before the send queue fills.

When the client is slow, `sendmsg()` starts returning `EAGAIN` once the kernel TCP send buffer is full, and `bytes_sent` stays at 0 until the receiver acks more data — making the displayed bandwidth converge to the actual link rate. For fast clients (kernel buffer never fills), behavior is unchanged.

Side benefit: `total_bytes_sent_cumulative` and `client_bytes_cumulative` no longer over-count bytes that were enqueued but lost on disconnect.

## Test plan

- [x] Builds clean (`cmake --build build`, no warnings)
- [x] Slow-client functional test: throttle loopback (`tc qdisc add dev lo root tbf rate 1mbit ...`), connect a normal `curl` to a stream, confirm status-page bandwidth converges to ~1 Mbit/s rather than upstream rate
- [x] Fast-client functional test: confirm normal stream still reports the upstream rate (unchanged)
- [x] e2e suite: `e2e/run-e2e.sh`