### PR TITLE
refactor(player): reduce video player duplication

### DIFF
--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -94,6 +94,7 @@ export function VideoPlayer({
   const activeSlotIdRef = useRef<SlotId>("a");
   const [visibleSlotId, setVisibleSlotId] = useState<SlotId>("a");
   const transitionGenRef = useRef(0);
+  const deferredStopFrameRef = useRef<Record<SlotId, number | null>>({ a: null, b: null });
   const pendingTransitionRef = useRef<PendingTransition | null>(null);
   const hasStartedPlaybackRef = useRef(false);
   const prevStreamRef = useRef<{ channelId: string; sourceIndex: number } | null>(null);
@@ -287,7 +288,15 @@ export function VideoPlayer({
     }
   });
 
+  const cancelDeferredSlotStop = useEffectEvent((slotId: SlotId) => {
+    const frame = deferredStopFrameRef.current[slotId];
+    if (frame === null) return;
+    window.cancelAnimationFrame(frame);
+    deferredStopFrameRef.current[slotId] = null;
+  });
+
   const destroySlot = useEffectEvent((slotId: SlotId) => {
+    cancelDeferredSlotStop(slotId);
     slotPlayerRef(slotId).current?.destroy();
     slotPlayerRef(slotId).current = null;
   });
@@ -295,6 +304,7 @@ export function VideoPlayer({
   const stopPendingTransition = useEffectEvent(() => {
     const pending = pendingTransitionRef.current;
     if (!pending) return;
+    cancelDeferredSlotStop(pending.slotId);
     slotPlayerRef(pending.slotId).current?.stop();
     cancelPendingTransition();
   });
@@ -329,7 +339,11 @@ export function VideoPlayer({
 
     if (oldActiveId !== newActiveId) {
       if (oldPlayer) {
-        window.requestAnimationFrame(() => stopSlotIfPlayerStillMatches(oldActiveId, oldPlayer));
+        cancelDeferredSlotStop(oldActiveId);
+        deferredStopFrameRef.current[oldActiveId] = window.requestAnimationFrame(() => {
+          deferredStopFrameRef.current[oldActiveId] = null;
+          stopSlotIfPlayerStillMatches(oldActiveId, oldPlayer);
+        });
       }
     }
   });
@@ -636,6 +650,7 @@ export function VideoPlayer({
     const gen = transitionGenRef.current;
 
     const pendingId = otherSlot(activeId);
+    cancelDeferredSlotStop(pendingId);
     slotPlayerRef(pendingId).current?.stop();
 
     const pendingPlayer = createPlayerForSlot(pendingId);

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -292,6 +292,13 @@ export function VideoPlayer({
     slotPlayerRef(slotId).current = null;
   });
 
+  const stopPendingTransition = useEffectEvent(() => {
+    const pending = pendingTransitionRef.current;
+    if (!pending) return;
+    slotPlayerRef(pending.slotId).current?.stop();
+    cancelPendingTransition();
+  });
+
   const stopSlotIfPlayerStillMatches = useEffectEvent((slotId: SlotId, player: Player) => {
     if (slotPlayerRef(slotId).current !== player) return;
     player.stop();
@@ -533,6 +540,19 @@ export function VideoPlayer({
     },
   );
 
+  const loadActiveSlotSegments = useEffectEvent((player: Player, slotId: SlotId, newSegments: PlayerSegment[]) => {
+    player.loadSegments(newSegments);
+
+    if (shouldAutoPlayRef.current) {
+      const video = slotVideoRef(slotId).current;
+      if (video) {
+        playVideoWithAutoplayFallback(video);
+      }
+    } else {
+      setIsLoading(false);
+    }
+  });
+
   // Media Session: lock screen / control center metadata (esp. useful during PiP playback)
   useEffect(() => {
     if (!("mediaSession" in navigator)) return;
@@ -605,21 +625,8 @@ export function VideoPlayer({
     }
 
     if (!useSeamlessSwitch) {
-      if (pendingTransitionRef.current) {
-        slotPlayerRef(pendingTransitionRef.current.slotId).current?.stop();
-        cancelPendingTransition();
-      }
-
-      activePlayer.loadSegments(newSegments);
-
-      if (shouldAutoPlayRef.current) {
-        const video = slotVideoRef(activeId).current;
-        if (video) {
-          playVideoWithAutoplayFallback(video);
-        }
-      } else {
-        setIsLoading(false);
-      }
+      stopPendingTransition();
+      loadActiveSlotSegments(activePlayer, activeId, newSegments);
       return;
     }
 
@@ -634,15 +641,7 @@ export function VideoPlayer({
     const pendingPlayer = createPlayerForSlot(pendingId);
     const pendingVideo = slotVideoRef(pendingId).current;
     if (!pendingPlayer || !pendingVideo) {
-      activePlayer.loadSegments(newSegments);
-      if (shouldAutoPlayRef.current) {
-        const video = slotVideoRef(activeId).current;
-        if (video) {
-          playVideoWithAutoplayFallback(video);
-        }
-      } else {
-        setIsLoading(false);
-      }
+      loadActiveSlotSegments(activePlayer, activeId, newSegments);
       return;
     }
 
@@ -710,11 +709,8 @@ export function VideoPlayer({
   }, [mp2SoftDecode]);
 
   useEffect(() => {
-    const pending = pendingTransitionRef.current;
-    if (!seamlessSwitch && pending) {
-      const pendingPlayer = pending.slotId === "a" ? slotAPlayerRef.current : slotBPlayerRef.current;
-      pendingPlayer?.stop();
-      cancelPendingTransition();
+    if (!seamlessSwitch) {
+      stopPendingTransition();
     }
   }, [seamlessSwitch]);
 
@@ -1012,39 +1008,27 @@ export function VideoPlayer({
       const video = (slotId === "a" ? slotAVideoRef : slotBVideoRef).current;
       if (!video) return () => {};
 
-      const onCanPlay = () => handleVideoCanPlay(slotId);
-      const onWaiting = () => handleVideoWaiting(slotId);
-      const onVolumeChange = () => handleVideoVolumeChange(slotId);
-      const onPlaying = (event: Event) => handleVideoPlaying(slotId, event.timeStamp);
-      const onPause = () => handleVideoPause(slotId);
-      const onTimeUpdate = () => handleVideoTimeUpdate(slotId);
-      const onEnded = () => handleVideoEnded(slotId);
-      const onEnterPiP = () => handleVideoEnterPiP(slotId);
-      const onLeavePiP = () => handleVideoLeavePiP(slotId);
-      const onError = (event: Event) => handleVideoElementError(slotId, event.timeStamp);
+      const listeners: Array<[string, EventListener]> = [
+        ["canplay", () => handleVideoCanPlay(slotId)],
+        ["waiting", () => handleVideoWaiting(slotId)],
+        ["volumechange", () => handleVideoVolumeChange(slotId)],
+        ["playing", (event) => handleVideoPlaying(slotId, event.timeStamp)],
+        ["pause", () => handleVideoPause(slotId)],
+        ["timeupdate", () => handleVideoTimeUpdate(slotId)],
+        ["ended", () => handleVideoEnded(slotId)],
+        ["enterpictureinpicture", () => handleVideoEnterPiP(slotId)],
+        ["leavepictureinpicture", () => handleVideoLeavePiP(slotId)],
+        ["error", (event) => handleVideoElementError(slotId, event.timeStamp)],
+      ];
 
-      video.addEventListener("canplay", onCanPlay);
-      video.addEventListener("waiting", onWaiting);
-      video.addEventListener("volumechange", onVolumeChange);
-      video.addEventListener("playing", onPlaying);
-      video.addEventListener("pause", onPause);
-      video.addEventListener("timeupdate", onTimeUpdate);
-      video.addEventListener("ended", onEnded);
-      video.addEventListener("enterpictureinpicture", onEnterPiP);
-      video.addEventListener("leavepictureinpicture", onLeavePiP);
-      video.addEventListener("error", onError);
+      for (const [event, listener] of listeners) {
+        video.addEventListener(event, listener);
+      }
 
       return () => {
-        video.removeEventListener("canplay", onCanPlay);
-        video.removeEventListener("waiting", onWaiting);
-        video.removeEventListener("volumechange", onVolumeChange);
-        video.removeEventListener("playing", onPlaying);
-        video.removeEventListener("pause", onPause);
-        video.removeEventListener("timeupdate", onTimeUpdate);
-        video.removeEventListener("ended", onEnded);
-        video.removeEventListener("enterpictureinpicture", onEnterPiP);
-        video.removeEventListener("leavepictureinpicture", onLeavePiP);
-        video.removeEventListener("error", onError);
+        for (const [event, listener] of listeners) {
+          video.removeEventListener(event, listener);
+        }
       };
     };
 


### PR DESCRIPTION
## Summary

This refactors the web video player to reduce duplication without splitting the component into new modules or increasing the runtime surface area.

The duplicated active-slot load/autoplay path is now centralized, pending transition stop/cancel is handled in one helper, and video element listener registration is table-driven so add/remove stay in sync.

This also addresses the deferred slot cleanup review feedback from the previous seamless switching PR. When a completed seamless switch schedules the old slot to stop on the next animation frame, that deferred stop is now tracked per slot and canceled before the slot is reused as a new pending slot. This preserves the RAF-based visual handoff while avoiding aborting a newly loaded pending stream.

`src/embedded_web_data.h` is intentionally not included in this PR.

## Validation

- `pnpm exec biome check web-ui/src/components/player/video-player.tsx`
- `pnpm run type-check:tsc`
- `pnpm exec vite build web-ui`
- `git diff --check`
