### PR TITLE
fix(web-ui): fit 16:9 frame with contain and stretch sources to fill

### DIFF
--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1099,20 +1099,18 @@ export function VideoPlayer({
         )}
       >
         <div className="video-frame">
-          <div className="grid size-full place-items-center [&>video]:col-start-1 [&>video]:row-start-1">
-            {(visibleSlotId === "a" ? (["b", "a"] as const) : (["a", "b"] as const)).map((slotId) => (
-              // biome-ignore lint/a11y/useMediaCaption: live streaming video has no caption tracks
-              <video
-                key={slotId}
-                ref={slotId === "a" ? slotAVideoRef : slotBVideoRef}
-                className={clsx(visibleSlotId !== slotId && "invisible pointer-events-none")}
-                playsInline
-                webkit-playsinline="true"
-                x5-playsinline="true"
-                onClick={visibleSlotId === slotId ? handleVideoClick : undefined}
-              />
-            ))}
-          </div>
+          {(visibleSlotId === "a" ? (["b", "a"] as const) : (["a", "b"] as const)).map((slotId) => (
+            // biome-ignore lint/a11y/useMediaCaption: live streaming video has no caption tracks
+            <video
+              key={slotId}
+              ref={slotId === "a" ? slotAVideoRef : slotBVideoRef}
+              className={clsx(visibleSlotId !== slotId && "invisible pointer-events-none")}
+              playsInline
+              webkit-playsinline="true"
+              x5-playsinline="true"
+              onClick={visibleSlotId === slotId ? handleVideoClick : undefined}
+            />
+          ))}
         </div>
 
         {showLoading && (

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1091,29 +1091,28 @@ export function VideoPlayer({
       onMouseMove={showControlsImmediately}
       onMouseLeave={hideControlsImmediately}
     >
-      {/* Mobile: 16:9 aspect ratio container, Desktop: full height */}
+      {/* Player area sizes the 16:9 frame via container queries; sources stretch to 16:9 inside it. */}
       <div
         className={clsx(
           "video-container relative w-full min-h-0 aspect-video md:aspect-auto md:h-full flex items-center justify-center",
           !showControls && "cursor-none",
         )}
       >
-        <div className="relative grid size-full min-h-0 min-w-0 max-w-full max-h-full place-items-center [&>video]:col-start-1 [&>video]:row-start-1">
-          {(visibleSlotId === "a" ? (["b", "a"] as const) : (["a", "b"] as const)).map((slotId) => (
-            // biome-ignore lint/a11y/useMediaCaption: live streaming video has no caption tracks
-            <video
-              key={slotId}
-              ref={slotId === "a" ? slotAVideoRef : slotBVideoRef}
-              className={clsx(
-                "max-w-full max-h-full object-fill aspect-video",
-                visibleSlotId !== slotId && "absolute inset-0 m-auto invisible pointer-events-none",
-              )}
-              playsInline
-              webkit-playsinline="true"
-              x5-playsinline="true"
-              onClick={visibleSlotId === slotId ? handleVideoClick : undefined}
-            />
-          ))}
+        <div className="video-frame">
+          <div className="grid size-full place-items-center [&>video]:col-start-1 [&>video]:row-start-1">
+            {(visibleSlotId === "a" ? (["b", "a"] as const) : (["a", "b"] as const)).map((slotId) => (
+              // biome-ignore lint/a11y/useMediaCaption: live streaming video has no caption tracks
+              <video
+                key={slotId}
+                ref={slotId === "a" ? slotAVideoRef : slotBVideoRef}
+                className={clsx(visibleSlotId !== slotId && "invisible pointer-events-none")}
+                playsInline
+                webkit-playsinline="true"
+                x5-playsinline="true"
+                onClick={visibleSlotId === slotId ? handleVideoClick : undefined}
+              />
+            ))}
+          </div>
         </div>
 
         {showLoading && (

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -105,20 +105,37 @@ body {
   }
 }
 
+.video-container {
+  container: video / size;
+}
+
+/* Largest 16:9 rect that fits the player area (contain in viewport). */
+.video-frame {
+  aspect-ratio: 16 / 9;
+  position: relative;
+  max-width: 100%;
+  max-height: 100%;
+  width: 100%;
+  height: auto;
+}
+
 @container video (min-aspect-ratio: 16 / 9) {
-  .video-container video {
-    width: auto;
+  .video-frame {
     height: 100%;
+    width: auto;
   }
 }
 
 @container video (max-aspect-ratio: 16 / 9) {
-  .video-container video {
+  .video-frame {
     width: 100%;
     height: auto;
   }
 }
 
-.video-container {
-  container: video / size;
+/* Stretch any source aspect ratio to 16:9 inside the frame. */
+.video-frame video {
+  width: 100%;
+  height: 100%;
+  object-fit: fill;
 }

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -117,6 +117,7 @@ body {
   max-height: 100%;
   width: 100%;
   height: auto;
+  overflow: hidden;
 }
 
 @container video (min-aspect-ratio: 16 / 9) {
@@ -135,7 +136,11 @@ body {
 
 /* Stretch any source aspect ratio to 16:9 inside the frame. */
 .video-frame video {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
+  min-width: 0;
+  min-height: 0;
   object-fit: fill;
 }


### PR DESCRIPTION
## Summary

- Add a two-layer video layout: `.video-frame` uses container queries to fit the largest 16:9 rect inside the player area (contain, short edge fills viewport).
- Stretch any source aspect ratio to 16:9 inside the frame via `object-fit: fill` on the video element.
- Fixes mobile fullscreen cropping reported in #541.

## Test plan

- [x] Play 16:9 channel on desktop — video fills player without distortion
- [x] Play 4:3 channel — video stretches to 16:9 inside the frame
- [x] Android mobile browser fullscreen — full picture visible with letterboxing, no cropping
- [x] Portrait and landscape orientations on mobile
- [x] Channel/source seamless switch still works with dual video slots