### PR TITLE
fix(openwrt): restore LuCI page buttons

### DIFF
--- a/openwrt-support/luci-app-rtp2httpd/htdocs/luci-static/resources/view/rtp2httpd.js
+++ b/openwrt-support/luci-app-rtp2httpd/htdocs/luci-static/resources/view/rtp2httpd.js
@@ -117,6 +117,7 @@ return view.extend({
 
   // Helper function to open a page (status or player)
   openPage: function (section_id, pageType) {
+    var self = this;
     var pathConfigKey =
       pageType === "status" ? "status-page-path" : "player-page-path";
     var uciPathKey =


### PR DESCRIPTION
Fixes #530. This fixes the OpenWrt LuCI status dashboard and player page buttons after the multiple listen addresses change by preserving the view instance context inside openPage(). Validation: checked LuCI JS syntax with node new Function wrapper.