### PR TITLE
fix(rtsp): bound interleaved frame copies

### DIFF
--- a/src/rtsp.c
+++ b/src/rtsp.c
@@ -1,4 +1,5 @@
 #include "rtsp.h"
+#include "buffer_pool.h"
 #include "configuration.h"
 #include "connection.h"
 #include "http.h"
@@ -1796,12 +1797,12 @@ static int rtsp_process_interleaved_buffer(rtsp_session_t *session, connection_t
       break; /* Wait for more data */
     }
 
-    /* Sanity check: prevent processing packets that are too large */
-    if (packet_length > RTSP_RESPONSE_BUFFER_SIZE - 4) {
+    /* Sanity check: bound against the zero-copy destination buffer. */
+    if (packet_length > BUFFER_POOL_BUFFER_SIZE) {
       logger(LOG_ERROR,
              "RTSP: Received packet too large (%d bytes, max %d), attempting "
              "resync",
-             packet_length, RTSP_RESPONSE_BUFFER_SIZE - 4);
+             packet_length, BUFFER_POOL_BUFFER_SIZE);
       uint8_t *next_marker = memchr(session->response_buffer + 1, '$', session->response_buffer_pos - 1);
       if (next_marker) {
         size_t skip = next_marker - session->response_buffer;


### PR DESCRIPTION
## Summary

This fixes an RTSP TCP interleaved path overflow where the incoming frame length was checked against the 4096-byte RTSP response buffer instead of the 1536-byte zero-copy destination buffer used for RTP forwarding.

## Fix

Oversized interleaved frames are now bounded by `BUFFER_POOL_BUFFER_SIZE` before copying into a pooled packet buffer. Frames above that limit continue through the existing reject/resync path instead of reaching `memcpy`.

## Validation

Built the daemon successfully, ran the RTSP transport e2e coverage, checked e2e collection, and verified the advisory-sized oversized frame with a temporary ASan PoC. The temporary regression check is intentionally not committed.