### PR TITLE
fix: restore URL buffer size to 2048 bytes

### DIFF
--- a/e2e/test_m3u.py
+++ b/e2e/test_m3u.py
@@ -1060,9 +1060,9 @@ class TestM3UQueryMerge:
         rtsp = MockRTSPServer(num_packets=500)
         rtsp.start()
         try:
-            # ~600 bytes per side guarantees the merged URL exceeds 1024.
-            configured_pad = "padconfigured=" + ("a" * 600)
-            request_pad = "padrequest=" + ("b" * 600)
+            # ~1200 bytes per side guarantees the merged URL exceeds 2048.
+            configured_pad = "padconfigured=" + ("a" * 1200)
+            request_pad = "padrequest=" + ("b" * 1200)
             config = make_m3u_rtsp_config(r2h_port, rtsp.port, "OverflowMerge", "?" + configured_pad)
             r2h = R2HProcess(r2h_binary, r2h_port, config_content=config, capture_log=True)
             r2h.start()

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -1,5 +1,6 @@
 #include "configuration.h"
 #include "epg.h"
+#include "http.h"
 #include "m3u.h"
 #include "service.h"
 #include "utils.h"
@@ -13,7 +14,7 @@
 #include <string.h>
 #include <strings.h>
 
-#define MAX_LINE 1024
+#define MAX_LINE 4096
 
 /* GLOBAL */
 config_t config;

--- a/src/http.c
+++ b/src/http.c
@@ -786,8 +786,8 @@ int http_parse_url_components(const char *url, char *protocol, char *host, char 
 
   /* Extract path if present */
   if (path_start && path) {
-    strncpy(path, path_start, 1023);
-    path[1023] = '\0';
+    strncpy(path, path_start, 2047);
+    path[2047] = '\0';
   }
 
   /* Parse host:port */

--- a/src/http.h
+++ b/src/http.h
@@ -25,7 +25,7 @@ typedef enum { HTTP_PARSE_REQ_LINE = 0, HTTP_PARSE_HEADERS, HTTP_PARSE_BODY, HTT
 /* HTTP request structure */
 typedef struct {
   char method[16];
-  char url[1024];
+  char url[2048];
   char hostname[256];
   char user_agent[256];
   char accept[256];
@@ -212,7 +212,7 @@ void http_send_401(connection_t *conn);
  * @param port Output buffer for port (can be NULL), size should be at least 16
  * bytes
  * @param path Output buffer for path (can be NULL), size should be at least
- * 1024 bytes
+ * 2048 bytes
  * @return 0 on success, -1 on error
  */
 int http_parse_url_components(const char *url, char *protocol, char *host, char *port, char *path);

--- a/src/http.h
+++ b/src/http.h
@@ -3,6 +3,14 @@
 
 #include <sys/types.h>
 
+/* Maximum URL buffer size shared across the HTTP/RTSP pipeline.
+ * RTSP_SERVER_URL_SIZE, RTSP_SERVER_PATH_SIZE, and RTSP_URL_COPY_SIZE (rtsp.h)
+ * are sized to match. Keep all in sync to avoid silent mid-pipeline
+ * truncation. Compile-time override: -DHTTP_URL_BUFFER_SIZE=N */
+#ifndef HTTP_URL_BUFFER_SIZE
+#define HTTP_URL_BUFFER_SIZE 2048
+#endif
+
 /* Forward declaration */
 typedef struct connection_s connection_t;
 
@@ -25,7 +33,7 @@ typedef enum { HTTP_PARSE_REQ_LINE = 0, HTTP_PARSE_HEADERS, HTTP_PARSE_BODY, HTT
 /* HTTP request structure */
 typedef struct {
   char method[16];
-  char url[2048];
+  char url[HTTP_URL_BUFFER_SIZE];
   char hostname[256];
   char user_agent[256];
   char accept[256];

--- a/src/rtsp.h
+++ b/src/rtsp.h
@@ -33,20 +33,20 @@
 /* RTSP server URL - complete RTSP URL. Kept in sync with HTTP_URL_BUFFER_SIZE
  * (service.h) so the entire pipeline shares one URL ceiling and there is no
  * silent mid-pipeline truncation. */
-#define RTSP_SERVER_URL_SIZE 1024
+#define RTSP_SERVER_URL_SIZE 2048
 
 /* RTSP server hostname - DNS name or IP address */
 #define RTSP_SERVER_HOST_SIZE 256
 
 /* RTSP server path - path component of URL with query string. Same sizing
  * rationale as RTSP_SERVER_URL_SIZE. */
-#define RTSP_SERVER_PATH_SIZE 1024
+#define RTSP_SERVER_PATH_SIZE 2048
 
 #define RTSP_CREDENTIAL_SIZE 128
 
 /* URL copy buffer - for URL parsing operations. Same sizing rationale as
  * RTSP_SERVER_URL_SIZE. */
-#define RTSP_URL_COPY_SIZE 1024
+#define RTSP_URL_COPY_SIZE 2048
 
 /* Time conversion buffers - for playseek time formatting */
 #define RTSP_TIME_STRING_SIZE 64

--- a/src/service.h
+++ b/src/service.h
@@ -8,16 +8,6 @@
 
 /* ========== HTTP/SERVICE BUFFER SIZE CONFIGURATION ========== */
 
-/* HTTP URL working buffer - for URL manipulation. The query-merge path in
- * service_create_with_query_merge() builds into this same buffer and then
- * re-parses through service_create_from_*_url(), and the RTSP layer
- * (RTSP_SERVER_URL_SIZE / RTSP_SERVER_PATH_SIZE / RTSP_URL_COPY_SIZE in
- * rtsp.h) is sized to match. Keep all four in sync to avoid silent
- * mid-pipeline truncation. */
-#ifndef HTTP_URL_BUFFER_SIZE
-#define HTTP_URL_BUFFER_SIZE 2048
-#endif
-
 /* HTTP URL component buffers - for parsing multicast URLs */
 #ifndef HTTP_ADDR_COMPONENT_SIZE
 #define HTTP_ADDR_COMPONENT_SIZE 256

--- a/src/service.h
+++ b/src/service.h
@@ -15,7 +15,7 @@
  * rtsp.h) is sized to match. Keep all four in sync to avoid silent
  * mid-pipeline truncation. */
 #ifndef HTTP_URL_BUFFER_SIZE
-#define HTTP_URL_BUFFER_SIZE 1024
+#define HTTP_URL_BUFFER_SIZE 2048
 #endif
 
 /* HTTP URL component buffers - for parsing multicast URLs */


### PR DESCRIPTION
## Summary

- Restore `HTTP_URL_BUFFER_SIZE`, `RTSP_SERVER_URL_SIZE`, `RTSP_SERVER_PATH_SIZE`, `RTSP_URL_COPY_SIZE`, and `http_request_t.url` from 1024 back to 2048 bytes — the original value before the zero-copy refactor (879acbc) inadvertently halved them.
- Move `HTTP_URL_BUFFER_SIZE` definition from `service.h` to `http.h` as the single source of truth; `http_request_t.url` uses the macro instead of a hard-coded literal.
- Raise config file `MAX_LINE` from 1024 to 4096 so inline M3U URLs up to 2048 bytes are not silently truncated by `fgets`.
- Fix `http_parse_url_components` path copy limit from 1023 to 2047 to match the restored 2048-byte ceiling.
- Adjust the merged-URL overflow e2e test padding to match the restored 2048 ceiling.

## Test plan

- [x] `cmake --build build` compiles cleanly
- [x] `test_error.py` — 17 passed (including `test_very_long_url`)
- [x] `test_m3u.py` — 33 passed (including `test_merged_url_overflow_returns_500`)
- [x] `test_url_template.py` — 32 passed
- [x] `test_rtsp_seek_mode.py` — 32 passed (including r2h-token stripping)
- [x] `test_http_proxy.py` — 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)