### PR TITLE
fix(web-ui): lock player document scrolling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ RTP/IPTV multicast-to-HTTP streaming daemon written in C, with a React/TypeScrip
 ## Code Style — TypeScript / JavaScript
 
 - Formatter/linter: Biome (`biome.json`), line width 120, indent with tabs
+- Prefer Tailwind CSS utilities for styling; add custom CSS classes only when Tailwind cannot express the behavior clearly.
 
 ## Code Style — Python
 

--- a/web-ui/player.html
+++ b/web-ui/player.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="overflow-hidden overscroll-none">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
@@ -36,7 +36,7 @@
     </script>
     <link href="/src/index.css" rel="stylesheet" />
   </head>
-  <body class="bg-background text-foreground">
+  <body class="overflow-hidden overscroll-none bg-background text-foreground">
     <div id="root"></div>
     <script type="module" src="/src/pages/player.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary

This PR now focuses only on locking document-level scrolling for the player page. The player app already owns its internal scroll regions, so `html` and `body` are set to `overflow-hidden overscroll-none` with Tailwind utilities to prevent the page itself from vertically rubber-banding.

The iOS 26 safe-area rendering issue is intentionally not handled here after manual testing showed it is an OS-level bug. All previous viewport-height and safe-area experiments have been removed from this branch.

`AGENTS.md` also records the project preference for Tailwind CSS utilities over custom CSS classes. `src/embedded_web_data.h` is intentionally not included in this PR.

## Validation

- `pnpm exec biome check web-ui/player.html AGENTS.md`
- `pnpm run web-ui:build`
