### PR TITLE
fix(player): improve M3U load failure state

### DIFF
--- a/web-ui/src/i18n/player.ts
+++ b/web-ui/src/i18n/player.ts
@@ -39,6 +39,17 @@ const base: TranslationDict = {
 
   // Errors
   failedToLoadPlaylist: "Failed to load playlist",
+  emptyPlaylist: "No playable channels were found in the playlist",
+  playlistLoadEyebrow: "M3U playlist",
+  playlistLoadTitle: "Playlist is not ready yet",
+  playlistLoadDescription:
+    "The Web Player loads channels from /playlist.m3u, but the playlist is unavailable right now. Configure an M3U playlist, then retry.",
+  playlistErrorChecklist: "Check your M3U setup",
+  playlistErrorHintReachable: "Make sure the external M3U URL is reachable by rtp2httpd.",
+  playlistErrorHintFormat: "Confirm the playlist contains valid #EXTINF entries and channel URLs.",
+  m3uIntegrationGuide: "View M3U setup guide",
+  playlistEndpoint: "Playlist endpoint",
+  technicalDetails: "Technical details",
   noCatchupSupport: "This channel does not support catchup playback",
   noRewindSupport: "This channel does not support rewind",
   codecError: "Unsupported video/audio codec. Your browser cannot decode this stream.",
@@ -127,6 +138,17 @@ const zhHans: TranslationDict = {
 
   // 错误信息
   failedToLoadPlaylist: "加载播放列表失败",
+  emptyPlaylist: "播放列表中没有可播放频道",
+  playlistLoadEyebrow: "M3U 播放列表",
+  playlistLoadTitle: "播放列表还没有准备好",
+  playlistLoadDescription:
+    "Web Player 会从 /playlist.m3u 加载频道，但当前无法获取播放列表。请先配置 M3U 播放列表，然后重试。",
+  playlistErrorChecklist: "请检查 M3U 配置",
+  playlistErrorHintReachable: "确认外部 M3U 地址可以被 rtp2httpd 正常访问。",
+  playlistErrorHintFormat: "确认播放列表包含有效的 #EXTINF 条目和频道地址。",
+  m3uIntegrationGuide: "查看 M3U 配置指南",
+  playlistEndpoint: "播放列表地址",
+  technicalDetails: "错误详情",
   noCatchupSupport: "此频道不支持回看功能",
   noRewindSupport: "此频道不支持时移功能",
   codecError: "不支持的视频/音频编码。您的浏览器无法解码此流。",
@@ -216,6 +238,17 @@ const zhHant: TranslationDict = {
 
   // 錯誤訊息
   failedToLoadPlaylist: "載入播放列表失敗",
+  emptyPlaylist: "播放列表中沒有可播放頻道",
+  playlistLoadEyebrow: "M3U 播放列表",
+  playlistLoadTitle: "播放列表尚未準備好",
+  playlistLoadDescription:
+    "Web Player 會從 /playlist.m3u 載入頻道，但目前無法取得播放列表。請先配置 M3U 播放列表，然後重試。",
+  playlistErrorChecklist: "請檢查 M3U 配置",
+  playlistErrorHintReachable: "確認外部 M3U 地址可以被 rtp2httpd 正常存取。",
+  playlistErrorHintFormat: "確認播放列表包含有效的 #EXTINF 條目和頻道地址。",
+  m3uIntegrationGuide: "查看 M3U 配置指南",
+  playlistEndpoint: "播放列表地址",
+  technicalDetails: "錯誤詳情",
   noCatchupSupport: "此頻道不支援回看功能",
   noRewindSupport: "此頻道不支援時移功能",
   codecError: "不支援的視頻/音頻編碼。您的瀏覽器無法解碼此串流。",

--- a/web-ui/src/i18n/player.ts
+++ b/web-ui/src/i18n/player.ts
@@ -43,7 +43,7 @@ const base: TranslationDict = {
   playlistLoadEyebrow: "M3U playlist",
   playlistLoadTitle: "Playlist is not ready yet",
   playlistLoadDescription:
-    "The Web Player loads channels from /playlist.m3u, but the playlist is unavailable right now. Configure an M3U playlist, then retry.",
+    "The Player loads channels from /playlist.m3u, but the playlist is unavailable right now. Configure an M3U playlist, then retry.",
   playlistErrorChecklist: "Check your M3U setup",
   playlistErrorHintReachable: "Make sure the external M3U URL is reachable by rtp2httpd.",
   playlistErrorHintFormat: "Confirm the playlist contains valid #EXTINF entries and channel URLs.",
@@ -142,7 +142,7 @@ const zhHans: TranslationDict = {
   playlistLoadEyebrow: "M3U 播放列表",
   playlistLoadTitle: "播放列表还没有准备好",
   playlistLoadDescription:
-    "Web Player 会从 /playlist.m3u 加载频道，但当前无法获取播放列表。请先配置 M3U 播放列表，然后重试。",
+    "播放器会从 /playlist.m3u 加载频道，但当前无法获取播放列表。请先配置 M3U 播放列表，然后重试。",
   playlistErrorChecklist: "请检查 M3U 配置",
   playlistErrorHintReachable: "确认外部 M3U 地址可以被 rtp2httpd 正常访问。",
   playlistErrorHintFormat: "确认播放列表包含有效的 #EXTINF 条目和频道地址。",
@@ -242,7 +242,7 @@ const zhHant: TranslationDict = {
   playlistLoadEyebrow: "M3U 播放列表",
   playlistLoadTitle: "播放列表尚未準備好",
   playlistLoadDescription:
-    "Web Player 會從 /playlist.m3u 載入頻道，但目前無法取得播放列表。請先配置 M3U 播放列表，然後重試。",
+    "播放器會從 /playlist.m3u 載入頻道，但目前無法取得播放列表。請先配置 M3U 播放列表，然後重試。",
   playlistErrorChecklist: "請檢查 M3U 配置",
   playlistErrorHintReachable: "確認外部 M3U 地址可以被 rtp2httpd 正常存取。",
   playlistErrorHintFormat: "確認播放列表包含有效的 #EXTINF 條目和頻道地址。",

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -15,6 +15,7 @@ import { useLocale } from "../hooks/use-locale";
 import { usePlayerTranslation } from "../hooks/use-player-translation";
 import { useTheme } from "../hooks/use-theme";
 import { type EPGData, fillEPGGaps, getCurrentProgram, getEPGChannelId, loadEPG } from "../lib/epg-parser";
+import type { Locale } from "../lib/locale";
 import { buildCatchupSegments, clampCatchupStartTime, parseM3U } from "../lib/m3u-parser";
 import {
   getLastChannelId,
@@ -32,7 +33,11 @@ import type { PlayerSegment } from "../mpegts";
 import { NEAR_LIVE_EDGE_MS } from "../mpegts/player/wall-clock";
 import type { Channel, M3UMetadata } from "../types/player";
 
-const M3U_INTEGRATION_GUIDE_URL = "https://rtp2httpd.com/guide/m3u-integration";
+function getM3UIntegrationGuideUrl(locale: Locale) {
+  return locale === "en"
+    ? "https://rtp2httpd.com/en/guide/m3u-integration"
+    : "https://rtp2httpd.com/guide/m3u-integration";
+}
 
 function PlayerPage() {
   const { locale, setLocale } = useLocale("player-locale");
@@ -518,7 +523,7 @@ function PlayerPage() {
                     {t("retry")}
                   </Button>
                   <a
-                    href={M3U_INTEGRATION_GUIDE_URL}
+                    href={getM3UIntegrationGuideUrl(locale)}
                     target="_blank"
                     rel="noreferrer"
                     className={buttonVariants({ variant: "outline", className: "gap-2" })}

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -1,4 +1,5 @@
 import { clsx } from "clsx";
+import { AlertTriangle, ExternalLink, ListChecks, RefreshCw } from "lucide-react";
 import { Activity, StrictMode, startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
@@ -8,6 +9,7 @@ import {
 import { EPGView, nextScrollBehaviorRef as epgViewNextScrollBehaviorRef } from "../components/player/epg-view";
 import { SettingsDropdown } from "../components/player/settings-dropdown";
 import { VideoPlayer } from "../components/player/video-player";
+import { Button, buttonVariants } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { useLocale } from "../hooks/use-locale";
 import { usePlayerTranslation } from "../hooks/use-player-translation";
@@ -29,6 +31,8 @@ import {
 import type { PlayerSegment } from "../mpegts";
 import { NEAR_LIVE_EDGE_MS } from "../mpegts/player/wall-clock";
 import type { Channel, M3UMetadata } from "../types/player";
+
+const M3U_INTEGRATION_GUIDE_URL = "https://rtp2httpd.com/guide/m3u-integration";
 
 function PlayerPage() {
   const { locale, setLocale } = useLocale("player-locale");
@@ -222,6 +226,11 @@ function PlayerPage() {
 
       const content = await response.text();
       const parsed = parseM3U(content);
+
+      if (parsed.channels.length === 0) {
+        throw new Error(t("emptyPlaylist"));
+      }
+
       setMetadata(parsed);
 
       // Load EPG if available
@@ -469,19 +478,68 @@ function PlayerPage() {
   );
 
   if (error && !metadata) {
+    const playlistErrorHints = [t("playlistErrorHintReachable"), t("playlistErrorHintFormat")];
+
     return (
-      <div className="flex h-dvh items-center justify-center bg-background">
-        <Card className="max-w-md p-6">
-          <div className="mb-4 text-xl font-semibold text-destructive">{t("error")}</div>
-          <div className="mb-4">{error}</div>
-          <button
-            type="button"
-            onClick={loadPlaylist}
-            className="rounded bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
-          >
-            {t("retry")}
-          </button>
-        </Card>
+      <div className="min-h-dvh bg-background">
+        <title>{t("title")}</title>
+        <div className="mx-auto flex min-h-dvh w-[calc(100%-2rem)] max-w-5xl items-center py-8 sm:w-[calc(100%-3rem)]">
+          <Card className="min-w-0 w-full overflow-hidden rounded-lg border-border/70 bg-card shadow-xl shadow-black/5 dark:shadow-black/40">
+            <div className="grid min-w-0 md:grid-cols-[minmax(0,1fr)_18rem]">
+              <div className="min-w-0 p-6 sm:p-8 md:p-10">
+                <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
+                  <AlertTriangle className="h-6 w-6" aria-hidden="true" />
+                </div>
+
+                <div className="text-sm font-semibold text-primary">{t("playlistLoadEyebrow")}</div>
+                <h1 className="mt-2 text-2xl font-semibold text-foreground sm:text-3xl">{t("playlistLoadTitle")}</h1>
+                <p className="mt-3 max-w-2xl break-words text-sm leading-6 text-muted-foreground sm:text-base">
+                  {t("playlistLoadDescription")}
+                </p>
+
+                <div className="mt-6 min-w-0 rounded-lg border border-border/70 bg-muted/40 p-4">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <ListChecks className="h-4 w-4 text-primary" aria-hidden="true" />
+                    {t("playlistErrorChecklist")}
+                  </div>
+                  <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                    {playlistErrorHints.map((hint) => (
+                      <li key={hint} className="flex min-w-0 gap-2">
+                        <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" aria-hidden="true" />
+                        <span className="min-w-0 break-words">{hint}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+                  <Button type="button" onClick={loadPlaylist} className="gap-2">
+                    <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                    {t("retry")}
+                  </Button>
+                  <a
+                    href={M3U_INTEGRATION_GUIDE_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={buttonVariants({ variant: "outline", className: "gap-2" })}
+                  >
+                    {t("m3uIntegrationGuide")}
+                    <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                  </a>
+                </div>
+              </div>
+
+              <div className="min-w-0 border-t border-border/70 bg-muted/30 p-6 md:border-t-0 md:border-l md:p-8">
+                <div className="text-sm font-semibold text-foreground">{t("playlistEndpoint")}</div>
+                <div className="mt-3 rounded-lg border border-border/70 bg-background px-3 py-2 font-mono text-sm text-foreground">
+                  /playlist.m3u
+                </div>
+                <div className="mt-6 text-sm font-semibold text-foreground">{t("technicalDetails")}</div>
+                <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">{error}</p>
+              </div>
+            </div>
+          </Card>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

This updates the Web Player failure state shown when `/playlist.m3u` cannot be loaded or contains no playable channels.

The page now gives a clearer M3U-focused message, shows lightweight generic checks, keeps the technical error visible, and links users to the M3U integration guide without prescribing one specific configuration path.

`src/embedded_web_data.h` is intentionally not included in this PR.

## Validation

- `pnpm run format:biome`
- `pnpm run type-check:tsc`
- `pnpm exec vite build web-ui`