### PR TITLE
fix(auth): encode r2h token cookies

### DIFF
--- a/e2e/test_auth.py
+++ b/e2e/test_auth.py
@@ -5,6 +5,8 @@ Tests verify token validation via query parameter, cookie, and User-Agent,
 as well as rejection on mismatch or absence.
 """
 
+from urllib.parse import quote
+
 import pytest
 
 from helpers import (
@@ -13,7 +15,8 @@ from helpers import (
     http_get,
 )
 
-SECRET = "s3cret-t0ken"
+SECRET = "semi;and&tilde~dollar$token"
+SECRET_ENCODED = quote(SECRET, safe="")
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +90,7 @@ class TestAuthQueryParam:
         status, _, _ = http_get(
             "127.0.0.1",
             token_r2h.port,
-            f"/status?r2h-token={SECRET}",
+            f"/status?r2h-token={SECRET_ENCODED}",
         )
         assert status == 200
 
@@ -96,11 +99,15 @@ class TestAuthQueryParam:
         status, hdrs, _ = http_get(
             "127.0.0.1",
             token_r2h.port,
-            f"/status?r2h-token={SECRET}",
+            f"/status?r2h-token={SECRET_ENCODED}",
         )
         assert status == 200
         set_cookie = hdrs.get("Set-Cookie", hdrs.get("set-cookie", ""))
-        assert "r2h-token=" in set_cookie
+        assert f"r2h-token={SECRET_ENCODED}" in set_cookie
+        assert "%3B" in set_cookie
+        assert "%26" in set_cookie
+        assert "%24" in set_cookie
+        assert "~" in set_cookie
 
 
 # ---------------------------------------------------------------------------
@@ -116,7 +123,7 @@ class TestAuthCookie:
             "127.0.0.1",
             token_r2h.port,
             "/status",
-            headers={"Cookie": f"r2h-token={SECRET}"},
+            headers={"Cookie": f"r2h-token={SECRET_ENCODED}"},
         )
         assert status == 200
 
@@ -191,7 +198,7 @@ rtp://239.0.0.1:1234
             status_auth, _, body = http_get(
                 "127.0.0.1",
                 port,
-                f"/playlist.m3u?r2h-token={SECRET}",
+                f"/playlist.m3u?r2h-token={SECRET_ENCODED}",
             )
             assert status_auth == 200
             assert b"Secured Channel" in body
@@ -220,7 +227,7 @@ rtp://239.0.0.1:1234
             status, _, body = http_get(
                 "127.0.0.1",
                 port,
-                f"/playlist.m3u?r2h-token={SECRET}",
+                f"/playlist.m3u?r2h-token={SECRET_ENCODED}",
             )
             assert status == 200
             text = body.decode()

--- a/src/connection.c
+++ b/src/connection.c
@@ -229,6 +229,10 @@ static token_source_t validate_r2h_token(connection_t *c, const char *query_star
   /* Source 2: Cookie header */
   if (c->http_req.cookie[0] != '\0') {
     if (parse_cookie_value(c->http_req.cookie, "r2h-token", token_value, sizeof(token_value)) == 0) {
+      if (http_url_decode(token_value) != 0) {
+        logger(LOG_WARN, "r2h-token invalid URL encoding (source: cookie)");
+        return TOKEN_SOURCE_NONE;
+      }
       if (strcmp(token_value, config.r2h_token) == 0) {
         logger(LOG_DEBUG, "r2h-token validated (source: cookie)");
         return TOKEN_SOURCE_COOKIE;

--- a/src/http.c
+++ b/src/http.c
@@ -95,7 +95,8 @@ int http_url_decode(char *str) {
 
   while (*src) {
     if (*src == '%') {
-      if (strlen(src) >= 3 && sscanf(src + 1, "%2x", &hex_value) == 1) {
+      if (isxdigit((unsigned char)src[1]) && isxdigit((unsigned char)src[2]) &&
+          sscanf(src + 1, "%2x", &hex_value) == 1) {
         *dst++ = (char)hex_value;
         src += 3;
       } else {
@@ -287,7 +288,7 @@ int http_parse_request(char *inbuf, int *in_len, http_request_t *req) {
             strcasecmp(inbuf, "Accept-Encoding") != 0 && strcasecmp(inbuf, "X-Forwarded-For") != 0 &&
             strcasecmp(inbuf, "X-Forwarded-Host") != 0 && strcasecmp(inbuf, "X-Forwarded-Proto") != 0) {
           const char *filtered_value = value;
-          char filter_buf[2048];
+          char filter_buf[HTTP_COOKIE_BUFFER_SIZE];
 
           /* Filter r2h-token from Cookie header */
           if (strcasecmp(inbuf, "Cookie") == 0 && config.r2h_token && config.r2h_token[0] != '\0') {
@@ -296,6 +297,9 @@ int http_parse_request(char *inbuf, int *in_len, http_request_t *req) {
               filtered_value = filter_buf;
             } else if (flen == 0) {
               /* Cookie is empty after filtering, skip this header */
+              filtered_value = NULL;
+            } else {
+              logger(LOG_WARN, "Dropping Cookie header after r2h-token filtering failed");
               filtered_value = NULL;
             }
           }

--- a/src/http.c
+++ b/src/http.c
@@ -54,10 +54,11 @@ void send_http_headers(connection_t *c, http_status_t status, const char *conten
   if (c->should_set_r2h_cookie && config.r2h_token && config.r2h_token[0] != '\0') {
     const char *cookie_path =
         (config.app_path_prefix && config.app_path_prefix[0] != '\0') ? config.app_path_prefix : "/";
-    len += snprintf(headers + len, sizeof(headers) - len,
-                    "Set-Cookie: r2h-token=%s; Path=%s; HttpOnly; "
-                    "SameSite=Strict\r\n",
-                    config.r2h_token, cookie_path);
+    int cookie_len = http_build_r2h_token_cookie_header(headers + len, sizeof(headers) - (size_t)len, cookie_path);
+    if (cookie_len > 0)
+      len += cookie_len;
+    else if (cookie_len < 0)
+      logger(LOG_ERROR, "Failed to build Set-Cookie header for r2h-token");
     c->should_set_r2h_cookie = 0; /* Only set once */
   }
 
@@ -150,6 +151,32 @@ char *http_url_encode(const char *str) {
   encoded[j] = '\0';
 
   return encoded;
+}
+
+int http_build_r2h_token_cookie_header(char *buffer, size_t buffer_size, const char *path) {
+  char *encoded_token;
+  int written;
+
+  if (!buffer || buffer_size == 0)
+    return -1;
+
+  if (!config.r2h_token || config.r2h_token[0] == '\0')
+    return 0;
+
+  encoded_token = http_url_encode(config.r2h_token);
+  if (!encoded_token)
+    return -1;
+
+  written = snprintf(buffer, buffer_size,
+                     "Set-Cookie: r2h-token=%s; Path=%s; HttpOnly; "
+                     "SameSite=Strict\r\n",
+                     encoded_token, path && path[0] ? path : "/");
+  free(encoded_token);
+
+  if (written < 0 || (size_t)written >= buffer_size)
+    return -1;
+
+  return written;
 }
 
 void http_request_init(http_request_t *req) {

--- a/src/http.h
+++ b/src/http.h
@@ -11,6 +11,13 @@
 #define HTTP_URL_BUFFER_SIZE 2048
 #endif
 
+/* Maximum Cookie header value retained for r2h-token extraction.
+ * Browsers may send many unrelated cookies for the same domain, so keep this
+ * large enough for common shared-domain deployments. */
+#ifndef HTTP_COOKIE_BUFFER_SIZE
+#define HTTP_COOKIE_BUFFER_SIZE 4096
+#endif
+
 /* Forward declaration */
 typedef struct connection_s connection_t;
 
@@ -42,7 +49,7 @@ typedef struct {
   char x_forwarded_host[256];
   char x_forwarded_proto[16];
   int x_request_snapshot;
-  char cookie[1024];                        /* Cookie header value for r2h-token extraction */
+  char cookie[HTTP_COOKIE_BUFFER_SIZE];     /* Cookie header value for r2h-token extraction */
   char access_control_request_method[64];   /* CORS preflight method */
   char access_control_request_headers[512]; /* CORS preflight headers */
   http_parse_state_t parse_state;
@@ -108,6 +115,18 @@ int http_url_decode(char *str);
  * @return Newly allocated encoded string (caller must free), or NULL on error
  */
 char *http_url_encode(const char *str);
+
+/**
+ * Build a Set-Cookie header for the configured r2h-token.
+ * The cookie value is URL-encoded so token characters such as ';' remain safe
+ * in Cookie/Set-Cookie syntax.
+ *
+ * @param buffer Output buffer
+ * @param buffer_size Output buffer size
+ * @param path Cookie Path attribute
+ * @return Header length, 0 if no token is configured, or -1 on error
+ */
+int http_build_r2h_token_cookie_header(char *buffer, size_t buffer_size, const char *path);
 
 /**
  * Parse query parameter value from query/form string (case-insensitive

--- a/src/http_proxy.c
+++ b/src/http_proxy.c
@@ -729,9 +729,7 @@ static int http_proxy_finalize_rewrite(http_proxy_session_t *session) {
 
     /* Inject Set-Cookie header if needed */
     if (session->conn && session->conn->should_set_r2h_cookie && config.r2h_token && config.r2h_token[0] != '\0') {
-      int cookie_written =
-          snprintf(hdr_ptr, hdr_remaining, "Set-Cookie: r2h-token=%s; Path=%s; HttpOnly; SameSite=Strict\r\n",
-                   config.r2h_token, http_proxy_get_cookie_path());
+      int cookie_written = http_build_r2h_token_cookie_header(hdr_ptr, hdr_remaining, http_proxy_get_cookie_path());
       if (cookie_written > 0 && (size_t)cookie_written < hdr_remaining) {
         hdr_ptr += cookie_written;
         hdr_remaining -= cookie_written;
@@ -1167,11 +1165,9 @@ static int http_proxy_parse_response_headers(http_proxy_session_t *session) {
 
       /* Inject Set-Cookie header if needed */
       if (session->conn->should_set_r2h_cookie && config.r2h_token && config.r2h_token[0] != '\0') {
-        char set_cookie_header[512];
-        int cookie_len = snprintf(set_cookie_header, sizeof(set_cookie_header),
-                                  "Set-Cookie: r2h-token=%s; Path=%s; HttpOnly; "
-                                  "SameSite=Strict\r\n",
-                                  config.r2h_token, http_proxy_get_cookie_path());
+        char set_cookie_header[1024];
+        int cookie_len =
+            http_build_r2h_token_cookie_header(set_cookie_header, sizeof(set_cookie_header), http_proxy_get_cookie_path());
         if (cookie_len > 0 && cookie_len < (int)sizeof(set_cookie_header)) {
           if (connection_queue_output(session->conn, (const uint8_t *)set_cookie_header, cookie_len) < 0) {
             logger(LOG_ERROR, "HTTP Proxy: Failed to send Set-Cookie header");
@@ -1199,11 +1195,9 @@ static int http_proxy_parse_response_headers(http_proxy_session_t *session) {
 
       /* Inject Set-Cookie header if needed */
       if (session->conn->should_set_r2h_cookie && config.r2h_token && config.r2h_token[0] != '\0') {
-        char set_cookie_header[512];
-        int cookie_len = snprintf(set_cookie_header, sizeof(set_cookie_header),
-                                  "Set-Cookie: r2h-token=%s; Path=%s; HttpOnly; "
-                                  "SameSite=Strict\r\n",
-                                  config.r2h_token, http_proxy_get_cookie_path());
+        char set_cookie_header[1024];
+        int cookie_len =
+            http_build_r2h_token_cookie_header(set_cookie_header, sizeof(set_cookie_header), http_proxy_get_cookie_path());
         if (cookie_len > 0 && cookie_len < (int)sizeof(set_cookie_header)) {
           if (connection_queue_output(session->conn, (const uint8_t *)set_cookie_header, cookie_len) < 0) {
             logger(LOG_ERROR, "HTTP Proxy: Failed to send Set-Cookie header");

--- a/src/http_proxy.c
+++ b/src/http_proxy.c
@@ -2,7 +2,7 @@
 #include "buffer_pool.h"
 #include "configuration.h"
 #include "connection.h"
-#include "http.h" /* For http_url_encode */
+#include "http.h"
 #include "http_proxy_rewrite.h"
 #include "platform_compat.h"
 #include "poller.h"
@@ -734,6 +734,8 @@ static int http_proxy_finalize_rewrite(http_proxy_session_t *session) {
         hdr_ptr += cookie_written;
         hdr_remaining -= cookie_written;
         headers_len += cookie_written;
+      } else if (cookie_written < 0) {
+        logger(LOG_ERROR, "HTTP Proxy: Failed to build Set-Cookie header for r2h-token");
       }
       session->conn->should_set_r2h_cookie = 0;
     }
@@ -1165,7 +1167,7 @@ static int http_proxy_parse_response_headers(http_proxy_session_t *session) {
 
       /* Inject Set-Cookie header if needed */
       if (session->conn->should_set_r2h_cookie && config.r2h_token && config.r2h_token[0] != '\0') {
-        char set_cookie_header[1024];
+        char set_cookie_header[HTTP_COOKIE_BUFFER_SIZE];
         int cookie_len =
             http_build_r2h_token_cookie_header(set_cookie_header, sizeof(set_cookie_header), http_proxy_get_cookie_path());
         if (cookie_len > 0 && cookie_len < (int)sizeof(set_cookie_header)) {
@@ -1174,6 +1176,8 @@ static int http_proxy_parse_response_headers(http_proxy_session_t *session) {
             return -1;
           }
           logger(LOG_DEBUG, "HTTP Proxy: Injected Set-Cookie header for r2h-token");
+        } else if (cookie_len < 0) {
+          logger(LOG_ERROR, "HTTP Proxy: Failed to build Set-Cookie header for r2h-token");
         }
         session->conn->should_set_r2h_cookie = 0;
       }
@@ -1195,7 +1199,7 @@ static int http_proxy_parse_response_headers(http_proxy_session_t *session) {
 
       /* Inject Set-Cookie header if needed */
       if (session->conn->should_set_r2h_cookie && config.r2h_token && config.r2h_token[0] != '\0') {
-        char set_cookie_header[1024];
+        char set_cookie_header[HTTP_COOKIE_BUFFER_SIZE];
         int cookie_len =
             http_build_r2h_token_cookie_header(set_cookie_header, sizeof(set_cookie_header), http_proxy_get_cookie_path());
         if (cookie_len > 0 && cookie_len < (int)sizeof(set_cookie_header)) {
@@ -1204,6 +1208,8 @@ static int http_proxy_parse_response_headers(http_proxy_session_t *session) {
             return -1;
           }
           logger(LOG_DEBUG, "HTTP Proxy: Injected Set-Cookie header for r2h-token");
+        } else if (cookie_len < 0) {
+          logger(LOG_ERROR, "HTTP Proxy: Failed to build Set-Cookie header for r2h-token");
         }
         session->conn->should_set_r2h_cookie = 0; /* Only set once */
       }

--- a/src/http_proxy.c
+++ b/src/http_proxy.c
@@ -1168,8 +1168,8 @@ static int http_proxy_parse_response_headers(http_proxy_session_t *session) {
       /* Inject Set-Cookie header if needed */
       if (session->conn->should_set_r2h_cookie && config.r2h_token && config.r2h_token[0] != '\0') {
         char set_cookie_header[HTTP_COOKIE_BUFFER_SIZE];
-        int cookie_len =
-            http_build_r2h_token_cookie_header(set_cookie_header, sizeof(set_cookie_header), http_proxy_get_cookie_path());
+        int cookie_len = http_build_r2h_token_cookie_header(set_cookie_header, sizeof(set_cookie_header),
+                                                            http_proxy_get_cookie_path());
         if (cookie_len > 0 && cookie_len < (int)sizeof(set_cookie_header)) {
           if (connection_queue_output(session->conn, (const uint8_t *)set_cookie_header, cookie_len) < 0) {
             logger(LOG_ERROR, "HTTP Proxy: Failed to send Set-Cookie header");
@@ -1200,8 +1200,8 @@ static int http_proxy_parse_response_headers(http_proxy_session_t *session) {
       /* Inject Set-Cookie header if needed */
       if (session->conn->should_set_r2h_cookie && config.r2h_token && config.r2h_token[0] != '\0') {
         char set_cookie_header[HTTP_COOKIE_BUFFER_SIZE];
-        int cookie_len =
-            http_build_r2h_token_cookie_header(set_cookie_header, sizeof(set_cookie_header), http_proxy_get_cookie_path());
+        int cookie_len = http_build_r2h_token_cookie_header(set_cookie_header, sizeof(set_cookie_header),
+                                                            http_proxy_get_cookie_path());
         if (cookie_len > 0 && cookie_len < (int)sizeof(set_cookie_header)) {
           if (connection_queue_output(session->conn, (const uint8_t *)set_cookie_header, cookie_len) < 0) {
             logger(LOG_ERROR, "HTTP Proxy: Failed to send Set-Cookie header");


### PR DESCRIPTION
## Summary

Encode `r2h-token` values before writing them into `Set-Cookie`, then URL-decode cookie auth values before comparison. This keeps tokens containing characters like `;`, `&`, and `$` from breaking cookie parsing.

Also increases the retained Cookie header buffer to 4 KB so deployments on shared domains with unrelated cookies have more room before auth parsing truncates the header.

Related to #579.

## Validation

- `cmake --build build -j$(getconf _NPROCESSORS_ONLN)`
- `./scripts/run-e2e.sh test_auth.py`
- `./scripts/run-e2e.sh test_pages.py`