### PR TITLE
feat(perf): add benchmark harness and forwarding optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ __pycache__/
 
 # Benchmark results
 tools/benchmark_results_*.txt
+perf-results/
 
 # iKuai package outputs
 ikuai-support/.staging/

--- a/src/buffer_pool.c
+++ b/src/buffer_pool.c
@@ -22,6 +22,8 @@ static uint64_t buffer_pool_time_us(void) {
 }
 
 void buffer_pool_update_stats(buffer_pool_t *pool) {
+  if (!pool)
+    return;
   if (!status_shared || worker_id < 0 || worker_id >= STATUS_MAX_WORKERS)
     return;
 
@@ -36,6 +38,20 @@ void buffer_pool_update_stats(buffer_pool_t *pool) {
     stats->control_pool_free_buffers = pool->num_free;
     stats->control_pool_max_buffers = pool->max_buffers;
   }
+
+  pool->stats_dirty = 0;
+}
+
+void buffer_pool_mark_stats_dirty(buffer_pool_t *pool) {
+  if (pool)
+    pool->stats_dirty = 1;
+}
+
+void buffer_pool_flush_stats(void) {
+  if (zerocopy_state.pool.stats_dirty)
+    buffer_pool_update_stats(&zerocopy_state.pool);
+  if (zerocopy_state.control_pool.stats_dirty)
+    buffer_pool_update_stats(&zerocopy_state.control_pool);
 }
 
 static buffer_pool_segment_t *buffer_pool_segment_create(size_t buffer_size, size_t num_buffers, buffer_pool_t *pool) {
@@ -192,7 +208,7 @@ void buffer_ref_put(buffer_ref_t *ref) {
     pool->free_list = ref;
     pool->num_free++;
 
-    buffer_pool_update_stats(pool);
+    buffer_pool_mark_stats_dirty(pool);
   }
 }
 
@@ -241,7 +257,7 @@ buffer_ref_t *buffer_pool_alloc_from(buffer_pool_t *pool) {
   ref->data_size = 0;
   ref->send_next = NULL;
 
-  buffer_pool_update_stats(pool);
+  buffer_pool_mark_stats_dirty(pool);
 
   return ref;
 }

--- a/src/buffer_pool.h
+++ b/src/buffer_pool.h
@@ -95,12 +95,15 @@ typedef struct buffer_pool_s {
   size_t expand_size;
   size_t low_watermark;
   size_t high_watermark;
+  int stats_dirty;
 } buffer_pool_t;
 
 int buffer_pool_init(buffer_pool_t *pool, size_t buffer_size, size_t initial_buffers, size_t max_buffers,
                      size_t expand_size, size_t low_watermark, size_t high_watermark);
 void buffer_pool_cleanup(buffer_pool_t *pool);
 void buffer_pool_update_stats(buffer_pool_t *pool);
+void buffer_pool_mark_stats_dirty(buffer_pool_t *pool);
+void buffer_pool_flush_stats(void);
 void buffer_ref_get(buffer_ref_t *ref);
 void buffer_ref_put(buffer_ref_t *ref);
 buffer_ref_t *buffer_pool_alloc_from(buffer_pool_t *pool);

--- a/src/connection.c
+++ b/src/connection.c
@@ -36,6 +36,7 @@
 #define CONN_QUEUE_SLOW_LIMIT_RATIO 0.9
 #define CONN_QUEUE_SLOW_EXIT_LIMIT_RATIO 0.75
 #define CONN_QUEUE_SLOW_CLAMP_FACTOR 0.8
+#define CONN_QUEUE_LIMIT_REFRESH_PACKETS 32
 
 /* Forward declarations */
 static void handle_playlist_request(connection_t *c);
@@ -395,8 +396,17 @@ static inline void connection_record_drop(connection_t *c, size_t len) {
   c->dropped_bytes += len;
 }
 
-static void connection_report_queue(connection_t *c) {
+void connection_mark_queue_dirty(connection_t *c) {
+  if (c)
+    c->queue_report_dirty = 1;
+}
+
+void connection_flush_queue_report(connection_t *c) {
+  if (!c)
+    return;
   if (c->status_index < 0)
+    return;
+  if (!c->queue_report_dirty)
     return;
 
   size_t queue_buffers = c->zc_queue.num_queued;
@@ -405,6 +415,34 @@ static void connection_report_queue(connection_t *c) {
   status_update_client_queue(c->status_index, queue_bytes, queue_buffers, c->queue_limit_bytes,
                              c->queue_bytes_highwater, c->queue_buffers_highwater, c->dropped_packets, c->dropped_bytes,
                              c->backpressure_events, c->slow_active);
+  c->queue_report_dirty = 0;
+}
+
+static void connection_arm_write(connection_t *c) {
+  if (!c)
+    return;
+  c->queue_flush_armed = 1;
+  connection_epoll_update_events(c->epfd, c->fd, POLLER_IN | POLLER_OUT | POLLER_RDHUP | POLLER_HUP | POLLER_ERR);
+}
+
+static void connection_disarm_write(connection_t *c) {
+  if (!c)
+    return;
+  c->queue_flush_armed = 0;
+  connection_epoll_update_events(c->epfd, c->fd, POLLER_IN | POLLER_RDHUP | POLLER_HUP | POLLER_ERR);
+}
+
+void connection_flush_batch_if_ready(connection_t *c) {
+  if (!c || !c->zc_queue.head || c->queue_flush_armed)
+    return;
+  if (zerocopy_should_flush(&c->zc_queue))
+    connection_arm_write(c);
+}
+
+int connection_batch_flush_delay_ms(connection_t *c, int64_t now_ms) {
+  if (!c || c->queue_flush_armed)
+    return -1;
+  return zerocopy_flush_delay_ms(&c->zc_queue, now_ms);
 }
 
 /* Backpressure watermarks for TCP-to-TCP relay flow control.  Upstream modules
@@ -466,7 +504,21 @@ void connection_begin_drain_close(connection_t *c) {
   if (!c || c->state == CONN_CLOSING)
     return;
   c->state = CONN_CLOSING;
-  connection_epoll_update_events(c->epfd, c->fd, POLLER_IN | POLLER_OUT | POLLER_RDHUP | POLLER_HUP | POLLER_ERR);
+  connection_arm_write(c);
+}
+
+static size_t connection_queue_limit_for_enqueue(connection_t *c) {
+  if (c->queue_limit_bytes == 0 ||
+      c->queue_limit_packets_since_update >= (uint32_t)CONN_QUEUE_LIMIT_REFRESH_PACKETS) {
+    int64_t now_ms = get_time_ms();
+    c->queue_limit_bytes = connection_update_queue_limit(c, now_ms);
+    c->queue_limit_last_update_ms = now_ms;
+    c->queue_limit_packets_since_update = 0;
+  } else {
+    c->queue_limit_packets_since_update++;
+  }
+
+  return c->queue_limit_bytes;
 }
 
 int connection_set_nonblocking(int fd) {
@@ -519,6 +571,10 @@ connection_t *connection_create(int fd, int epfd, struct sockaddr_storage *clien
   c->queue_avg_bytes = 0.0;
   c->slow_active = 0;
   c->slow_candidate_since = 0;
+  c->queue_limit_last_update_ms = 0;
+  c->queue_limit_packets_since_update = 0;
+  c->queue_report_dirty = 0;
+  c->queue_flush_armed = 0;
 
   /* Enforce TCP user timeout so unacknowledged data fails quickly */
 #ifdef TCP_USER_TIMEOUT
@@ -563,6 +619,8 @@ void connection_cleanup(connection_t *c) {
 
   /* Cleanup zero-copy queue - this releases all buffer references */
   zerocopy_queue_cleanup(&c->zc_queue);
+  connection_mark_queue_dirty(c);
+  connection_flush_queue_report(c);
 
   /* Try to shrink buffer pool after connection cleanup
    * This is an ideal time to reclaim memory as buffers are likely freed
@@ -648,9 +706,9 @@ int connection_queue_output_and_flush(connection_t *c, const uint8_t *data, size
   int result = connection_queue_output(c, data, len);
   if (result < 0)
     return result;
-  connection_epoll_update_events(c->epfd, c->fd, POLLER_IN | POLLER_OUT | POLLER_RDHUP | POLLER_HUP | POLLER_ERR);
 
   if (c) {
+    connection_arm_write(c);
     c->state = CONN_CLOSING;
   }
 
@@ -662,8 +720,8 @@ connection_write_status_t connection_handle_write(connection_t *c) {
     return CONNECTION_WRITE_IDLE;
 
   if (!c->zc_queue.head) {
-    connection_epoll_update_events(c->epfd, c->fd, POLLER_IN | POLLER_RDHUP | POLLER_HUP | POLLER_ERR);
-    connection_report_queue(c);
+    connection_disarm_write(c);
+    connection_mark_queue_dirty(c);
     if (c->state == CONN_CLOSING && !c->zc_queue.pending_head)
       return CONNECTION_WRITE_CLOSED;
     return CONNECTION_WRITE_IDLE;
@@ -682,14 +740,14 @@ connection_write_status_t connection_handle_write(connection_t *c) {
 
     if (ret < 0 && ret != -2) {
       c->state = CONN_CLOSING;
-      connection_epoll_update_events(c->epfd, c->fd, POLLER_IN | POLLER_RDHUP | POLLER_HUP | POLLER_ERR);
-      connection_report_queue(c);
+      connection_disarm_write(c);
+      connection_mark_queue_dirty(c);
       return CONNECTION_WRITE_CLOSED;
     }
 
     if (ret == -2) {
       /* EAGAIN - socket send buffer full, wait for next writable event */
-      connection_report_queue(c);
+      connection_mark_queue_dirty(c);
       if (total_sent > 0)
         stream_on_client_drain(&c->stream);
       return CONNECTION_WRITE_BLOCKED;
@@ -697,8 +755,8 @@ connection_write_status_t connection_handle_write(connection_t *c) {
 
     if (!c->zc_queue.head) {
       if (c->state == CONN_CLOSING && !c->zc_queue.pending_head) {
-        connection_epoll_update_events(c->epfd, c->fd, POLLER_IN | POLLER_RDHUP | POLLER_HUP | POLLER_ERR);
-        connection_report_queue(c);
+        connection_disarm_write(c);
+        connection_mark_queue_dirty(c);
         return CONNECTION_WRITE_CLOSED;
       }
       /* Notify upstream BEFORE arming the poller mask: resume() may queue
@@ -709,8 +767,9 @@ connection_write_status_t connection_handle_write(connection_t *c) {
       uint32_t mask = POLLER_IN | POLLER_RDHUP | POLLER_HUP | POLLER_ERR;
       if (c->zc_queue.head)
         mask |= POLLER_OUT;
+      c->queue_flush_armed = c->zc_queue.head ? 1 : 0;
       connection_epoll_update_events(c->epfd, c->fd, mask);
-      connection_report_queue(c);
+      connection_mark_queue_dirty(c);
       return CONNECTION_WRITE_IDLE;
     }
 
@@ -720,7 +779,7 @@ connection_write_status_t connection_handle_write(connection_t *c) {
   }
 
   /* Queue still has data but we couldn't make progress */
-  connection_report_queue(c);
+  connection_mark_queue_dirty(c);
   if (total_sent > 0)
     stream_on_client_drain(&c->stream);
   return CONNECTION_WRITE_PENDING;
@@ -1178,8 +1237,7 @@ int connection_queue_zerocopy(connection_t *c, buffer_ref_t *buf_ref) {
   if (!c || !buf_ref || buf_ref->data_size == 0)
     return 0;
 
-  int64_t now_ms = get_time_ms();
-  size_t limit_bytes = connection_update_queue_limit(c, now_ms);
+  size_t limit_bytes = connection_queue_limit_for_enqueue(c);
   size_t queued_bytes = connection_queue_bytes(c);
   size_t projected_bytes = queued_bytes + buf_ref->data_size;
 
@@ -1195,7 +1253,7 @@ int connection_queue_zerocopy(connection_t *c, buffer_ref_t *buf_ref) {
              buf_ref->data_size, c->fd, queued_bytes, limit_bytes, (unsigned long long)c->dropped_packets);
     }
 
-    connection_report_queue(c);
+    connection_mark_queue_dirty(c);
     return -1;
   }
 
@@ -1210,18 +1268,17 @@ int connection_queue_zerocopy(connection_t *c, buffer_ref_t *buf_ref) {
   if (c->zc_queue.num_queued > c->queue_buffers_highwater)
     c->queue_buffers_highwater = c->zc_queue.num_queued;
 
-  connection_report_queue(c);
+  connection_mark_queue_dirty(c);
 
   /* Batching optimization: Only enable EPOLLOUT when flush threshold is reached
    * Benefits:
    * - Reduces sendmsg() syscall overhead (fewer calls)
    * - Reduces MSG_ZEROCOPY optmem consumption (fewer operations)
    * - Better batching with iovec (up to 64 packets per sendmsg)
-   * - Lower latency impact (100ms is acceptable for streaming)
+   * - Bounded latency for low-rate streams via the first-packet age threshold
    */
-  if (zerocopy_should_flush(&c->zc_queue)) {
-    connection_epoll_update_events(c->epfd, c->fd, POLLER_IN | POLLER_OUT | POLLER_RDHUP | POLLER_HUP | POLLER_ERR);
-  }
+  if (zerocopy_should_flush(&c->zc_queue))
+    connection_arm_write(c);
 
   return 0;
 }
@@ -1236,7 +1293,7 @@ int connection_queue_file(connection_t *c, int file_fd, off_t file_offset, size_
     return -1;
 
   /* Always flush immediately for file sends (no batching) */
-  connection_epoll_update_events(c->epfd, c->fd, POLLER_IN | POLLER_OUT | POLLER_RDHUP | POLLER_HUP | POLLER_ERR);
+  connection_arm_write(c);
 
   /* Set connection to closing state after file transfer */
   c->state = CONN_CLOSING;

--- a/src/connection.h
+++ b/src/connection.h
@@ -71,6 +71,10 @@ typedef struct connection_s {
   double queue_avg_bytes;
   int slow_active;
   int64_t slow_candidate_since;
+  int64_t queue_limit_last_update_ms;
+  uint32_t queue_limit_packets_since_update;
+  int queue_report_dirty;
+  int queue_flush_armed;
   /* Set when any TCP upstream session attached to this connection has paused
    * its reads due to client-side backpressure.  Lets the per-write notify
    * fast-path skip cheaply when no upstream is paused (the common case). */
@@ -221,6 +225,10 @@ int connection_can_resume_upstream(connection_t *c);
  * stream_on_client_drain() stays accurate.
  */
 void connection_recompute_any_upstream_paused(connection_t *c);
+void connection_mark_queue_dirty(connection_t *c);
+void connection_flush_queue_report(connection_t *c);
+void connection_flush_batch_if_ready(connection_t *c);
+int connection_batch_flush_delay_ms(connection_t *c, int64_t now_ms);
 
 /**
  * Mark the connection for orderly shutdown after upstream EOF/error: switch

--- a/src/rtp_reorder.c
+++ b/src/rtp_reorder.c
@@ -225,6 +225,11 @@ int rtp_reorder_insert(rtp_reorder_t *r, buffer_ref_t *buf_ref, uint16_t seqn, c
 
   /* Case 1: Expected sequence -> store and flush */
   if (likely(seq_diff == 0)) {
+    if (likely(!is_snapshot && !fec_is_enabled(fec) && r->count == 0)) {
+      r->base_seq++;
+      return rtp_queue_buf_direct(conn, buf_ref);
+    }
+
     int slot = seqn & r->window_mask;
     if (r->slots[slot]) {
       /* Old packet from ring wrap-around, release it */

--- a/src/stream.c
+++ b/src/stream.c
@@ -373,6 +373,7 @@ int stream_tick(stream_context_t *ctx, int64_t now) {
 
     /* Update bytes and bandwidth in status */
     status_update_client_bytes(ctx->status_index, ctx->total_bytes_sent, current_bandwidth);
+    connection_flush_queue_report(ctx->conn);
 
     /* Save current bytes for next calculation */
     ctx->last_bytes_sent = ctx->total_bytes_sent;

--- a/src/worker.c
+++ b/src/worker.c
@@ -263,9 +263,17 @@ int worker_run_event_loop(int *listen_sockets, int num_sockets, int notif_fd) {
 
   /* Unified event loop: accept + clients + stream fds */
   int64_t last_tick = get_time_ms();
+  int64_t last_pool_stats_flush = last_tick;
 
   while (!stop_flag) {
     int timeout_ms = 100;
+    int64_t wait_now = get_time_ms();
+    for (connection_t *c = conn_head; c; c = c->next) {
+      int delay_ms = connection_batch_flush_delay_ms(c, wait_now);
+      if (delay_ms >= 0 && delay_ms < timeout_ms)
+        timeout_ms = delay_ms;
+    }
+
     int n = poller_wait(epfd, events, (int)(sizeof(events) / sizeof(events[0])), timeout_ms);
     if (n < 0) {
       if (errno == EINTR)
@@ -520,6 +528,7 @@ int worker_run_event_loop(int *listen_sockets, int num_sockets, int notif_fd) {
       connection_t *c = conn_head;
       while (c) {
         connection_t *next = c->next; /* Save next pointer before potential cleanup */
+        connection_flush_batch_if_ready(c);
         if (c->streaming) {
           if (stream_tick(&c->stream, now) < 0) {
             /* Send 503 if headers not sent yet (no data ever arrived) */
@@ -633,6 +642,11 @@ int worker_run_event_loop(int *listen_sockets, int num_sockets, int notif_fd) {
             }
           }
         }
+      }
+
+      if (now - last_pool_stats_flush >= 1000) {
+        last_pool_stats_flush = now;
+        buffer_pool_flush_stats();
       }
     }
   }

--- a/src/zerocopy.c
+++ b/src/zerocopy.c
@@ -153,6 +153,7 @@ int zerocopy_queue_add(zerocopy_queue_t *queue, buffer_ref_t *buf_ref) {
   if (!queue || !buf_ref || buf_ref->data_size == 0)
     return 0;
 
+  int was_empty = queue->head == NULL;
   uint8_t *base = (uint8_t *)buf_ref->data;
 
   if (!base || buf_ref->data_offset > BUFFER_POOL_BUFFER_SIZE ||
@@ -185,6 +186,9 @@ int zerocopy_queue_add(zerocopy_queue_t *queue, buffer_ref_t *buf_ref) {
     queue->head = queue->tail = buf_ref;
   }
 
+  if (was_empty)
+    queue->first_enqueue_time_ms = get_time_ms();
+
   queue->total_bytes += buf_ref->data_size;
   queue->num_queued++;
 
@@ -194,6 +198,8 @@ int zerocopy_queue_add(zerocopy_queue_t *queue, buffer_ref_t *buf_ref) {
 int zerocopy_queue_add_file(zerocopy_queue_t *queue, int file_fd, off_t file_offset, size_t file_size) {
   if (file_fd < 0 || file_size == 0)
     return -1;
+
+  int was_empty = queue->head == NULL;
 
   /* Allocate a buffer_ref_t to represent the file (not from pool) */
   buffer_ref_t *buf_ref = calloc(1, sizeof(buffer_ref_t));
@@ -222,6 +228,9 @@ int zerocopy_queue_add_file(zerocopy_queue_t *queue, int file_fd, off_t file_off
     queue->head = queue->tail = buf_ref;
   }
 
+  if (was_empty)
+    queue->first_enqueue_time_ms = get_time_ms();
+
   /* Note: File buffers do NOT count towards total_bytes for batching logic
    * because they are always flushed immediately and don't participate in
    * the batching optimization designed for small RTP packets.
@@ -235,16 +244,29 @@ int zerocopy_queue_add_file(zerocopy_queue_t *queue, int file_fd, off_t file_off
 }
 
 int zerocopy_should_flush(zerocopy_queue_t *queue) {
-  if (!queue || !queue->head)
-    return 0; /* Nothing to flush */
-
-  /* Flush if accumulated bytes >= threshold */
-  if (queue->total_bytes >= ZEROCOPY_BATCH_BYTES) {
+  if (zerocopy_flush_delay_ms(queue, get_time_ms()) == 0) {
     WORKER_STATS_INC(batch_sends);
     return 1;
   }
 
   return 0; /* Not ready to flush yet */
+}
+
+int zerocopy_flush_delay_ms(const zerocopy_queue_t *queue, int64_t now_ms) {
+  if (!queue || !queue->head)
+    return -1;
+
+  if (queue->total_bytes >= ZEROCOPY_BATCH_BYTES)
+    return 0;
+
+  if (queue->first_enqueue_time_ms <= 0)
+    return ZEROCOPY_BATCH_MAX_DELAY_MS;
+
+  int64_t elapsed = now_ms - queue->first_enqueue_time_ms;
+  if (elapsed >= ZEROCOPY_BATCH_MAX_DELAY_MS)
+    return 0;
+
+  return (int)(ZEROCOPY_BATCH_MAX_DELAY_MS - elapsed);
 }
 
 int zerocopy_send(int fd, zerocopy_queue_t *queue, size_t *bytes_sent) {
@@ -283,8 +305,10 @@ int zerocopy_send(int fd, zerocopy_queue_t *queue, size_t *bytes_sent) {
       size_t total_file_size = file_buf->file_size; /* Save before put */
 
       queue->head = file_buf->send_next;
-      if (!queue->head)
+      if (!queue->head) {
         queue->tail = NULL;
+        queue->first_enqueue_time_ms = 0;
+      }
 
       /* Note: File buffers don't count towards total_bytes, so no need to
        * update it */
@@ -401,8 +425,10 @@ int zerocopy_send(int fd, zerocopy_queue_t *queue, size_t *bytes_sent) {
         queue->num_queued--;
         queue->head = current->send_next;
 
-        if (!queue->head)
+        if (!queue->head) {
           queue->tail = NULL;
+          queue->first_enqueue_time_ms = 0;
+        }
 
         /* Add to pending completion queue */
         current->send_next = NULL;
@@ -445,8 +471,10 @@ int zerocopy_send(int fd, zerocopy_queue_t *queue, size_t *bytes_sent) {
         queue->num_queued--;
         queue->head = current->send_next;
 
-        if (!queue->head)
+        if (!queue->head) {
           queue->tail = NULL;
+          queue->first_enqueue_time_ms = 0;
+        }
 
         /* Free buffer immediately since kernel has copied the data */
         buffer_ref_put(current);

--- a/src/zerocopy.h
+++ b/src/zerocopy.h
@@ -20,6 +20,7 @@
 
 /* Batching configuration - accumulate small packets before sending */
 #define ZEROCOPY_BATCH_BYTES 65536 /* Send when accumulated >= 64KB */
+#define ZEROCOPY_BATCH_MAX_DELAY_MS 20
 
 /**
  * Zero-copy send queue for a connection
@@ -32,6 +33,7 @@ typedef struct zerocopy_queue_s {
   size_t total_bytes;         /* Total bytes queued */
   size_t num_queued;          /* Number of buffers in send queue */
   size_t num_pending;         /* Number of buffers pending completion */
+  int64_t first_enqueue_time_ms;
   uint32_t next_zerocopy_id;  /* Next ID for MSG_ZEROCOPY tracking */
   uint32_t last_completed_id; /* Last completed MSG_ZEROCOPY ID */
 } zerocopy_queue_t;
@@ -112,6 +114,14 @@ int zerocopy_send(int fd, zerocopy_queue_t *queue, size_t *bytes_sent);
  * @return 1 if should flush, 0 otherwise
  */
 int zerocopy_should_flush(zerocopy_queue_t *queue);
+
+/**
+ * Return milliseconds until a queued batch should flush.
+ * @param queue Send queue
+ * @param now_ms Current monotonic time in milliseconds
+ * @return 0 if ready, positive delay if pending, -1 if no queued batch
+ */
+int zerocopy_flush_delay_ms(const zerocopy_queue_t *queue, int64_t now_ms);
 
 /**
  * Handle MSG_ZEROCOPY completion notifications

--- a/tools/README.md
+++ b/tools/README.md
@@ -18,7 +18,8 @@ Multicast UDP replay tool for testing rtp2httpd.
 
 - Python 3.12+
 - [uv](https://docs.astral.sh/uv/)
-- Linux (uses `/proc/net/igmp` for IGMP monitoring)
+- Linux for IGMP monitoring via `/proc/net/igmp`
+- macOS or Linux for explicit target replay mode
 
 ## Usage
 
@@ -28,14 +29,18 @@ uv run python tools/main.py <pcapng_file> [options]
 
 ### Options
 
-| Option                  | Description                                                       |
-| ----------------------- | ----------------------------------------------------------------- |
-| `-i, --interface IFACE` | Network interface for multicast (e.g., eth0)                      |
-| `-v, --verbose`         | Show verbose output                                               |
-| `--loss PERCENT`        | Simulate packet loss (0-100%, default: 0)                         |
-| `--reorder PERCENT`     | Simulate packet reordering (0-100%, default: 0)                   |
-| `--speed MULTIPLIER`    | Playback speed multiplier (e.g., 2.0 for 2x, default: 1)          |
-| `--continuous`          | Continuous replay without gaps, with incrementing RTP seq numbers |
+| Option                     | Description                                                            |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `-i, --interface IFACE`    | Network interface for multicast (e.g., eth0)                           |
+| `--multicast-if-addr ADDR` | IPv4 address for `IP_MULTICAST_IF` (e.g., `127.0.0.1` on macOS lo0)    |
+| `--target ADDR`            | Explicit replay target address; can be specified multiple times        |
+| `--target-base A.B.C`      | Generate explicit targets from a `/24` prefix, starting at `.1`        |
+| `--target-count N`         | Number of generated targets for `--target-base`                        |
+| `-v, --verbose`            | Show verbose output                                                    |
+| `--loss PERCENT`           | Simulate packet loss (0-100%, default: 0)                              |
+| `--reorder PERCENT`        | Simulate packet reordering (0-100%, default: 0)                        |
+| `--speed MULTIPLIER`       | Playback speed multiplier (e.g., 2.0 for 2x, default: 1)               |
+| `--continuous`             | Continuous replay without gaps, with incrementing RTP seq numbers      |
 
 ### Examples
 
@@ -63,6 +68,14 @@ uv run python tools/main.py tools/fixtures/fec_sample.pcapng --speed 2.0 -v
 
 # 10x speed continuous stress test (no gaps between loops)
 uv run python tools/main.py tools/fixtures/fec_sample.pcapng --speed 10 --continuous -v
+
+# macOS/local explicit targets (no /proc/net/igmp required)
+uv run python tools/main.py tools/fixtures/fec_sample.pcapng --continuous --speed 5 \
+  --multicast-if-addr 127.0.0.1 --target 239.81.0.1
+
+# Generate 8 explicit targets in 239.81.0.0/24
+uv run python tools/main.py tools/fixtures/fec_sample.pcapng --continuous --speed 5 \
+  --multicast-if-addr 127.0.0.1 --target-base 239.81.0 --target-count 8
 
 # Continuous replay with packet loss simulation
 uv run python tools/main.py tools/fixtures/fec_sample.pcapng --continuous --loss 1.0 -v
@@ -106,6 +119,19 @@ curl http://localhost:5140/rtp/239.81.0.3:4056 -o /dev/null
 ```
 
 The replay tool will simultaneously send packets to all joined addresses.
+
+### Explicit Targets
+
+On macOS, the Linux `/proc/net/igmp` membership monitor is not available. Use
+explicit targets to send continuously without waiting for IGMP joins:
+
+```bash
+uv run python tools/main.py tools/fixtures/fec_sample.pcapng --continuous --speed 5 \
+  --multicast-if-addr 127.0.0.1 --target 239.81.0.1
+```
+
+This mode is also useful for repeatable performance tests because the replay
+target set is fixed by the command line.
 
 ## How It Works
 
@@ -276,6 +302,48 @@ This tests the server's ability to handle multiple independent streams. Use `--s
 - Uses `top -b -n 2` for accurate CPU sampling (first sample is cumulative, second is actual usage)
 - Aggregates CPU usage across parent process and all forked child processes
 - More accurate than `/proc/[pid]/stat` for programs using io_uring
+
+## rtp2httpd Before/After Performance Benchmark
+
+`perf_benchmark.py` is the macOS-first benchmark harness for measuring rtp2httpd
+optimization changes. It starts explicit-target multicast replay, starts
+rtp2httpd, launches curl clients, samples the rtp2httpd supervisor/worker
+process tree with `ps`, and writes JSON results for comparison.
+
+Build the benchmark binary first:
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AGGRESSIVE_OPT=ON
+cmake --build build -j$(sysctl -n hw.ncpu)
+```
+
+Run the quick suite:
+
+```bash
+uv run python tools/perf_benchmark.py run --suite quick --label baseline
+uv run python tools/perf_benchmark.py run --suite quick --label candidate
+uv run python tools/perf_benchmark.py compare perf-results/baseline.json perf-results/candidate.json
+```
+
+Useful short smoke run while developing the harness:
+
+```bash
+uv run python tools/perf_benchmark.py run --suite quick --label smoke --warmup 1 --measure 3 --repeat 1
+```
+
+Default macOS runtime settings are `-C -l 5140 -m 999 -w 1 -r lo0` for
+rtp2httpd and `--continuous --multicast-if-addr 127.0.0.1` for replay.
+
+### Benchmark Suites
+
+- `quick`: `same_8_40m`, 8 clients on one multicast address, 5x replay speed,
+  10s warmup, 30s measurement, 3 repeats.
+- `full`: `same_1_40m`, `same_8_40m`, `same_16_40m`, `unique_8_40m`, and
+  `single_400m`, each with 10s warmup, 60s measurement, 5 repeats.
+
+Results are marked noisy when repeat CPU averages have a coefficient of
+variation above 5%. A CPU improvement is considered effective when the average
+CPU drop is at least 3% relative and 0.5 percentage points absolute.
 
 ### Memory Measurement
 

--- a/tools/main.py
+++ b/tools/main.py
@@ -69,6 +69,8 @@ def parse_args() -> argparse.Namespace:
 Examples:
   %(prog)s fixtures/fec_sample.pcapng
   %(prog)s fixtures/fec_sample.pcapng -i eth0
+  %(prog)s fixtures/fec_sample.pcapng --target 239.81.0.1 --multicast-if-addr 127.0.0.1
+  %(prog)s fixtures/fec_sample.pcapng --target-base 239.81.0 --target-count 8
   %(prog)s fixtures/fec_sample.pcapng -v
   %(prog)s fixtures/fec_sample.pcapng --speed 2.0           # 2x speed
   %(prog)s fixtures/fec_sample.pcapng --speed 10 --continuous  # Stress test
@@ -80,6 +82,29 @@ Examples:
         "-i",
         "--interface",
         help="Network interface for multicast (e.g., eth0)",
+    )
+    parser.add_argument(
+        "--multicast-if-addr",
+        help="IPv4 address to use for IP_MULTICAST_IF (e.g., 127.0.0.1 on macOS lo0)",
+    )
+    parser.add_argument(
+        "--target",
+        action="append",
+        default=[],
+        metavar="ADDR",
+        help="Explicit multicast target address. Can be specified multiple times.",
+    )
+    parser.add_argument(
+        "--target-base",
+        metavar="A.B.C",
+        help="Generate explicit targets from a /24 prefix, starting at .1 (e.g., 239.81.0)",
+    )
+    parser.add_argument(
+        "--target-count",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Number of targets to generate with --target-base",
     )
     parser.add_argument(
         "-v",
@@ -264,6 +289,7 @@ def get_interface_ip(interface: str) -> str:
 
 def create_multicast_socket(
     interface: str | None = None,
+    interface_addr: str | None = None,
     ttl: int = 1,
 ) -> socket.socket:
     """Create UDP socket configured for multicast sending."""
@@ -271,7 +297,12 @@ def create_multicast_socket(
     sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
     sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 1)
 
-    if interface:
+    if interface_addr:
+        try:
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(interface_addr))
+        except OSError as e:
+            raise OSError(f"Failed to use multicast interface address {interface_addr}: {e}") from e
+    elif interface:
         try:
             ip_addr = get_interface_ip(interface)
             sock.setsockopt(
@@ -367,6 +398,7 @@ def replay_loop(
     sock: socket.socket,
     group_events: dict[str, Event] | None = None,
     igmp_monitor: IGMPMonitor | None = None,
+    explicit_targets: set[str] | None = None,
     loss_rate: float = 0.0,
     reorder_rate: float = 0.0,
     speed: float = 1.0,
@@ -410,7 +442,16 @@ def replay_loop(
     # Get unique ports from pcap
     pcap_ports = set(p.dst_port for p in packets)
 
-    if igmp_monitor and igmp_monitor.subnets:
+    if explicit_targets:
+        print(
+            f"Using explicit replay target(s): {', '.join(sorted(explicit_targets))}",
+            flush=True,
+        )
+        print(
+            f"Will replay using ports: {', '.join(str(p) for p in sorted(pcap_ports))}",
+            flush=True,
+        )
+    elif igmp_monitor and igmp_monitor.subnets:
         print(
             f"Waiting for IGMP Join on subnets: {', '.join(igmp_monitor.subnets)}",
             flush=True,
@@ -458,6 +499,8 @@ def replay_loop(
     # Timing is essential for controlled replay at specific speeds
 
     def get_target_addresses() -> set[str]:
+        if explicit_targets:
+            return explicit_targets
         if igmp_monitor and igmp_monitor.subnets:
             return igmp_monitor.get_active_groups()
         return {addr for addr, event in group_events.items() if event.is_set()}
@@ -718,6 +761,46 @@ def replay_loop(
         )
 
 
+def _validate_ipv4(addr: str) -> str:
+    try:
+        socket.inet_aton(addr)
+    except OSError as e:
+        raise ValueError(f"Invalid IPv4 address: {addr}") from e
+    if addr.count(".") != 3:
+        raise ValueError(f"Invalid IPv4 address: {addr}")
+    return addr
+
+
+def build_explicit_targets(args: argparse.Namespace) -> set[str]:
+    """Build explicit target addresses from --target and --target-base."""
+    targets = set(_validate_ipv4(addr) for addr in args.target)
+
+    if args.target_count < 0:
+        raise ValueError("--target-count must be >= 0")
+
+    if args.target_base:
+        if args.target_count <= 0:
+            raise ValueError("--target-count must be > 0 when --target-base is set")
+        parts = args.target_base.split(".")
+        if len(parts) != 3:
+            raise ValueError("--target-base must use A.B.C format, e.g. 239.81.0")
+        try:
+            octets = [int(part) for part in parts]
+        except ValueError as e:
+            raise ValueError("--target-base contains a non-numeric octet") from e
+        if any(octet < 0 or octet > 255 for octet in octets):
+            raise ValueError("--target-base octets must be in 0..255")
+        if args.target_count > 254:
+            raise ValueError("--target-count must be <= 254")
+        prefix = ".".join(str(octet) for octet in octets)
+        for host in range(1, args.target_count + 1):
+            targets.add(f"{prefix}.{host}")
+    elif args.target_count > 0:
+        raise ValueError("--target-count requires --target-base")
+
+    return targets
+
+
 def main() -> int:
     """Main entry point."""
     args = parse_args()
@@ -738,6 +821,19 @@ def main() -> int:
         print("Error: --speed must be greater than 0", file=sys.stderr)
         return 1
 
+    if args.multicast_if_addr:
+        try:
+            _validate_ipv4(args.multicast_if_addr)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+    try:
+        explicit_targets = build_explicit_targets(args)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
     try:
         packets = load_packets(args.pcapng_file)
     except Exception as e:
@@ -748,24 +844,30 @@ def main() -> int:
         print("Error: No UDP packets found in file", file=sys.stderr)
         return 1
 
-    # Calculate subnets to monitor based on destination addresses in pcap
-    # Each unique destination IP gets its corresponding /24 subnet monitored
-    pcap_addrs = set(p.dst_addr for p in packets)
-    subnets = sorted(set(get_subnet_for_ip(addr) for addr in pcap_addrs))
+    igmp_monitor = None
+    if explicit_targets:
+        print("Explicit target mode enabled; IGMP monitoring is disabled", flush=True)
+    else:
+        # Calculate subnets to monitor based on destination addresses in pcap
+        # Each unique destination IP gets its corresponding /24 subnet monitored
+        pcap_addrs = set(p.dst_addr for p in packets)
+        subnets = sorted(set(get_subnet_for_ip(addr) for addr in pcap_addrs))
 
-    print(
-        f"Monitoring IGMP for subnets (based on pcap): {', '.join(subnets)}",
-        flush=True,
-    )
+        print(
+            f"Monitoring IGMP for subnets (based on pcap): {', '.join(subnets)}",
+            flush=True,
+        )
 
-    # Start IGMP monitor in subnet mode
-    igmp_monitor = IGMPMonitor(subnets=subnets)
-    igmp_monitor.start()
+        # Start IGMP monitor in subnet mode
+        igmp_monitor = IGMPMonitor(subnets=subnets)
+        igmp_monitor.start()
 
     try:
-        sock = create_multicast_socket(args.interface)
+        sock = create_multicast_socket(args.interface, args.multicast_if_addr)
     except OSError as e:
         print(f"Error creating socket: {e}", file=sys.stderr)
+        if igmp_monitor:
+            igmp_monitor.stop()
         return 1
 
     try:
@@ -773,6 +875,7 @@ def main() -> int:
             packets,
             sock,
             igmp_monitor=igmp_monitor,
+            explicit_targets=explicit_targets,
             loss_rate=args.loss,
             reorder_rate=args.reorder,
             speed=args.speed,
@@ -780,7 +883,8 @@ def main() -> int:
             verbose=args.verbose,
         )
     finally:
-        igmp_monitor.stop()
+        if igmp_monitor:
+            igmp_monitor.stop()
         sock.close()
 
     return 0

--- a/tools/perf_benchmark.py
+++ b/tools/perf_benchmark.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""
+macOS-first performance benchmark for rtp2httpd.
+
+The tool runs a fixed multicast replay workload, starts rtp2httpd, streams data
+through curl clients, samples the rtp2httpd process tree CPU usage, and writes a
+JSON result suitable for before/after comparisons.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import platform
+import socket
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+MULTICAST_BASE = "239.81.0"
+MULTICAST_PORT = 4056
+DEFAULT_PORT = 5140
+CPU_NOISY_CV_THRESHOLD = 5.0
+EFFECTIVE_CPU_RELATIVE_DROP = 3.0
+EFFECTIVE_CPU_ABSOLUTE_DROP = 0.5
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    clients: int
+    same_address: bool
+    speed: float
+    warmup: int
+    measure: int
+    repeat: int
+
+
+@dataclass
+class ProcessSample:
+    elapsed: float
+    cpu_percent: float
+    rss_mb: float
+    pids: list[int]
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = max(0, min(len(ordered) - 1, math.ceil((pct / 100.0) * len(ordered)) - 1))
+    return ordered[idx]
+
+
+def summarize(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {"avg": 0.0, "median": 0.0, "p95": 0.0, "max": 0.0}
+    return {
+        "avg": statistics.fmean(values),
+        "median": statistics.median(values),
+        "p95": percentile(values, 95.0),
+        "max": max(values),
+    }
+
+
+def coefficient_of_variation(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = statistics.fmean(values)
+    if mean == 0:
+        return 0.0
+    return statistics.stdev(values) / mean * 100.0
+
+
+def project_root() -> Path:
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "CMakeLists.txt").exists() and (current / "src" / "rtp2httpd.c").exists():
+            return current
+        current = current.parent
+    return Path(__file__).resolve().parent.parent
+
+
+def run_text(cmd: list[str], cwd: Path) -> str:
+    try:
+        proc = subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, timeout=10)
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def git_info(root: Path) -> dict[str, Any]:
+    status = run_text(["git", "status", "--porcelain"], root)
+    return {
+        "commit": run_text(["git", "rev-parse", "HEAD"], root),
+        "branch": run_text(["git", "branch", "--show-current"], root),
+        "dirty": bool(status),
+    }
+
+
+def environment_info() -> dict[str, Any]:
+    return {
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "python": platform.python_version(),
+        "cpu_count": os.cpu_count(),
+    }
+
+
+class ProcessSampler:
+    backend_name = "unknown"
+
+    def sample(self, root_pid: int, elapsed: float) -> ProcessSample:
+        raise NotImplementedError
+
+
+class PsProcessSampler(ProcessSampler):
+    """Sample aggregate CPU/RSS for a root process and its descendants."""
+
+    backend_name = "ps-process-tree"
+
+    def _process_table(self) -> dict[int, dict[str, Any]]:
+        proc = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,pcpu=,rss=,comm="],
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip() or "ps failed")
+
+        table: dict[int, dict[str, Any]] = {}
+        for line in proc.stdout.splitlines():
+            parts = line.split(None, 4)
+            if len(parts) < 4:
+                continue
+            try:
+                pid = int(parts[0])
+                ppid = int(parts[1])
+                cpu = float(parts[2])
+                rss_kb = int(parts[3])
+            except ValueError:
+                continue
+            table[pid] = {
+                "ppid": ppid,
+                "cpu": cpu,
+                "rss_kb": rss_kb,
+                "comm": parts[4] if len(parts) >= 5 else "",
+            }
+        return table
+
+    def descendants(self, root_pid: int, table: dict[int, dict[str, Any]]) -> list[int]:
+        children: dict[int, list[int]] = {}
+        for pid, row in table.items():
+            children.setdefault(row["ppid"], []).append(pid)
+
+        result: list[int] = []
+        stack = [root_pid]
+        seen: set[int] = set()
+        while stack:
+            pid = stack.pop()
+            if pid in seen:
+                continue
+            seen.add(pid)
+            if pid in table:
+                result.append(pid)
+            stack.extend(children.get(pid, []))
+        return sorted(result)
+
+    def sample(self, root_pid: int, elapsed: float) -> ProcessSample:
+        table = self._process_table()
+        pids = self.descendants(root_pid, table)
+        cpu = sum(float(table[pid]["cpu"]) for pid in pids)
+        rss_kb = sum(int(table[pid]["rss_kb"]) for pid in pids)
+        return ProcessSample(elapsed=elapsed, cpu_percent=cpu, rss_mb=rss_kb / 1024.0, pids=pids)
+
+
+class MacOSProcessSampler(PsProcessSampler):
+    backend_name = "macos-ps-process-tree"
+
+
+class LinuxProcessSampler(PsProcessSampler):
+    """Placeholder backend keeping the same contract until /proc sampling lands."""
+
+    backend_name = "linux-ps-placeholder"
+
+
+def create_process_sampler() -> ProcessSampler:
+    if sys.platform == "darwin":
+        return MacOSProcessSampler()
+    if sys.platform.startswith("linux"):
+        return LinuxProcessSampler()
+    return PsProcessSampler()
+
+
+def scenario_targets(scenario: Scenario) -> list[str]:
+    count = 1 if scenario.same_address else scenario.clients
+    return [f"{MULTICAST_BASE}.{idx}" for idx in range(1, count + 1)]
+
+
+def client_url(port: int, scenario: Scenario, client_index: int) -> str:
+    host = 1 if scenario.same_address else client_index + 1
+    return f"http://127.0.0.1:{port}/rtp/{MULTICAST_BASE}.{host}:{MULTICAST_PORT}"
+
+
+def wait_for_port(port: int, timeout: float = 6.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+def terminate_process(proc: subprocess.Popen[Any], timeout: float = 3.0) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=timeout)
+
+
+def scenario_suites() -> dict[str, list[Scenario]]:
+    return {
+        "quick": [
+            Scenario("same_8_40m", clients=8, same_address=True, speed=5.0, warmup=10, measure=30, repeat=3),
+        ],
+        "full": [
+            Scenario("same_1_40m", clients=1, same_address=True, speed=5.0, warmup=10, measure=60, repeat=5),
+            Scenario("same_8_40m", clients=8, same_address=True, speed=5.0, warmup=10, measure=60, repeat=5),
+            Scenario("same_16_40m", clients=16, same_address=True, speed=5.0, warmup=10, measure=60, repeat=5),
+            Scenario("unique_8_40m", clients=8, same_address=False, speed=5.0, warmup=10, measure=60, repeat=5),
+            Scenario("single_400m", clients=1, same_address=True, speed=50.0, warmup=10, measure=60, repeat=5),
+        ],
+    }
+
+
+def apply_overrides(scenario: Scenario, args: argparse.Namespace) -> Scenario:
+    return Scenario(
+        name=scenario.name,
+        clients=scenario.clients,
+        same_address=scenario.same_address,
+        speed=scenario.speed,
+        warmup=args.warmup if args.warmup is not None else scenario.warmup,
+        measure=args.measure if args.measure is not None else scenario.measure,
+        repeat=args.repeat if args.repeat is not None else scenario.repeat,
+    )
+
+
+def run_repeat(
+    root: Path,
+    scenario: Scenario,
+    repeat_index: int,
+    args: argparse.Namespace,
+    sampler: ProcessSampler,
+) -> dict[str, Any]:
+    tools_dir = root / "tools"
+    pcapng = tools_dir / "fixtures" / "fec_sample.pcapng"
+    binary_arg = Path(args.binary)
+    binary = binary_arg if binary_arg.is_absolute() else (root / binary_arg)
+    binary = binary.resolve()
+    total_seconds = scenario.warmup + scenario.measure
+    targets = scenario_targets(scenario)
+    stdout_target = None if args.verbose else subprocess.DEVNULL
+    stderr_target = None if args.verbose else subprocess.DEVNULL
+
+    replay_cmd = [
+        sys.executable,
+        str(tools_dir / "main.py"),
+        str(pcapng),
+        "--continuous",
+        "--speed",
+        str(scenario.speed),
+        "--multicast-if-addr",
+        args.multicast_if_addr,
+    ]
+    for target in targets:
+        replay_cmd.extend(["--target", target])
+
+    server_cmd = [
+        str(binary),
+        "-C",
+        "-l",
+        str(args.port),
+        "-m",
+        "999",
+        "-w",
+        str(args.workers),
+        "-r",
+        args.multicast_ifname,
+    ]
+
+    replay_proc: subprocess.Popen[Any] | None = None
+    server_proc: subprocess.Popen[Any] | None = None
+    curl_procs: list[subprocess.Popen[Any]] = []
+    samples: list[ProcessSample] = []
+    client_bytes: list[int] = []
+    error = ""
+    valid = False
+
+    try:
+        replay_proc = subprocess.Popen(replay_cmd, cwd=tools_dir, stdout=stdout_target, stderr=stderr_target)
+        time.sleep(0.5)
+
+        server_proc = subprocess.Popen(server_cmd, cwd=root, stdout=stdout_target, stderr=stderr_target)
+        if not wait_for_port(args.port):
+            if server_proc.poll() is not None:
+                error = f"rtp2httpd exited before accepting connections (code={server_proc.returncode})"
+            else:
+                error = f"rtp2httpd did not listen on 127.0.0.1:{args.port}"
+            raise RuntimeError(error)
+
+        urls = [client_url(args.port, scenario, i) for i in range(scenario.clients)]
+        for url in urls:
+            curl_cmd = [
+                "curl",
+                "-sS",
+                "--no-buffer",
+                "--max-time",
+                str(total_seconds),
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{size_download}",
+                url,
+            ]
+            curl_procs.append(
+                subprocess.Popen(curl_cmd, stdout=subprocess.PIPE, stderr=stderr_target, text=True)
+            )
+
+        start = time.monotonic()
+        measure_start = start + scenario.warmup
+        deadline = start + total_seconds
+        next_sample = measure_start
+
+        while time.monotonic() < deadline:
+            now = time.monotonic()
+            if replay_proc.poll() is not None:
+                error = f"replay exited during benchmark (code={replay_proc.returncode})"
+                raise RuntimeError(error)
+            if server_proc.poll() is not None:
+                error = f"rtp2httpd exited during benchmark (code={server_proc.returncode})"
+                raise RuntimeError(error)
+            for idx, proc in enumerate(curl_procs):
+                if proc.poll() is not None and now < deadline - 0.5:
+                    error = f"curl client {idx + 1} exited before measurement ended"
+                    raise RuntimeError(error)
+
+            if now >= next_sample:
+                samples.append(sampler.sample(server_proc.pid, now - measure_start))
+                next_sample += 1.0
+            else:
+                time.sleep(min(0.2, next_sample - now))
+
+        for proc in curl_procs:
+            try:
+                out, _ = proc.communicate(timeout=3)
+            except subprocess.TimeoutExpired:
+                terminate_process(proc)
+                out = ""
+            try:
+                client_bytes.append(int((out or "0").strip() or "0"))
+            except ValueError:
+                client_bytes.append(0)
+
+        if len(client_bytes) != scenario.clients:
+            error = f"expected {scenario.clients} client byte counts, got {len(client_bytes)}"
+        elif any(value <= 0 for value in client_bytes):
+            error = "one or more clients received zero bytes"
+        elif not samples:
+            error = "no CPU samples collected"
+        else:
+            valid = True
+    except Exception as exc:
+        if not error:
+            error = str(exc)
+    finally:
+        for proc in curl_procs:
+            terminate_process(proc)
+        if server_proc:
+            terminate_process(server_proc)
+        if replay_proc:
+            terminate_process(replay_proc)
+
+    cpu_values = [sample.cpu_percent for sample in samples]
+    rss_values = [sample.rss_mb for sample in samples]
+    return {
+        "repeat": repeat_index,
+        "valid": valid,
+        "error": error,
+        "scenario": asdict(scenario),
+        "commands": {
+            "replay": replay_cmd,
+            "server": server_cmd,
+            "clients": [client_url(args.port, scenario, i) for i in range(scenario.clients)],
+        },
+        "samples": [asdict(sample) for sample in samples],
+        "cpu": summarize(cpu_values),
+        "rss_mb": summarize(rss_values),
+        "client_bytes": client_bytes,
+    }
+
+
+def summarize_scenario(repeats: list[dict[str, Any]]) -> dict[str, Any]:
+    valid_repeats = [repeat for repeat in repeats if repeat["valid"]]
+    cpu_avgs = [float(repeat["cpu"]["avg"]) for repeat in valid_repeats]
+    cv = coefficient_of_variation(cpu_avgs)
+    return {
+        "valid_repeats": len(valid_repeats),
+        "total_repeats": len(repeats),
+        "cpu_avg_mean": statistics.fmean(cpu_avgs) if cpu_avgs else 0.0,
+        "cpu_avg_median": statistics.median(cpu_avgs) if cpu_avgs else 0.0,
+        "cpu_avg_cv_percent": cv,
+        "noisy": cv > CPU_NOISY_CV_THRESHOLD,
+        "valid": len(valid_repeats) == len(repeats) and bool(valid_repeats),
+    }
+
+
+def run_suite(args: argparse.Namespace) -> int:
+    root = project_root()
+    binary_arg = Path(args.binary)
+    binary = binary_arg if binary_arg.is_absolute() else (root / binary_arg)
+    binary = binary.resolve()
+    if not binary.exists():
+        print(f"Error: rtp2httpd binary not found: {binary}", file=sys.stderr)
+        return 1
+
+    suites = scenario_suites()
+    scenarios = [apply_overrides(s, args) for s in suites[args.suite]]
+    if args.scenario:
+        selected = set(args.scenario)
+        scenarios = [s for s in scenarios if s.name in selected]
+        missing = selected - {s.name for s in scenarios}
+        if missing:
+            print(f"Error: unknown scenario(s): {', '.join(sorted(missing))}", file=sys.stderr)
+            return 1
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{args.label}.json"
+    sampler = create_process_sampler()
+
+    result: dict[str, Any] = {
+        "label": args.label,
+        "created_at": datetime.now(UTC).isoformat(),
+        "command": [sys.executable, *sys.argv],
+        "git": git_info(root),
+        "environment": environment_info(),
+        "build": {
+            "binary": str(binary),
+            "type": "Release",
+            "aggressive_opt": True,
+            "recommended_command": "cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AGGRESSIVE_OPT=ON && cmake --build build -j$(sysctl -n hw.ncpu)",
+        },
+        "sampler": {
+            "backend": sampler.backend_name,
+        },
+        "defaults": {
+            "port": args.port,
+            "workers": args.workers,
+            "multicast_ifname": args.multicast_ifname,
+            "multicast_if_addr": args.multicast_if_addr,
+        },
+        "rules": {
+            "noisy_cv_percent": CPU_NOISY_CV_THRESHOLD,
+            "effective_cpu_relative_drop_percent": EFFECTIVE_CPU_RELATIVE_DROP,
+            "effective_cpu_absolute_drop_points": EFFECTIVE_CPU_ABSOLUTE_DROP,
+        },
+        "scenarios": [],
+    }
+
+    had_failure = False
+    for scenario in scenarios:
+        print(
+            f"Running {scenario.name}: clients={scenario.clients} same_address={scenario.same_address} "
+            f"speed={scenario.speed} warmup={scenario.warmup}s measure={scenario.measure}s repeat={scenario.repeat}"
+        )
+        repeats = []
+        for idx in range(1, scenario.repeat + 1):
+            print(f"  repeat {idx}/{scenario.repeat}")
+            repeat = run_repeat(root, scenario, idx, args, sampler)
+            if not repeat["valid"]:
+                had_failure = True
+                print(f"    invalid: {repeat['error']}")
+            else:
+                print(f"    cpu avg={repeat['cpu']['avg']:.2f}% max={repeat['cpu']['max']:.2f}%")
+            repeats.append(repeat)
+            time.sleep(args.cooldown)
+
+        summary = summarize_scenario(repeats)
+        if summary["noisy"]:
+            print(
+                f"  noisy: repeat CPU avg CV={summary['cpu_avg_cv_percent']:.2f}% "
+                f"(threshold {CPU_NOISY_CV_THRESHOLD:.2f}%)"
+            )
+        result["scenarios"].append(
+            {
+                "name": scenario.name,
+                "config": asdict(scenario),
+                "summary": summary,
+                "repeats": repeats,
+            }
+        )
+
+    output_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"Wrote {output_path}")
+    return 1 if had_failure else 0
+
+
+def load_result(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def scenario_map(result: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {scenario["name"]: scenario for scenario in result.get("scenarios", [])}
+
+
+def compare_results(args: argparse.Namespace) -> int:
+    baseline = load_result(Path(args.baseline))
+    candidate = load_result(Path(args.candidate))
+    base_map = scenario_map(baseline)
+    cand_map = scenario_map(candidate)
+    names = sorted(set(base_map) & set(cand_map))
+    if not names:
+        print("No overlapping scenarios", file=sys.stderr)
+        return 1
+
+    print(f"Baseline:  {baseline.get('label', args.baseline)}")
+    print(f"Candidate: {candidate.get('label', args.candidate)}")
+    print("")
+    print("| Scenario | Baseline CPU avg | Candidate CPU avg | Delta | Result |")
+    print("| --- | ---: | ---: | ---: | --- |")
+    for name in names:
+        base_cpu = float(base_map[name]["summary"].get("cpu_avg_mean", 0.0))
+        cand_cpu = float(cand_map[name]["summary"].get("cpu_avg_mean", 0.0))
+        delta = base_cpu - cand_cpu
+        pct = (delta / base_cpu * 100.0) if base_cpu > 0 else 0.0
+        effective = delta >= EFFECTIVE_CPU_ABSOLUTE_DROP and pct >= EFFECTIVE_CPU_RELATIVE_DROP
+        result = "effective" if effective else "not significant"
+        if cand_map[name]["summary"].get("noisy") or base_map[name]["summary"].get("noisy"):
+            result = f"{result}, noisy"
+        print(f"| {name} | {base_cpu:.2f}% | {cand_cpu:.2f}% | {delta:+.2f}% ({pct:+.2f}%) | {result} |")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run and compare rtp2httpd performance benchmarks")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Run benchmark suite")
+    run_parser.add_argument("--suite", choices=sorted(scenario_suites()), default="quick")
+    run_parser.add_argument("--label", required=True)
+    run_parser.add_argument("--output-dir", default="perf-results")
+    run_parser.add_argument("--binary", default="build/rtp2httpd")
+    run_parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    run_parser.add_argument("--workers", type=int, default=1)
+    run_parser.add_argument("--multicast-ifname", default="lo0" if sys.platform == "darwin" else "lo")
+    run_parser.add_argument("--multicast-if-addr", default="127.0.0.1")
+    run_parser.add_argument("--scenario", action="append", help="Run only this scenario name")
+    run_parser.add_argument("--warmup", type=int, help="Override scenario warmup seconds")
+    run_parser.add_argument("--measure", type=int, help="Override scenario measurement seconds")
+    run_parser.add_argument("--repeat", type=int, help="Override scenario repeat count")
+    run_parser.add_argument("--cooldown", type=float, default=2.0, help="Seconds to wait between repeats")
+    run_parser.add_argument("-v", "--verbose", action="store_true", help="Show subprocess output")
+
+    compare_parser = subparsers.add_parser("compare", help="Compare two JSON benchmark results")
+    compare_parser.add_argument("baseline")
+    compare_parser.add_argument("candidate")
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "run":
+        return run_suite(args)
+    if args.command == "compare":
+        return compare_results(args)
+    raise AssertionError(f"unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This adds repo-local performance tooling for rtp2httpd before/after comparisons and keeps the benchmark result output out of git. The replay tool can now send to explicit multicast targets, which makes the core multicast RTP-to-HTTP path reproducible on macOS and Linux without relying on `/proc/net/igmp`.

The PR also keeps the forwarding-path optimizations from the local plan: throttled queue and buffer-pool status reporting, the sequential RTP reorder fast path, cached queue-limit refresh during enqueue, and a bounded batching age threshold.

## Validation

Built with Release + `ENABLE_AGGRESSIVE_OPT=ON` on macOS. Ran Python compile/lint checks for the tools, multicast/FCC/flow-control e2e tests, macOS zerocopy e2e skip check, and benchmark smoke runs. Perf result JSON is intentionally not included; `perf-results/` is ignored so the same tooling can be rerun on another machine.
