### PR TITLE
feat(player): persist volume and mute in local storage

### DIFF
--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -10,7 +10,6 @@ import {
   PictureInPicture2,
   Play,
   Tv,
-  Volume,
   Volume1,
   Volume2,
   VolumeX,
@@ -286,10 +285,8 @@ export function PlayerControls({
               className="rounded-full p-1.5 md:p-2 text-white transition cursor-pointer hover:bg-white/20 active:scale-95"
               title={isMuted ? t("unmute") : t("mute")}
             >
-              {isMuted ? (
+              {isMuted || volume === 0 ? (
                 <VolumeX className="h-5 w-5 md:h-7 md:w-7" />
-              ) : volume === 0 ? (
-                <Volume className="h-5 w-5 md:h-7 md:w-7" />
               ) : volume < 0.5 ? (
                 <Volume1 className="h-5 w-5 md:h-7 md:w-7" />
               ) : (

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1092,6 +1092,9 @@ export function VideoPlayer({
     const video = getActiveVideo();
     if (video) {
       video.volume = newVolume;
+      if (video.muted && newVolume > 0) {
+        video.muted = false;
+      }
     }
   });
 

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react"
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import type { Locale } from "../../lib/locale";
 import { buildCatchupSegments } from "../../lib/m3u-parser";
+import { getMuted, getVolume, saveMuted, saveVolume } from "../../lib/player-storage";
 import {
   createPlayer,
   defaultConfig,
@@ -21,7 +22,6 @@ import {
   wallClockToMse,
 } from "../../mpegts/player/wall-clock";
 import mp2WasmUrl from "../../mpegts/wasm/minimp3/mp2_decoder.wasm?url";
-import { getMuted, getVolume, saveMuted, saveVolume } from "../../lib/player-storage";
 import type { Channel, EPGProgram } from "../../types/player";
 import { PlayerControls } from "./player-controls";
 

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -21,6 +21,7 @@ import {
   wallClockToMse,
 } from "../../mpegts/player/wall-clock";
 import mp2WasmUrl from "../../mpegts/wasm/minimp3/mp2_decoder.wasm?url";
+import { getMuted, getVolume, saveMuted, saveVolume } from "../../lib/player-storage";
 import type { Channel, EPGProgram } from "../../types/player";
 import { PlayerControls } from "./player-controls";
 
@@ -112,8 +113,8 @@ export function VideoPlayer({
   const [showLoading, setShowLoading] = useState(false);
   const loadingTimeoutRef = useRef<number>(0);
   const [error, setError] = useState<string | null>(() => (isSupported() ? null : t("mseNotSupported")));
-  const [volume, setVolume] = useState(1);
-  const [isMuted, setIsMuted] = useState(false);
+  const [volume, setVolume] = useState(() => getVolume());
+  const [isMuted, setIsMuted] = useState(() => getMuted());
   const [isPlaying, setIsPlaying] = useState(false);
   const [liveSessionAnchor, setLiveSessionAnchor] = useState<LiveSessionAnchor | null>(null);
   // Before session calibration (initial load / reload), treat live mode as Live — not Go Live.
@@ -318,8 +319,8 @@ export function VideoPlayer({
     const oldActiveId = getActiveSlotId();
     const oldVideo = slotVideoRef(oldActiveId).current;
     const oldPlayer = slotPlayerRef(oldActiveId).current;
-    const savedVolume = oldVideo?.volume ?? 1;
-    const savedMuted = oldVideo?.muted ?? false;
+    const savedVolume = oldVideo?.volume ?? volume;
+    const savedMuted = oldVideo?.muted ?? isMuted;
 
     const newVideo = slotVideoRef(newActiveId).current;
     if (newVideo) {
@@ -506,6 +507,9 @@ export function VideoPlayer({
 
     const existing = slotPlayerRef(slotId).current;
     if (existing) return existing;
+
+    video.volume = volume;
+    video.muted = isMuted;
 
     const p = createPlayer(video, {
       wasmDecoders: useMp2SoftDecode ? { mp2: mp2WasmUrl } : {},
@@ -773,6 +777,8 @@ export function VideoPlayer({
     if (!video) return;
     setVolume(video.volume);
     setIsMuted(video.muted);
+    saveVolume(video.volume);
+    saveMuted(video.muted);
   });
 
   const handleVideoPlaying = useEffectEvent((slotId: SlotId, eventTimeStamp: number) => {

--- a/web-ui/src/lib/player-storage.ts
+++ b/web-ui/src/lib/player-storage.ts
@@ -46,6 +46,8 @@ export const [getLastChannelId, saveLastChannelId] = createStore<string | null>(
 export const [getSidebarVisible, saveSidebarVisible] = createStore("rtp2httpd-player-sidebar-visible", true);
 export const [getSeamlessSwitch, saveSeamlessSwitch] = createStore("rtp2httpd-player-seamless-switch", true);
 export const [getMp2SoftDecode, saveMp2SoftDecode] = createStore("rtp2httpd-player-mp2-soft-decode", isIOS());
+export const [getVolume, saveVolume] = createStore("rtp2httpd-player-volume", 1);
+export const [getMuted, saveMuted] = createStore("rtp2httpd-player-muted", false);
 
 // Per-channel source index uses a JSON object map, so it needs custom logic
 const [getSourceIndexMap, saveSourceIndexMap] = createStore<Record<string, number>>(


### PR DESCRIPTION
## Summary
- Persist player volume and mute state in Local Storage so preferences survive page reloads
- Restore audio settings from component state when creating player slots and during slot transitions
- Save volume/mute changes on `volumechange` events
- Unmute automatically when adjusting the volume slider above zero while muted (slider still displays 0 in muted state)
- Show the muted icon (`VolumeX`) when volume is zero, even if not explicitly muted

## Test plan
- [x] Adjust volume and mute, refresh the page, confirm settings are restored
- [x] Toggle MP2 soft decode and verify volume/mute are preserved
- [x] Switch channels with seamless switch enabled and confirm audio state carries over
- [x] Clear Local Storage and confirm defaults (volume 1, unmuted) apply
- [x] Mute via icon, then drag volume slider — confirm audio resumes at the selected level
- [x] Set volume to zero without muting — confirm icon shows as muted