### PR TITLE
feat(player): support multiple channel groups

### DIFF
--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -16,6 +16,7 @@ interface ChannelListItemProps {
 const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemProps>(
   ({ channel, isCurrentChannel, handleChannelClick, locale, currentProgram }, ref) => {
     const t = usePlayerTranslation(locale);
+    const groupLabel = channel.groups.join(" / ");
 
     const handleClick = useCallback(() => {
       handleChannelClick(channel);
@@ -48,7 +49,7 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
             )}
           </div>
           <div className="mt-0.5 truncate text-[10px] md:text-xs text-muted-foreground">
-            {channel.group}
+            {groupLabel}
             {currentProgram && (
               <>
                 <span className="mx-1">·</span>

--- a/web-ui/src/components/player/channel-list.tsx
+++ b/web-ui/src/components/player/channel-list.tsx
@@ -76,7 +76,7 @@ function ChannelListComponent({
   const filteredChannels = useMemo(() => {
     if (!channels) return [];
     const filtered = channels.filter((ch) => {
-      const matchesGroup = !selectedGroup || ch.group === selectedGroup;
+      const matchesGroup = !selectedGroup || ch.groups.includes(selectedGroup);
       if (!matchesGroup) return false;
 
       if (!searchQuery) return true;

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -616,9 +616,10 @@ export function VideoPlayer({
       navigator.mediaSession.metadata = null;
       return;
     }
+    const groupLabel = channel.groups.join(" / ");
     navigator.mediaSession.metadata = new MediaMetadata({
       title: currentProgram?.title || channel.name,
-      artist: currentProgram?.title ? channel.name : channel.group,
+      artist: currentProgram?.title ? channel.name : groupLabel,
       artwork: channel.logo ? [{ src: channel.logo }] : [],
     });
   }, [channel, currentProgram]);
@@ -1245,10 +1246,12 @@ export function VideoPlayer({
                     {digitBuffer || channel.id}
                   </span>
                   <h2 className="text-xs md:text-base font-bold text-white truncate">{channel.name}</h2>
-                  {channel.group && (
+                  {channel.groups.length > 0 && (
                     <>
                       <span className="text-xs md:text-sm text-white/50 hidden sm:inline">·</span>
-                      <div className="text-xs md:text-sm text-white/70 truncate hidden sm:block">{channel.group}</div>
+                      <div className="text-xs md:text-sm text-white/70 truncate hidden sm:block">
+                        {channel.groups.join(" / ")}
+                      </div>
                     </>
                   )}
                 </div>

--- a/web-ui/src/lib/m3u-parser.ts
+++ b/web-ui/src/lib/m3u-parser.ts
@@ -8,7 +8,7 @@ import type { Channel, M3UMetadata, Source } from "../types/player";
 export function parseM3U(content: string): M3UMetadata {
   const lines = content.split("\n");
   const channels: Channel[] = [];
-  const groups: string[] = [];
+  const playlistGroups: string[] = [];
   const seenGroups = new Set<string>();
   let tvgUrl: string | undefined;
   let defaultCatchup: string | undefined;
@@ -17,7 +17,7 @@ export function parseM3U(content: string): M3UMetadata {
   let currentExtinf: {
     name: string;
     logo?: string;
-    group: string;
+    groups: string[];
     tvgId?: string;
     tvgName?: string;
     catchup?: string;
@@ -53,7 +53,6 @@ export function parseM3U(content: string): M3UMetadata {
       const tvgIdMatch = line.match(/tvg-id="([^"]+)"/);
       const tvgNameMatch = line.match(/tvg-name="([^"]+)"/);
       const tvgLogoMatch = line.match(/tvg-logo="([^"]+)"/);
-      const groupTitleMatch = line.match(/group-title="([^"]+)"/);
       const catchupMatch = line.match(/catchup="([^"]+)"/);
       const catchupSourceMatch = line.match(/catchup-source="([^"]+)"/);
 
@@ -61,18 +60,20 @@ export function parseM3U(content: string): M3UMetadata {
       const nameMatch = line.match(/,(.+)$/);
       const name = nameMatch ? nameMatch[1].trim() : "Unknown";
 
-      const group = groupTitleMatch?.[1] || "";
+      const groups = parseGroupTitles(line);
 
       // Collect group in order if not seen before
-      if (group && !seenGroups.has(group)) {
-        groups.push(group);
-        seenGroups.add(group);
+      for (const group of groups) {
+        if (!seenGroups.has(group)) {
+          playlistGroups.push(group);
+          seenGroups.add(group);
+        }
       }
 
       currentExtinf = {
         name,
         logo: tvgLogoMatch?.[1],
-        group,
+        groups,
         tvgId: tvgIdMatch?.[1],
         tvgName: tvgNameMatch?.[1],
         catchup: catchupMatch?.[1] || defaultCatchup,
@@ -98,7 +99,7 @@ export function parseM3U(content: string): M3UMetadata {
         id: `${channels.length + 1}`,
         name: currentExtinf.name,
         logo: currentExtinf.logo,
-        group: currentExtinf.group,
+        groups: currentExtinf.groups,
         tvgId: currentExtinf.tvgId,
         tvgName: currentExtinf.tvgName,
         sources: [
@@ -112,19 +113,37 @@ export function parseM3U(content: string): M3UMetadata {
   return {
     tvgUrl,
     channels: mergeChannelSources(channels),
-    groups,
+    groups: playlistGroups,
   };
 }
 
+function parseGroupTitles(line: string): string[] {
+  const seenGroups = new Set<string>();
+  const groups: string[] = [];
+
+  for (const match of line.matchAll(/group-title="([^"]+)"/g)) {
+    const groupTitles = match[1].split(";");
+    for (const groupTitle of groupTitles) {
+      const group = groupTitle.trim();
+      if (group && !seenGroups.has(group)) {
+        groups.push(group);
+        seenGroups.add(group);
+      }
+    }
+  }
+
+  return groups;
+}
+
 /**
- * Merge channels with the same name and group into a single channel with multiple sources.
- * Channels are considered duplicates if they share the same group + name combination.
+ * Merge channels with the same name and groups into a single channel with multiple sources.
+ * Channels are considered duplicates if they share the same group list + name combination.
  */
 function mergeChannelSources(channels: Channel[]): Channel[] {
   const mergeMap = new Map<string, Channel>();
 
   for (const ch of channels) {
-    const key = `${ch.group}\0${ch.name}`;
+    const key = `${ch.groups.join("\0")}\0${ch.name}`;
     const existing = mergeMap.get(key);
 
     if (existing) {
@@ -133,7 +152,7 @@ function mergeChannelSources(channels: Channel[]): Channel[] {
         existing.logo = ch.logo;
       }
     } else {
-      mergeMap.set(key, { ...ch });
+      mergeMap.set(key, { ...ch, groups: [...ch.groups] });
     }
   }
 

--- a/web-ui/src/types/player.ts
+++ b/web-ui/src/types/player.ts
@@ -9,7 +9,7 @@ export interface Channel {
   id: string;
   name: string;
   logo?: string;
-  group: string;
+  groups: string[];
   tvgId?: string;
   tvgName?: string;
   sources: Source[];


### PR DESCRIPTION
## Summary

This updates the web player playlist parser to represent channel groups as `groups: string[]` and parse multiple groups from either semicolon-separated `group-title` values or repeated `group-title` attributes.

The channel list now filters channels by membership in the selected group, so a single channel appears under every parsed group. Channel display and media session metadata show all groups joined with ` / `.

This intentionally does not include regenerated `src/embedded_web_data.h`.

Related issue: #564

## Validation

Ran `pnpm run type-check:tsc`, `pnpm exec biome check` on the changed web UI files, and `git diff --check`.
