### PR TITLE
docs(stream): clean up stale service ownership comments

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -517,7 +517,7 @@ void connection_cleanup(connection_t *c) {
    * The function is lightweight and only acts if conditions are met */
   buffer_pool_try_shrink();
 
-  /* Free service if owned */
+  /* Free the per-connection service instance */
   if (c->service) {
     service_free(c->service);
     c->service = NULL;

--- a/src/stream.c
+++ b/src/stream.c
@@ -417,8 +417,7 @@ int stream_context_cleanup(stream_context_t *ctx) {
 
   /* NOTE: Do NOT free ctx->service here!
    * The service pointer is shared with the parent connection (c->service).
-   * The connection owns the service and will free it in connection_cleanup()
-   * based on the c->service_owned flag.
+   * The connection owns the service and will free it in connection_cleanup().
    * Freeing it here would cause double-free when connection_cleanup() is called.
    */
   ctx->service = NULL; /* Clear pointer but don't free */

--- a/src/stream.h
+++ b/src/stream.h
@@ -89,7 +89,8 @@ int stream_handle_fd_event(stream_context_t *ctx, int fd, uint32_t events, int64
 int stream_tick(stream_context_t *ctx, int64_t now);
 
 /**
- * Cleanup all resources owned by the stream context and free dynamic service.
+ * Cleanup all resources owned by the stream context.
+ * The parent connection owns and frees the service pointer.
  * @param ctx Stream context to cleanup
  * @return 0 if cleanup completed, 1 if async TEARDOWN in progress (cleanup
  * deferred)


### PR DESCRIPTION
## Summary
- Removed stale `service_owned` references from stream cleanup comments.
- Clarified that `connection_cleanup()` owns and frees the per-connection service instance.
- Updated the `stream_context_cleanup()` comment to reflect the current ownership model.

## Testing
- Not run (not requested)