### PR TITLE
fix(web-ui): strip host from M3U URLs in web player

### DIFF
--- a/web-ui/src/lib/m3u-parser.ts
+++ b/web-ui/src/lib/m3u-parser.ts
@@ -1,5 +1,6 @@
 import type { PlayerSegment } from "../mpegts";
 import type { Channel, M3UMetadata, Source } from "../types/player";
+import { toPlaylistRelativePath } from "./url";
 
 /**
  * Parse M3U playlist content
@@ -34,7 +35,7 @@ export function parseM3U(content: string): M3UMetadata {
     if (line.startsWith("#EXTM3U")) {
       const tvgUrlMatch = line.match(/x-tvg-url="([^"]+)"/);
       if (tvgUrlMatch) {
-        tvgUrl = tvgUrlMatch[1];
+        tvgUrl = toPlaylistRelativePath(tvgUrlMatch[1]);
       }
       const catchupMatch = line.match(/catchup="([^"]+)"/);
       if (catchupMatch) {
@@ -42,7 +43,7 @@ export function parseM3U(content: string): M3UMetadata {
       }
       const catchupSourceMatch = line.match(/catchup-source="([^"]+)"/);
       if (catchupSourceMatch) {
-        defaultCatchupSource = catchupSourceMatch[1];
+        defaultCatchupSource = toPlaylistRelativePath(catchupSourceMatch[1]);
       }
       continue;
     }
@@ -77,7 +78,7 @@ export function parseM3U(content: string): M3UMetadata {
         tvgId: tvgIdMatch?.[1],
         tvgName: tvgNameMatch?.[1],
         catchup: catchupMatch?.[1] || defaultCatchup,
-        catchupSource: catchupSourceMatch?.[1] || defaultCatchupSource,
+        catchupSource: resolveCatchupSource(catchupSourceMatch?.[1] || defaultCatchupSource),
       };
       continue;
     }
@@ -87,6 +88,9 @@ export function parseM3U(content: string): M3UMetadata {
       // Extract optional $<label> suffix from URL (e.g., "http://...url$UHD" → label "UHD")
       const labelMatch = line.match(/\$([^$]+)$/);
       const sourceLabel = labelMatch ? labelMatch[1] : undefined;
+      const urlWithoutLabel = labelMatch ? line.slice(0, line.lastIndexOf("$")) : line;
+      const resolvedUrl =
+        toPlaylistRelativePath(urlWithoutLabel) + (labelMatch ? line.slice(line.lastIndexOf("$")) : "");
 
       channels.push({
         id: `${channels.length + 1}`,
@@ -96,7 +100,12 @@ export function parseM3U(content: string): M3UMetadata {
         tvgId: currentExtinf.tvgId,
         tvgName: currentExtinf.tvgName,
         sources: [
-          { url: line, catchup: currentExtinf.catchup, catchupSource: currentExtinf.catchupSource, label: sourceLabel },
+          {
+            url: resolvedUrl,
+            catchup: currentExtinf.catchup,
+            catchupSource: currentExtinf.catchupSource,
+            label: sourceLabel,
+          },
         ],
       });
       currentExtinf = null;
@@ -112,6 +121,13 @@ export function parseM3U(content: string): M3UMetadata {
 
 function isPlaylistUrl(line: string): boolean {
   return line.startsWith("/") || line.startsWith("http://") || line.startsWith("https://");
+}
+
+function resolveCatchupSource(value: string | undefined): string | undefined {
+  if (!value) {
+    return value;
+  }
+  return toPlaylistRelativePath(value);
 }
 
 function parseGroupTitles(line: string): string[] {

--- a/web-ui/src/lib/url.ts
+++ b/web-ui/src/lib/url.ts
@@ -37,3 +37,25 @@ export function buildStatusPath(suffix: string): string {
 
   return `${basePath}${normalizedSuffix}`;
 }
+
+/**
+ * Strip scheme/host from playlist URLs, leaving site-root-relative paths.
+ * Matches server use-relative-path-in-m3u output (e.g. /app/rtp2httpd/Channel).
+ * Query-only templates (e.g. ?playseek=...) are returned unchanged.
+ */
+export function toPlaylistRelativePath(url: string): string {
+  if (!url) {
+    return url;
+  }
+
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `toPlaylistRelativePath()` to strip `http(s)://host:port` from M3U URLs and keep site-root-relative paths
- Apply the rewrite when parsing channel URLs, EPG (`x-tvg-url`), and catchup sources in the web player
- Preserve `$label` suffixes and query-only catchup templates unchanged

This mirrors server `use-relative-path-in-m3u` output so playback and EPG requests follow the browser's current origin (reverse proxy, custom host, PWA, etc.).

## Test plan
- [ ] Open the built-in player via a host/port different from the one embedded in `playlist.m3u` and verify channels play
- [ ] Confirm EPG loads when `x-tvg-url` in M3U uses an absolute URL with a different host
- [ ] Verify multi-source channels with `$label` suffixes still switch correctly
- [ ] Verify catchup playback still works for append-mode (`?playseek=...`) and default-mode catchup sources