### PR TITLE
fix(player): improve logo contrast

### DIFF
--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -35,7 +35,7 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         onClick={handleClick}
       >
         {/* Left: Channel Number and Info */}
-        <span className="flex h-5 md:h-6 min-w-7 md:min-w-8 items-center justify-center rounded-md bg-primary/10 px-1.5 md:px-2 text-[10px] md:text-xs font-semibold text-primary shrink-0">
+        <span className="flex h-5 md:h-6 min-w-7 md:min-w-8 items-center justify-center rounded-lg bg-primary/10 px-1.5 md:px-2 text-[10px] md:text-xs font-semibold text-primary shrink-0">
           {channel.id}
         </span>
         <div className="flex-1 overflow-hidden min-w-0">
@@ -59,12 +59,12 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         </div>
         {/* Right: Logo */}
         {channel.logo && (
-          <div className="flex h-8 w-12 md:h-10 md:w-16 shrink-0 items-center justify-center overflow-hidden rounded bg-linear-to-br from-muted/20 to-muted/40 p-0.5 md:p-1">
+          <div className="channel-logo-tile flex h-8 w-14 md:h-10 md:w-20 shrink-0 items-center justify-center overflow-hidden rounded-lg px-1.5 py-0.5 md:px-2 md:py-1">
             <img
               src={channel.logo}
               alt={channel.name}
               referrerPolicy="no-referrer"
-              className="h-full w-full object-contain transition-transform duration-200 group-hover:scale-105 drop-shadow-[0_1px_2px_rgba(0,0,0,0.3)]"
+              className="h-full w-full object-contain transition-transform duration-200 group-hover:scale-105"
               onError={(e) => {
                 (e.target as HTMLImageElement).style.display = "none";
               }}

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -298,7 +298,7 @@ export function PlayerControls({
             </button>
 
             {/* Volume Slider */}
-            <div className="absolute bottom-full left-1/2 -translate-x-1/2 rounded bg-black/60 backdrop-blur-sm px-2 md:px-3 py-2 shadow-lg cursor-pointer opacity-0 invisible group-hover/volume:opacity-100 group-hover/volume:visible transition-[opacity,visibility] duration-150">
+            <div className="player-overlay-surface absolute bottom-full left-1/2 -translate-x-1/2 rounded-lg px-2 md:px-3 py-2 cursor-pointer opacity-0 invisible group-hover/volume:opacity-100 group-hover/volume:visible transition-[opacity,visibility] duration-150">
               <input
                 type="range"
                 min="0"
@@ -355,7 +355,7 @@ export function PlayerControls({
               >
                 {channel.sources[activeSourceIndex]?.label || `${t("source")} ${activeSourceIndex + 1}`}
               </button>
-              <div className="absolute bottom-full left-1/2 -translate-x-1/2 rounded bg-black/60 backdrop-blur-sm py-1 shadow-lg opacity-0 invisible group-hover/source:opacity-100 group-hover/source:visible group-focus-within/source:opacity-100 group-focus-within/source:visible transition-[opacity,visibility] duration-150">
+              <div className="player-overlay-surface absolute bottom-full left-1/2 -translate-x-1/2 rounded-lg py-1 opacity-0 invisible group-hover/source:opacity-100 group-hover/source:visible group-focus-within/source:opacity-100 group-focus-within/source:visible transition-[opacity,visibility] duration-150">
                 {channel.sources
                   .map((source, index) => ({ source, index }))
                   .filter(({ source }) => isLive || (source.catchup && source.catchupSource))

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1180,7 +1180,7 @@ export function VideoPlayer({
         </div>
 
         {showLoading && (
-          <div className="absolute top-4 left-4 md:top-8 md:left-8 z-10 flex items-center gap-2 md:gap-3 rounded-lg bg-white/10 ring-1 ring-white/20 backdrop-blur-sm px-3 py-2 md:px-4 md:py-3">
+          <div className="player-overlay-surface absolute top-4 left-4 md:top-8 md:left-8 z-10 flex items-center gap-2 md:gap-3 rounded-lg px-3 py-2 md:px-4 md:py-3">
             <div className="relative h-4 w-4 md:h-5 md:w-5">
               <div className="absolute inset-0 rounded-full border-2 border-white/30" />
               <div className="absolute inset-0 rounded-full border-2 border-white border-t-transparent animate-spin" />
@@ -1203,7 +1203,7 @@ export function VideoPlayer({
               showControls ? "opacity-100" : "opacity-0",
             )}
           >
-            <div className="flex flex-col gap-1.5 md:gap-2 px-2 py-1.5 md:px-3 md:py-2 items-center justify-center overflow-hidden rounded-lg bg-white/10 ring-1 ring-white/20 backdrop-blur-sm max-w-[calc(100vw-2rem)] md:max-w-none">
+            <div className="player-overlay-surface flex flex-col gap-1.5 md:gap-2 px-2 py-1.5 md:px-3 md:py-2 items-center justify-center overflow-hidden rounded-lg max-w-[calc(100vw-2rem)] md:max-w-none">
               {channel.logo && (
                 <img
                   src={channel.logo}

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -94,6 +94,21 @@ body {
   border-radius: 9999px;
 }
 
+.channel-logo-tile {
+  background: #404d6a;
+}
+
+.dark .channel-logo-tile {
+  background: transparent;
+}
+
+.player-overlay-surface {
+  background: rgba(9, 9, 11, 0.58);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(12px) saturate(1.15);
+}
+
 @keyframes zoom-fade-out {
   0% {
     transform: scale(1);


### PR DESCRIPTION
## Summary

Improve the web player visual contrast for light-colored channel logos and video overlays.

## Changes

- Add a stable logo tile treatment for sidebar channel logos so white/light logos remain visible in light mode.
- Reuse the logo shadow treatment in the player overlay.
- Replace the top loading and channel-info blur-only treatment with a darker translucent surface that stays readable over bright video frames.

## Validation

- `pnpm exec biome check web-ui/src/components/player/channel-list-item.tsx web-ui/src/components/player/video-player.tsx web-ui/src/index.css`
- `pnpm run type-check:tsc`
- `pnpm exec vite build web-ui`