### PR TITLE
fix(player): improve static catchup segment continuity

### DIFF
--- a/web-ui/src/lib/m3u-parser.ts
+++ b/web-ui/src/lib/m3u-parser.ts
@@ -179,6 +179,7 @@ function mergeChannelSources(channels: Channel[]): Channel[] {
 
 /** Minimum catchup window (ms). Shorter playseek ranges can fail on some servers. */
 export const CATCHUP_MIN_DURATION_MS = 30_000;
+const CATCHUP_SEGMENT_OVERLAP_MS = 1_000;
 
 /** Clamp catchup start so the window back to `now` is at least {@link CATCHUP_MIN_DURATION_MS}. */
 export function clampCatchupStartTime(seekTime: Date, now = new Date()): Date {
@@ -487,6 +488,13 @@ export function buildCatchupSegments(source: Source, startTimeArg: Date): Player
     5 * 60 * 60 * 1000, // max 5 hours
   );
   const segmentDurationSec = segmentDurationMs / 1000;
+  const buildOverlappedSegmentUrl = (segmentStartTime: Date, segmentEndTime: Date): string => {
+    const requestStartTime =
+      segments.length === 0
+        ? segmentStartTime
+        : new Date(Math.max(startTime.getTime(), segmentStartTime.getTime() - CATCHUP_SEGMENT_OVERLAP_MS));
+    return buildCatchupUrl(requestStartTime, segmentEndTime);
+  };
 
   // Build segments from startTime to now (catchup/replay segments)
   let currentTime = new Date(startTime.getTime());
@@ -499,7 +507,7 @@ export function buildCatchupSegments(source: Source, startTimeArg: Date): Player
 
     segments.push({
       duration: segmentDurationSec,
-      url: buildCatchupUrl(currentTime, segmentEndTime),
+      url: buildOverlappedSegmentUrl(currentTime, segmentEndTime),
     });
 
     currentTime = segmentEndTime;
@@ -511,7 +519,7 @@ export function buildCatchupSegments(source: Source, startTimeArg: Date): Player
 
     segments.push({
       duration: segmentDurationSec / 2,
-      url: buildCatchupUrl(currentTime, segmentEndTime),
+      url: buildOverlappedSegmentUrl(currentTime, segmentEndTime),
     });
 
     currentTime = segmentEndTime;

--- a/web-ui/src/mpegts/demux/ts-demuxer.ts
+++ b/web-ui/src/mpegts/demux/ts-demuxer.ts
@@ -225,6 +225,15 @@ class TSDemuxer {
   }
 
   public resetSegmentBoundary(probe_data?: TSProbeResult): void {
+    const pesQueuePids = Object.keys(this.pes_slice_queues_);
+    if (pesQueuePids.length > 0 || this.video_track_.samples.length > 0 || this.audio_track_.samples.length > 0) {
+      Log.v(
+        this.TAG,
+        `[segment-debug] reset TS boundary: pesQueues=${pesQueuePids.join(",") || "none"}, ` +
+          `videoSamples=${this.video_track_.samples.length}, audioSamples=${this.audio_track_.samples.length}, ` +
+          `videoStarted=${this.video_output_started_}`,
+      );
+    }
     if (probe_data) {
       this.ts_packet_size_ = probe_data.ts_packet_size as number;
       this.sync_offset_ = probe_data.sync_offset as number;

--- a/web-ui/src/mpegts/demux/ts-demuxer.ts
+++ b/web-ui/src/mpegts/demux/ts-demuxer.ts
@@ -244,6 +244,20 @@ class TSDemuxer {
     this.continuity_counters_ = {};
   }
 
+  public flushSegmentBoundary(): void {
+    if (this.shouldWaitForVideoKeyframe() || !this.isInitSegmentDispatched()) {
+      return;
+    }
+    if (this.audio_track_.length || this.video_track_.length) {
+      Log.v(
+        this.TAG,
+        `[segment-debug] flush TS segment boundary: videoSamples=${this.video_track_.samples.length}, ` +
+          `audioSamples=${this.audio_track_.samples.length}`,
+      );
+      this.onDataAvailable?.(this.audio_track_, this.video_track_, true);
+    }
+  }
+
   public static probe(data: Uint8Array): TSProbeResult {
     let sync_offset = -1;
     let ts_packet_size = 188;

--- a/web-ui/src/mpegts/demux/ts-demuxer.ts
+++ b/web-ui/src/mpegts/demux/ts-demuxer.ts
@@ -225,15 +225,6 @@ class TSDemuxer {
   }
 
   public resetSegmentBoundary(probe_data?: TSProbeResult): void {
-    const pesQueuePids = Object.keys(this.pes_slice_queues_);
-    if (pesQueuePids.length > 0 || this.video_track_.samples.length > 0 || this.audio_track_.samples.length > 0) {
-      Log.v(
-        this.TAG,
-        `[segment-debug] reset TS boundary: pesQueues=${pesQueuePids.join(",") || "none"}, ` +
-          `videoSamples=${this.video_track_.samples.length}, audioSamples=${this.audio_track_.samples.length}, ` +
-          `videoStarted=${this.video_output_started_}`,
-      );
-    }
     if (probe_data) {
       this.ts_packet_size_ = probe_data.ts_packet_size as number;
       this.sync_offset_ = probe_data.sync_offset as number;
@@ -249,11 +240,6 @@ class TSDemuxer {
       return;
     }
     if (this.audio_track_.length || this.video_track_.length) {
-      Log.v(
-        this.TAG,
-        `[segment-debug] flush TS segment boundary: videoSamples=${this.video_track_.samples.length}, ` +
-          `audioSamples=${this.audio_track_.samples.length}`,
-      );
       this.onDataAvailable?.(this.audio_track_, this.video_track_, true);
     }
   }

--- a/web-ui/src/mpegts/demux/ts-demuxer.ts
+++ b/web-ui/src/mpegts/demux/ts-demuxer.ts
@@ -57,6 +57,9 @@ type CommonPidKey = keyof PMT["common_pids"];
 type TSDemuxerOptions = {
   waitForInitialVideoKeyframe?: boolean;
 };
+type TSSegmentBoundaryOptions = {
+  resetAudioParserState?: boolean;
+};
 type AACAudioMetadata = {
   codec: "aac";
   audio_object_type: MPEG4AudioObjectTypes;
@@ -224,7 +227,7 @@ class TSDemuxer {
     this.soft_decode_audio_codec_ = null;
   }
 
-  public resetSegmentBoundary(probe_data?: TSProbeResult): void {
+  public resetSegmentBoundary(probe_data?: TSProbeResult, options: TSSegmentBoundaryOptions = {}): void {
     if (probe_data) {
       this.ts_packet_size_ = probe_data.ts_packet_size as number;
       this.sync_offset_ = probe_data.sync_offset as number;
@@ -233,6 +236,9 @@ class TSDemuxer {
     this.pes_slice_queues_ = {};
     this.section_slice_queues_ = {};
     this.continuity_counters_ = {};
+    if (options.resetAudioParserState === true) {
+      this.resetAudioParserState();
+    }
   }
 
   public flushSegmentBoundary(): void {

--- a/web-ui/src/mpegts/hls/hls-source.ts
+++ b/web-ui/src/mpegts/hls/hls-source.ts
@@ -131,7 +131,6 @@ export class HlsSource implements SegmentSource {
         url: seg.url,
         start: this.timelinePos,
         duration: seg.duration,
-        timestampBase: 0,
         resetRemuxer: seg.discontinuity || skipped,
         initUrl: seg.initUrl,
       });

--- a/web-ui/src/mpegts/remux/mp4-remuxer.ts
+++ b/web-ui/src/mpegts/remux/mp4-remuxer.ts
@@ -84,6 +84,7 @@ interface MP4Sample {
 }
 
 interface TrackTimingState {
+  lastOriginalDts: number | undefined;
   lastOriginalEndDts: number | undefined;
   lastOutputEndDts: number | undefined;
   lastOutputDuration: number | undefined;
@@ -235,6 +236,7 @@ class MP4Remuxer {
 
   private _createTrackTimingState(): TrackTimingState {
     return {
+      lastOriginalDts: undefined,
       lastOriginalEndDts: undefined,
       lastOutputEndDts: undefined,
       lastOutputDuration: undefined,
@@ -258,11 +260,11 @@ class MP4Remuxer {
       return firstSampleOriginalDts - nextDts;
     }
 
-    if (timing.lastOriginalEndDts === undefined || timing.lastOutputEndDts === undefined) {
+    if (timing.lastOriginalDts === undefined || timing.lastOutputEndDts === undefined) {
       return firstSampleOriginalDts - this._dtsBaseOffset;
     }
 
-    const distance = firstSampleOriginalDts - timing.lastOriginalEndDts;
+    const distance = firstSampleOriginalDts - timing.lastOriginalDts;
     const bridgedDistance = distance > 0 ? 0 : distance;
     if (bridgedDistance !== distance) {
       Log.v(this.TAG, `${type}: bridging ${Math.round(distance)}ms timestamp hole after discontinuity`);
@@ -272,6 +274,7 @@ class MP4Remuxer {
   }
 
   private _recordTrackTiming(timing: TrackTimingState, sample: MP4Sample): void {
+    timing.lastOriginalDts = sample.originalDts;
     timing.lastOriginalEndDts = sample.originalDts + sample.duration;
     timing.lastOutputEndDts = sample.dts + sample.duration;
   }
@@ -282,8 +285,8 @@ class MP4Remuxer {
     timing: TrackTimingState,
     mdatBytes: number,
   ): number {
-    const lastOriginalEndDts = timing.lastOriginalEndDts;
-    if (lastOriginalEndDts === undefined) {
+    const lastOriginalDts = timing.lastOriginalDts;
+    if (lastOriginalDts === undefined) {
       return mdatBytes;
     }
 
@@ -292,7 +295,7 @@ class MP4Remuxer {
     let lastDroppedDts = 0;
     while (samples.length > 0) {
       const originalDts = samples[0].dts - this._dtsBase;
-      if (originalDts >= lastOriginalEndDts) {
+      if (originalDts > lastOriginalDts) {
         break;
       }
 
@@ -310,7 +313,7 @@ class MP4Remuxer {
         this.TAG,
         `${type}: dropping ${dropped} overlapping sample(s), ` +
           `rawDts=${Math.round(firstDroppedDts)}-${Math.round(lastDroppedDts)}ms, ` +
-          `lastRawEnd=${Math.round(lastOriginalEndDts)}ms`,
+          `lastRawDts=${Math.round(lastOriginalDts)}ms`,
       );
     }
 
@@ -820,7 +823,7 @@ class MP4Remuxer {
         Log.v(
           this.TAG,
           `[segment-debug] video segment skipped (${this._debugVideoSegmentsReason}): all samples overlap, ` +
-            `lastRawEnd=${this._videoTiming.lastOriginalEndDts?.toFixed(3) ?? "unset"}`,
+            `lastRawDts=${this._videoTiming.lastOriginalDts?.toFixed(3) ?? "unset"}`,
         );
         this._debugVideoSegmentsRemaining--;
       }

--- a/web-ui/src/mpegts/remux/mp4-remuxer.ts
+++ b/web-ui/src/mpegts/remux/mp4-remuxer.ts
@@ -135,6 +135,8 @@ class MP4Remuxer {
 
   private _silentAudioMode: boolean;
   private _silentAudioLastDts: number | undefined;
+  private _debugVideoSegmentsRemaining: number;
+  private _debugVideoSegmentsReason: string;
 
   constructor() {
     this.TAG = "MP4Remuxer";
@@ -166,6 +168,8 @@ class MP4Remuxer {
 
     this._silentAudioMode = false;
     this._silentAudioLastDts = undefined;
+    this._debugVideoSegmentsRemaining = 0;
+    this._debugVideoSegmentsReason = "";
   }
 
   destroy(): void {
@@ -173,6 +177,8 @@ class MP4Remuxer {
     this._dtsBaseInited = false;
     this._silentAudioMode = false;
     this._silentAudioLastDts = undefined;
+    this._debugVideoSegmentsRemaining = 0;
+    this._debugVideoSegmentsReason = "";
     this._audioTiming = this._createTrackTimingState();
     this._videoTiming = this._createTrackTimingState();
     this._pcmTiming = this._createTrackTimingState();
@@ -220,6 +226,11 @@ class MP4Remuxer {
     this._audioNextDts = this._videoNextDts = undefined;
     this._silentAudioLastDts = undefined;
     this._videoPresentationOffset = undefined;
+  }
+
+  debugLogNextVideoSegments(reason: string, count = 3): void {
+    this._debugVideoSegmentsReason = reason;
+    this._debugVideoSegmentsRemaining = Math.max(this._debugVideoSegmentsRemaining, count);
   }
 
   private _createTrackTimingState(): TrackTimingState {
@@ -820,6 +831,15 @@ class MP4Remuxer {
     }
 
     if (mp4Samples.length === 0) {
+      if (this._debugVideoSegmentsRemaining > 0) {
+        Log.v(
+          this.TAG,
+          `[segment-debug] video segment skipped (${this._debugVideoSegmentsReason}): ` +
+            `inputSamples=${samples.length}, presentationFloor=${presentationFloor.toFixed(3)}, ` +
+            `presentationOffset=${this._videoPresentationOffset?.toFixed(3) ?? "unset"}`,
+        );
+        this._debugVideoSegmentsRemaining--;
+      }
       track.samples = [];
       track.length = 0;
       return;
@@ -828,6 +848,22 @@ class MP4Remuxer {
     const latest = mp4Samples[mp4Samples.length - 1];
     this._videoNextDts = latest.dts + latest.duration;
     this._recordTrackTiming(this._videoTiming, latest);
+
+    if (this._debugVideoSegmentsRemaining > 0) {
+      const first = mp4Samples[0];
+      const last = mp4Samples[mp4Samples.length - 1];
+      Log.v(
+        this.TAG,
+        `[segment-debug] video segment (${this._debugVideoSegmentsReason}): ` +
+          `count=${mp4Samples.length}, first={dts=${first.dts.toFixed(3)},pts=${first.pts.toFixed(3)},` +
+          `cts=${first.cts.toFixed(3)},dur=${first.duration},key=${first.isKeyframe === true},` +
+          `orig=${first.originalDts.toFixed(3)}} ` +
+          `last={dts=${last.dts.toFixed(3)},pts=${last.pts.toFixed(3)},cts=${last.cts.toFixed(3)},` +
+          `dur=${last.duration},key=${last.isKeyframe === true},orig=${last.originalDts.toFixed(3)}} ` +
+          `next=${this._videoNextDts.toFixed(3)}, presentationOffset=${this._videoPresentationOffset?.toFixed(3) ?? "unset"}`,
+      );
+      this._debugVideoSegmentsRemaining--;
+    }
 
     track.samples = mp4Samples;
     track.sequenceNumber++;

--- a/web-ui/src/mpegts/remux/mp4-remuxer.ts
+++ b/web-ui/src/mpegts/remux/mp4-remuxer.ts
@@ -4,8 +4,6 @@ import Log from "../utils/logger";
 import AAC from "./aac-silent";
 import MP4 from "./mp4-generator";
 
-const PRESENTATION_REANCHOR_THRESHOLD_MS = 500;
-
 interface AudioSample {
   unit: Uint8Array;
   dts: number;
@@ -126,7 +124,6 @@ class MP4Remuxer {
   private _videoPresentationOffset: number | undefined;
   private _videoInitialPresentationOffset: number | undefined;
   private _videoInitialOutputTime: number | undefined;
-  private _needsVideoPresentationBoundaryCheck: boolean;
 
   private _audioMeta: TrackMetadata | null;
   private _videoMeta: TrackMetadata | null;
@@ -159,7 +156,6 @@ class MP4Remuxer {
     this._videoPresentationOffset = undefined;
     this._videoInitialPresentationOffset = undefined;
     this._videoInitialOutputTime = undefined;
-    this._needsVideoPresentationBoundaryCheck = false;
 
     this._audioMeta = null;
     this._videoMeta = null;
@@ -189,7 +185,6 @@ class MP4Remuxer {
     this._videoPresentationOffset = undefined;
     this._videoInitialPresentationOffset = undefined;
     this._videoInitialOutputTime = undefined;
-    this._needsVideoPresentationBoundaryCheck = false;
     this._audioMeta = null;
     this._videoMeta = null;
     this._onInitSegment = null;
@@ -238,10 +233,6 @@ class MP4Remuxer {
     this._debugVideoSegmentsRemaining = Math.max(this._debugVideoSegmentsRemaining, count);
   }
 
-  markVideoPresentationBoundary(): void {
-    this._needsVideoPresentationBoundaryCheck = true;
-  }
-
   private _createTrackTimingState(): TrackTimingState {
     return {
       lastOriginalEndDts: undefined,
@@ -283,6 +274,47 @@ class MP4Remuxer {
   private _recordTrackTiming(timing: TrackTimingState, sample: MP4Sample): void {
     timing.lastOriginalEndDts = sample.originalDts + sample.duration;
     timing.lastOutputEndDts = sample.dts + sample.duration;
+  }
+
+  private _dropOverlappingTrackSamples<T extends { dts: number; length: number }>(
+    type: "audio" | "video",
+    samples: T[],
+    timing: TrackTimingState,
+    mdatBytes: number,
+  ): number {
+    const lastOriginalEndDts = timing.lastOriginalEndDts;
+    if (lastOriginalEndDts === undefined) {
+      return mdatBytes;
+    }
+
+    let dropped = 0;
+    let firstDroppedDts = 0;
+    let lastDroppedDts = 0;
+    while (samples.length > 0) {
+      const originalDts = samples[0].dts - this._dtsBase;
+      if (originalDts >= lastOriginalEndDts) {
+        break;
+      }
+
+      const sample = samples.shift() as T;
+      mdatBytes -= sample.length;
+      if (dropped === 0) {
+        firstDroppedDts = originalDts;
+      }
+      lastDroppedDts = originalDts;
+      dropped++;
+    }
+
+    if (dropped > 0) {
+      Log.v(
+        this.TAG,
+        `${type}: dropping ${dropped} overlapping sample(s), ` +
+          `rawDts=${Math.round(firstDroppedDts)}-${Math.round(lastDroppedDts)}ms, ` +
+          `lastRawEnd=${Math.round(lastOriginalEndDts)}ms`,
+      );
+    }
+
+    return mdatBytes;
   }
 
   private _nextSampleDuration(timing: TrackTimingState, refSampleDuration: unknown, fallbackDuration: number): number {
@@ -574,7 +606,7 @@ class MP4Remuxer {
     }
 
     const track = audioTrack;
-    const samples = track.samples;
+    const samples = track.samples as AudioSample[];
     let firstDts = -1;
     const refSampleDuration = this._audioMeta.refSampleDuration;
 
@@ -624,6 +656,13 @@ class MP4Remuxer {
     // Stash the lastSample of current batch, waiting for next batch
     if (lastSample != null) {
       this._audioStashedLastSample = lastSample;
+    }
+
+    mdatBytes = this._dropOverlappingTrackSamples("audio", samples, this._audioTiming, mdatBytes);
+    if (samples.length === 0) {
+      track.samples = [];
+      track.length = 0;
+      return;
     }
 
     const firstSampleOriginalDts = (samples[0] as AudioSample).dts - this._dtsBase;
@@ -740,7 +779,7 @@ class MP4Remuxer {
     }
 
     const track = videoTrack;
-    const samples = track.samples;
+    const samples = track.samples as VideoSample[];
     let firstDts = -1;
 
     if (!samples || samples.length === 0) {
@@ -775,6 +814,21 @@ class MP4Remuxer {
       this._videoStashedLastSample = lastSample;
     }
 
+    mdatBytes = this._dropOverlappingTrackSamples("video", samples, this._videoTiming, mdatBytes);
+    if (samples.length === 0) {
+      if (this._debugVideoSegmentsRemaining > 0) {
+        Log.v(
+          this.TAG,
+          `[segment-debug] video segment skipped (${this._debugVideoSegmentsReason}): all samples overlap, ` +
+            `lastRawEnd=${this._videoTiming.lastOriginalEndDts?.toFixed(3) ?? "unset"}`,
+        );
+        this._debugVideoSegmentsRemaining--;
+      }
+      track.samples = [];
+      track.length = 0;
+      return;
+    }
+
     const firstSampleOriginalDts = (samples[0] as VideoSample).dts - this._dtsBase;
 
     const dtsCorrection = this._computeDtsCorrection(
@@ -787,17 +841,6 @@ class MP4Remuxer {
     const mp4Samples: MP4Sample[] = [];
     let nextOutputDts = firstSampleOriginalDts - dtsCorrection;
     const presentationFloor = this._videoInitialOutputTime ?? this._dtsBaseOffset;
-    const firstOriginalPts = firstSampleOriginalDts + (samples[0] as VideoSample).cts;
-
-    if (this._needsVideoPresentationBoundaryCheck && this._videoPresentationOffset !== undefined) {
-      const projectedPts = firstOriginalPts - this._videoPresentationOffset;
-      const drift = projectedPts - nextOutputDts;
-      if (Math.abs(drift) > PRESENTATION_REANCHOR_THRESHOLD_MS) {
-        this._videoPresentationOffset = undefined;
-        Log.v(this.TAG, `video: re-anchoring presentation offset at TS boundary, drift=${Math.round(drift)}ms`);
-      }
-      this._needsVideoPresentationBoundaryCheck = false;
-    }
 
     // Correct dts for each sample, and calculate sample duration. Then output to mp4Samples
     for (let i = 0; i < samples.length; i++) {
@@ -807,14 +850,15 @@ class MP4Remuxer {
 
       const dts = nextOutputDts;
       const originalPts = originalDts + sample.cts;
+      const correctedPtsBase = originalPts - dtsCorrection;
       if (this._videoPresentationOffset === undefined) {
-        this._videoPresentationOffset = originalPts - dts;
+        this._videoPresentationOffset = correctedPtsBase - dts;
         if (this._videoInitialPresentationOffset === undefined) {
           this._videoInitialPresentationOffset = this._videoPresentationOffset;
         }
       }
 
-      const pts = originalPts - this._videoPresentationOffset;
+      const pts = correctedPtsBase - this._videoPresentationOffset;
       if (pts < presentationFloor - 0.001) {
         mdatBytes -= sample.length;
         continue;

--- a/web-ui/src/mpegts/remux/mp4-remuxer.ts
+++ b/web-ui/src/mpegts/remux/mp4-remuxer.ts
@@ -137,8 +137,6 @@ class MP4Remuxer {
   private _silentAudioMode: boolean;
   private _silentAudioLastDts: number | undefined;
   private _tsSegmentContinuityNormalization: boolean;
-  private _debugVideoSegmentsRemaining: number;
-  private _debugVideoSegmentsReason: string;
 
   constructor() {
     this.TAG = "MP4Remuxer";
@@ -171,8 +169,6 @@ class MP4Remuxer {
     this._silentAudioMode = false;
     this._silentAudioLastDts = undefined;
     this._tsSegmentContinuityNormalization = false;
-    this._debugVideoSegmentsRemaining = 0;
-    this._debugVideoSegmentsReason = "";
   }
 
   destroy(): void {
@@ -181,8 +177,6 @@ class MP4Remuxer {
     this._silentAudioMode = false;
     this._silentAudioLastDts = undefined;
     this._tsSegmentContinuityNormalization = false;
-    this._debugVideoSegmentsRemaining = 0;
-    this._debugVideoSegmentsReason = "";
     this._audioTiming = this._createTrackTimingState();
     this._videoTiming = this._createTrackTimingState();
     this._pcmTiming = this._createTrackTimingState();
@@ -230,11 +224,6 @@ class MP4Remuxer {
     this._audioNextDts = this._videoNextDts = undefined;
     this._silentAudioLastDts = undefined;
     this._videoPresentationOffset = undefined;
-  }
-
-  debugLogNextVideoSegments(reason: string, count = 3): void {
-    this._debugVideoSegmentsReason = reason;
-    this._debugVideoSegmentsRemaining = Math.max(this._debugVideoSegmentsRemaining, count);
   }
 
   setTsSegmentContinuityNormalization(enabled: boolean): void {
@@ -287,7 +276,6 @@ class MP4Remuxer {
   }
 
   private _dropOverlappingTrackSamples<T extends { dts: number; length: number }>(
-    type: "audio" | "video",
     samples: T[],
     timing: TrackTimingState,
     mdatBytes: number,
@@ -301,9 +289,6 @@ class MP4Remuxer {
       return mdatBytes;
     }
 
-    let dropped = 0;
-    let firstDroppedDts = 0;
-    let lastDroppedDts = 0;
     while (samples.length > 0) {
       const originalDts = samples[0].dts - this._dtsBase;
       if (originalDts > lastOriginalDts) {
@@ -312,20 +297,6 @@ class MP4Remuxer {
 
       const sample = samples.shift() as T;
       mdatBytes -= sample.length;
-      if (dropped === 0) {
-        firstDroppedDts = originalDts;
-      }
-      lastDroppedDts = originalDts;
-      dropped++;
-    }
-
-    if (dropped > 0) {
-      Log.v(
-        this.TAG,
-        `${type}: dropping ${dropped} overlapping sample(s), ` +
-          `rawDts=${Math.round(firstDroppedDts)}-${Math.round(lastDroppedDts)}ms, ` +
-          `lastRawDts=${Math.round(lastOriginalDts)}ms`,
-      );
     }
 
     return mdatBytes;
@@ -672,7 +643,7 @@ class MP4Remuxer {
       this._audioStashedLastSample = lastSample;
     }
 
-    mdatBytes = this._dropOverlappingTrackSamples("audio", samples, this._audioTiming, mdatBytes);
+    mdatBytes = this._dropOverlappingTrackSamples(samples, this._audioTiming, mdatBytes);
     if (samples.length === 0) {
       track.samples = [];
       track.length = 0;
@@ -828,16 +799,8 @@ class MP4Remuxer {
       this._videoStashedLastSample = lastSample;
     }
 
-    mdatBytes = this._dropOverlappingTrackSamples("video", samples, this._videoTiming, mdatBytes);
+    mdatBytes = this._dropOverlappingTrackSamples(samples, this._videoTiming, mdatBytes);
     if (samples.length === 0) {
-      if (this._debugVideoSegmentsRemaining > 0) {
-        Log.v(
-          this.TAG,
-          `[segment-debug] video segment skipped (${this._debugVideoSegmentsReason}): all samples overlap, ` +
-            `lastRawDts=${this._videoTiming.lastOriginalDts?.toFixed(3) ?? "unset"}`,
-        );
-        this._debugVideoSegmentsRemaining--;
-      }
       track.samples = [];
       track.length = 0;
       return;
@@ -909,15 +872,6 @@ class MP4Remuxer {
     }
 
     if (mp4Samples.length === 0) {
-      if (this._debugVideoSegmentsRemaining > 0) {
-        Log.v(
-          this.TAG,
-          `[segment-debug] video segment skipped (${this._debugVideoSegmentsReason}): ` +
-            `inputSamples=${samples.length}, presentationFloor=${presentationFloor.toFixed(3)}, ` +
-            `presentationOffset=${this._videoPresentationOffset?.toFixed(3) ?? "unset"}`,
-        );
-        this._debugVideoSegmentsRemaining--;
-      }
       track.samples = [];
       track.length = 0;
       return;
@@ -926,22 +880,6 @@ class MP4Remuxer {
     const latest = mp4Samples[mp4Samples.length - 1];
     this._videoNextDts = latest.dts + latest.duration;
     this._recordTrackTiming(this._videoTiming, latest);
-
-    if (this._debugVideoSegmentsRemaining > 0) {
-      const first = mp4Samples[0];
-      const last = mp4Samples[mp4Samples.length - 1];
-      Log.v(
-        this.TAG,
-        `[segment-debug] video segment (${this._debugVideoSegmentsReason}): ` +
-          `count=${mp4Samples.length}, first={dts=${first.dts.toFixed(3)},pts=${first.pts.toFixed(3)},` +
-          `cts=${first.cts.toFixed(3)},dur=${first.duration},key=${first.isKeyframe === true},` +
-          `orig=${first.originalDts.toFixed(3)}} ` +
-          `last={dts=${last.dts.toFixed(3)},pts=${last.pts.toFixed(3)},cts=${last.cts.toFixed(3)},` +
-          `dur=${last.duration},key=${last.isKeyframe === true},orig=${last.originalDts.toFixed(3)}} ` +
-          `next=${this._videoNextDts.toFixed(3)}, presentationOffset=${this._videoPresentationOffset?.toFixed(3) ?? "unset"}`,
-      );
-      this._debugVideoSegmentsRemaining--;
-    }
 
     track.samples = mp4Samples;
     track.sequenceNumber++;

--- a/web-ui/src/mpegts/remux/mp4-remuxer.ts
+++ b/web-ui/src/mpegts/remux/mp4-remuxer.ts
@@ -233,6 +233,10 @@ class MP4Remuxer {
     this._debugVideoSegmentsRemaining = Math.max(this._debugVideoSegmentsRemaining, count);
   }
 
+  resetVideoPresentationOffset(): void {
+    this._videoPresentationOffset = undefined;
+  }
+
   private _createTrackTimingState(): TrackTimingState {
     return {
       lastOriginalEndDts: undefined,

--- a/web-ui/src/mpegts/remux/mp4-remuxer.ts
+++ b/web-ui/src/mpegts/remux/mp4-remuxer.ts
@@ -136,6 +136,7 @@ class MP4Remuxer {
 
   private _silentAudioMode: boolean;
   private _silentAudioLastDts: number | undefined;
+  private _tsSegmentContinuityNormalization: boolean;
   private _debugVideoSegmentsRemaining: number;
   private _debugVideoSegmentsReason: string;
 
@@ -169,6 +170,7 @@ class MP4Remuxer {
 
     this._silentAudioMode = false;
     this._silentAudioLastDts = undefined;
+    this._tsSegmentContinuityNormalization = false;
     this._debugVideoSegmentsRemaining = 0;
     this._debugVideoSegmentsReason = "";
   }
@@ -178,6 +180,7 @@ class MP4Remuxer {
     this._dtsBaseInited = false;
     this._silentAudioMode = false;
     this._silentAudioLastDts = undefined;
+    this._tsSegmentContinuityNormalization = false;
     this._debugVideoSegmentsRemaining = 0;
     this._debugVideoSegmentsReason = "";
     this._audioTiming = this._createTrackTimingState();
@@ -234,6 +237,10 @@ class MP4Remuxer {
     this._debugVideoSegmentsRemaining = Math.max(this._debugVideoSegmentsRemaining, count);
   }
 
+  setTsSegmentContinuityNormalization(enabled: boolean): void {
+    this._tsSegmentContinuityNormalization = enabled;
+  }
+
   private _createTrackTimingState(): TrackTimingState {
     return {
       lastOriginalDts: undefined,
@@ -260,11 +267,11 @@ class MP4Remuxer {
       return firstSampleOriginalDts - nextDts;
     }
 
-    if (timing.lastOriginalDts === undefined || timing.lastOutputEndDts === undefined) {
+    if (timing.lastOriginalEndDts === undefined || timing.lastOutputEndDts === undefined) {
       return firstSampleOriginalDts - this._dtsBaseOffset;
     }
 
-    const distance = firstSampleOriginalDts - timing.lastOriginalDts;
+    const distance = firstSampleOriginalDts - timing.lastOriginalEndDts;
     const bridgedDistance = distance > 0 ? 0 : distance;
     if (bridgedDistance !== distance) {
       Log.v(this.TAG, `${type}: bridging ${Math.round(distance)}ms timestamp hole after discontinuity`);
@@ -285,6 +292,10 @@ class MP4Remuxer {
     timing: TrackTimingState,
     mdatBytes: number,
   ): number {
+    if (!this._tsSegmentContinuityNormalization) {
+      return mdatBytes;
+    }
+
     const lastOriginalDts = timing.lastOriginalDts;
     if (lastOriginalDts === undefined) {
       return mdatBytes;
@@ -853,7 +864,7 @@ class MP4Remuxer {
 
       const dts = nextOutputDts;
       const originalPts = originalDts + sample.cts;
-      const correctedPtsBase = originalPts - dtsCorrection;
+      const correctedPtsBase = this._tsSegmentContinuityNormalization ? originalPts - dtsCorrection : originalPts;
       if (this._videoPresentationOffset === undefined) {
         this._videoPresentationOffset = correctedPtsBase - dts;
         if (this._videoInitialPresentationOffset === undefined) {

--- a/web-ui/src/mpegts/remux/mp4-remuxer.ts
+++ b/web-ui/src/mpegts/remux/mp4-remuxer.ts
@@ -4,6 +4,8 @@ import Log from "../utils/logger";
 import AAC from "./aac-silent";
 import MP4 from "./mp4-generator";
 
+const PRESENTATION_REANCHOR_THRESHOLD_MS = 500;
+
 interface AudioSample {
   unit: Uint8Array;
   dts: number;
@@ -124,6 +126,7 @@ class MP4Remuxer {
   private _videoPresentationOffset: number | undefined;
   private _videoInitialPresentationOffset: number | undefined;
   private _videoInitialOutputTime: number | undefined;
+  private _needsVideoPresentationBoundaryCheck: boolean;
 
   private _audioMeta: TrackMetadata | null;
   private _videoMeta: TrackMetadata | null;
@@ -156,6 +159,7 @@ class MP4Remuxer {
     this._videoPresentationOffset = undefined;
     this._videoInitialPresentationOffset = undefined;
     this._videoInitialOutputTime = undefined;
+    this._needsVideoPresentationBoundaryCheck = false;
 
     this._audioMeta = null;
     this._videoMeta = null;
@@ -185,6 +189,7 @@ class MP4Remuxer {
     this._videoPresentationOffset = undefined;
     this._videoInitialPresentationOffset = undefined;
     this._videoInitialOutputTime = undefined;
+    this._needsVideoPresentationBoundaryCheck = false;
     this._audioMeta = null;
     this._videoMeta = null;
     this._onInitSegment = null;
@@ -233,8 +238,8 @@ class MP4Remuxer {
     this._debugVideoSegmentsRemaining = Math.max(this._debugVideoSegmentsRemaining, count);
   }
 
-  resetVideoPresentationOffset(): void {
-    this._videoPresentationOffset = undefined;
+  markVideoPresentationBoundary(): void {
+    this._needsVideoPresentationBoundaryCheck = true;
   }
 
   private _createTrackTimingState(): TrackTimingState {
@@ -782,6 +787,17 @@ class MP4Remuxer {
     const mp4Samples: MP4Sample[] = [];
     let nextOutputDts = firstSampleOriginalDts - dtsCorrection;
     const presentationFloor = this._videoInitialOutputTime ?? this._dtsBaseOffset;
+    const firstOriginalPts = firstSampleOriginalDts + (samples[0] as VideoSample).cts;
+
+    if (this._needsVideoPresentationBoundaryCheck && this._videoPresentationOffset !== undefined) {
+      const projectedPts = firstOriginalPts - this._videoPresentationOffset;
+      const drift = projectedPts - nextOutputDts;
+      if (Math.abs(drift) > PRESENTATION_REANCHOR_THRESHOLD_MS) {
+        this._videoPresentationOffset = undefined;
+        Log.v(this.TAG, `video: re-anchoring presentation offset at TS boundary, drift=${Math.round(drift)}ms`);
+      }
+      this._needsVideoPresentationBoundaryCheck = false;
+    }
 
     // Correct dts for each sample, and calculate sample duration. Then output to mp4Samples
     for (let i = 0; i < samples.length; i++) {

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -331,7 +331,6 @@ class Pipeline {
     );
     this._demuxer?.flushSegmentBoundary();
     this._remuxer?.flushStashedSamples();
-    this._remuxer?.markVideoPresentationBoundary();
   }
 
   private _resetAudioTiming(): void {

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -317,13 +317,6 @@ class Pipeline {
     return meta.resetRemuxer || !this._hlsSource;
   }
 
-  private _getTsTimestampBase(meta: SegmentMeta, normalizeStaticSegmentContinuity: boolean): number {
-    // Reused TS demuxer/remuxer paths are continuous segment boundaries, same as
-    // ordinary HLS-TS segments. Do not add static segment.start to raw PTS/DTS,
-    // otherwise remux DTS continues but PTS jumps forward by the segment start.
-    return normalizeStaticSegmentContinuity ? 0 : meta.timestampBase;
-  }
-
   private _finishStaticTsSegmentBoundary(): void {
     // Flush stashed samples at every TS segment boundary so the next segment's first
     // remux batch is not mixed with the previous segment's tail.
@@ -418,21 +411,16 @@ class Pipeline {
     const canReuseStatic =
       this._hlsSource === null && this._discreteSegments && this._demuxer !== null && this._remuxer !== null;
     const canReuse = canReuseHls || canReuseStatic;
-    const timestampBase = this._getTsTimestampBase(meta, canReuseStatic);
     if (canReuseStatic) {
       Log.v(
         this.TAG,
         `[segment-debug] setup TS segment: source=${sourceKind}, reuse=${canReuse}, ` +
           `start=${meta.start.toFixed(3)}, duration=${meta.duration.toFixed(3)}, ` +
-          `timestampBase=${timestampBase.toFixed(3)}, metaTimestampBase=${meta.timestampBase.toFixed(3)}, ` +
           `resetRemuxer=${meta.resetRemuxer}, shouldAnchor=${shouldAnchor}`,
       );
     }
     if (canReuse) {
       this._demuxer?.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0]);
-      if (this._demuxer && canReuseStatic) {
-        this._demuxer.timestampBase = timestampBase * 90000; // seconds → 90kHz ticks
-      }
       this._remuxer?.setTsSegmentContinuityNormalization(canReuseStatic);
       if (canReuseStatic) {
         this._remuxer?.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
@@ -461,7 +449,7 @@ class Pipeline {
     }
 
     demuxer.onError = this._onDemuxException.bind(this);
-    demuxer.timestampBase = timestampBase * 90000; // seconds → 90kHz ticks
+    demuxer.timestampBase = 0;
     demuxer.onTrackDiscontinuity = (track) => {
       if (track === "video") {
         this._remuxer?.flushStashedSamples();

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -331,7 +331,9 @@ class Pipeline {
     );
     this._demuxer?.flushSegmentBoundary();
     this._remuxer?.flushStashedSamples();
-    this._remuxer?.resetVideoPresentationOffset();
+    if (!this._hlsSource && this._discreteSegments) {
+      this._remuxer?.resetVideoPresentationOffset();
+    }
   }
 
   private _resetAudioTiming(): void {

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -326,6 +326,13 @@ class Pipeline {
     return this._isStaticSegmentList() || (this._hlsSource !== null && !shouldAnchor);
   }
 
+  private _getTsTimestampBase(meta: SegmentMeta, reuseDemuxer: boolean): number {
+    // Reused TS demuxer/remuxer paths are continuous segment boundaries, same as
+    // ordinary HLS-TS segments. Do not add static segment.start to raw PTS/DTS,
+    // otherwise remux DTS continues but PTS jumps forward by the segment start.
+    return reuseDemuxer ? 0 : meta.timestampBase;
+  }
+
   private _finishTsSegmentBoundary(): void {
     // Flush stashed samples at every TS segment boundary so the next segment's first
     // remux batch is not mixed with the previous segment's tail.
@@ -417,16 +424,18 @@ class Pipeline {
     const shouldAnchor = this._shouldAnchorSegment(meta);
     const sourceKind = this._hlsSource ? "hls" : this._discreteSegments ? "static" : "single";
     const canReuse = this._canReuseTsDemuxer(shouldAnchor);
+    const timestampBase = this._getTsTimestampBase(meta, canReuse);
     Log.v(
       this.TAG,
       `[segment-debug] setup TS segment: source=${sourceKind}, reuse=${canReuse}, ` +
         `start=${meta.start.toFixed(3)}, duration=${meta.duration.toFixed(3)}, ` +
-        `timestampBase=${meta.timestampBase.toFixed(3)}, resetRemuxer=${meta.resetRemuxer}, shouldAnchor=${shouldAnchor}`,
+        `timestampBase=${timestampBase.toFixed(3)}, metaTimestampBase=${meta.timestampBase.toFixed(3)}, ` +
+        `resetRemuxer=${meta.resetRemuxer}, shouldAnchor=${shouldAnchor}`,
     );
     if (canReuse) {
       this._demuxer?.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0]);
       if (this._demuxer) {
-        this._demuxer.timestampBase = meta.timestampBase * 90000; // seconds → 90kHz ticks
+        this._demuxer.timestampBase = timestampBase * 90000; // seconds → 90kHz ticks
       }
       this._remuxer?.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
       return;
@@ -451,7 +460,7 @@ class Pipeline {
     this._remuxer.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
 
     demuxer.onError = this._onDemuxException.bind(this);
-    demuxer.timestampBase = meta.timestampBase * 90000; // seconds → 90kHz ticks
+    demuxer.timestampBase = timestampBase * 90000; // seconds → 90kHz ticks
     demuxer.onTrackDiscontinuity = (track) => {
       if (track === "video") {
         this._remuxer?.flushStashedSamples();

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -320,7 +320,6 @@ class Pipeline {
   private _finishStaticTsSegmentBoundary(): void {
     // Flush stashed samples at every TS segment boundary so the next segment's first
     // remux batch is not mixed with the previous segment's tail.
-    Log.v(this.TAG, `[segment-debug] finish TS segment: source=${this._discreteSegments ? "static" : "single"}`);
     this._demuxer?.flushSegmentBoundary();
     this._remuxer?.flushStashedSamples();
     this._workerAudioDecoder?.reset();
@@ -406,25 +405,13 @@ class Pipeline {
 
   private _setupTSDemuxerRemuxer(probeData: unknown, meta: SegmentMeta): void {
     const shouldAnchor = this._shouldAnchorSegment(meta);
-    const sourceKind = this._hlsSource ? "hls" : this._discreteSegments ? "static" : "single";
     const canReuseHls = this._hlsSource !== null && !shouldAnchor && this._demuxer !== null && this._remuxer !== null;
     const canReuseStatic =
       this._hlsSource === null && this._discreteSegments && this._demuxer !== null && this._remuxer !== null;
     const canReuse = canReuseHls || canReuseStatic;
-    if (canReuseStatic) {
-      Log.v(
-        this.TAG,
-        `[segment-debug] setup TS segment: source=${sourceKind}, reuse=${canReuse}, ` +
-          `start=${meta.start.toFixed(3)}, duration=${meta.duration.toFixed(3)}, ` +
-          `resetRemuxer=${meta.resetRemuxer}, shouldAnchor=${shouldAnchor}`,
-      );
-    }
     if (canReuse) {
       this._demuxer?.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0]);
       this._remuxer?.setTsSegmentContinuityNormalization(canReuseStatic);
-      if (canReuseStatic) {
-        this._remuxer?.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
-      }
       return;
     }
 
@@ -444,9 +431,6 @@ class Pipeline {
       }
     }
     this._remuxer.setTsSegmentContinuityNormalization(false);
-    if (!this._hlsSource) {
-      this._remuxer.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
-    }
 
     demuxer.onError = this._onDemuxException.bind(this);
     demuxer.timestampBase = 0;

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -331,9 +331,7 @@ class Pipeline {
     );
     this._demuxer?.flushSegmentBoundary();
     this._remuxer?.flushStashedSamples();
-    if (!this._hlsSource && this._discreteSegments) {
-      this._remuxer?.resetVideoPresentationOffset();
-    }
+    this._remuxer?.markVideoPresentationBoundary();
   }
 
   private _resetAudioTiming(): void {

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -278,17 +278,8 @@ class Pipeline {
 
         if (this._fmp4Mode) {
           this._flushFmp4Segment(meta);
-        }
-        // Flush stashed samples at every segment boundary so the next segment's first
-        // remux batch is not mixed with the previous segment's tail (which would share
-        // one dtsCorrection and preserve upstream HLS timestamp gaps in MSE).
-        this._remuxer?.flushStashedSamples();
-        if (!this._hlsSource) {
-          // Each static segment is an independent TS timeline: a partial MP2
-          // frame carried from the previous URL must not be prepended to the
-          // next one, and the PTS anchor must re-establish from the new PES
-          this._workerAudioDecoder?.reset();
-          this._resetAudioTiming();
+        } else {
+          this._finishTsSegmentBoundary();
         }
       } catch (e) {
         if (this._runId !== runId || e === CANCELLED) return;
@@ -322,6 +313,23 @@ class Pipeline {
 
   private _shouldAnchorSegment(meta: SegmentMeta): boolean {
     return meta.resetRemuxer || !this._hlsSource;
+  }
+
+  private _isStaticSegmentList(): boolean {
+    return !this._hlsSource && this._discreteSegments;
+  }
+
+  private _canReuseTsDemuxer(shouldAnchor: boolean): boolean {
+    if (!this._demuxer || !this._remuxer) {
+      return false;
+    }
+    return this._isStaticSegmentList() || (this._hlsSource !== null && !shouldAnchor);
+  }
+
+  private _finishTsSegmentBoundary(): void {
+    // Flush stashed samples at every TS segment boundary so the next segment's first
+    // remux batch is not mixed with the previous segment's tail.
+    this._remuxer?.flushStashedSamples();
   }
 
   private _resetAudioTiming(): void {
@@ -403,8 +411,11 @@ class Pipeline {
 
   private _setupTSDemuxerRemuxer(probeData: unknown, meta: SegmentMeta): void {
     const shouldAnchor = this._shouldAnchorSegment(meta);
-    if (this._hlsSource && !shouldAnchor && this._demuxer && this._remuxer) {
-      this._demuxer.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0]);
+    if (this._canReuseTsDemuxer(shouldAnchor)) {
+      this._demuxer?.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0]);
+      if (this._demuxer) {
+        this._demuxer.timestampBase = meta.timestampBase * 90000; // seconds → 90kHz ticks
+      }
       return;
     }
 

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -329,6 +329,10 @@ class Pipeline {
   private _finishTsSegmentBoundary(): void {
     // Flush stashed samples at every TS segment boundary so the next segment's first
     // remux batch is not mixed with the previous segment's tail.
+    Log.v(
+      this.TAG,
+      `[segment-debug] finish TS segment: source=${this._hlsSource ? "hls" : this._discreteSegments ? "static" : "single"}`,
+    );
     this._remuxer?.flushStashedSamples();
   }
 
@@ -411,11 +415,20 @@ class Pipeline {
 
   private _setupTSDemuxerRemuxer(probeData: unknown, meta: SegmentMeta): void {
     const shouldAnchor = this._shouldAnchorSegment(meta);
-    if (this._canReuseTsDemuxer(shouldAnchor)) {
+    const sourceKind = this._hlsSource ? "hls" : this._discreteSegments ? "static" : "single";
+    const canReuse = this._canReuseTsDemuxer(shouldAnchor);
+    Log.v(
+      this.TAG,
+      `[segment-debug] setup TS segment: source=${sourceKind}, reuse=${canReuse}, ` +
+        `start=${meta.start.toFixed(3)}, duration=${meta.duration.toFixed(3)}, ` +
+        `timestampBase=${meta.timestampBase.toFixed(3)}, resetRemuxer=${meta.resetRemuxer}, shouldAnchor=${shouldAnchor}`,
+    );
+    if (canReuse) {
       this._demuxer?.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0]);
       if (this._demuxer) {
         this._demuxer.timestampBase = meta.timestampBase * 90000; // seconds → 90kHz ticks
       }
+      this._remuxer?.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
       return;
     }
 
@@ -435,6 +448,7 @@ class Pipeline {
         this._pendingDtsOffsetMs = 0;
       }
     }
+    this._remuxer.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
 
     demuxer.onError = this._onDemuxException.bind(this);
     demuxer.timestampBase = meta.timestampBase * 90000; // seconds → 90kHz ticks

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -329,6 +329,7 @@ class Pipeline {
       this.TAG,
       `[segment-debug] finish TS segment: source=${this._hlsSource ? "hls" : this._discreteSegments ? "static" : "single"}`,
     );
+    this._demuxer?.flushSegmentBoundary();
     this._remuxer?.flushStashedSamples();
   }
 

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -410,7 +410,9 @@ class Pipeline {
       this._hlsSource === null && this._discreteSegments && this._demuxer !== null && this._remuxer !== null;
     const canReuse = canReuseHls || canReuseStatic;
     if (canReuse) {
-      this._demuxer?.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0]);
+      this._demuxer?.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0], {
+        resetAudioParserState: canReuseStatic,
+      });
       this._remuxer?.setTsSegmentContinuityNormalization(canReuseStatic);
       return;
     }

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -315,17 +315,6 @@ class Pipeline {
     return meta.resetRemuxer || !this._hlsSource;
   }
 
-  private _isStaticSegmentList(): boolean {
-    return !this._hlsSource && this._discreteSegments;
-  }
-
-  private _canReuseTsDemuxer(shouldAnchor: boolean): boolean {
-    if (!this._demuxer || !this._remuxer) {
-      return false;
-    }
-    return this._isStaticSegmentList() || (this._hlsSource !== null && !shouldAnchor);
-  }
-
   private _getTsTimestampBase(meta: SegmentMeta, reuseDemuxer: boolean): number {
     // Reused TS demuxer/remuxer paths are continuous segment boundaries, same as
     // ordinary HLS-TS segments. Do not add static segment.start to raw PTS/DTS,
@@ -423,7 +412,7 @@ class Pipeline {
   private _setupTSDemuxerRemuxer(probeData: unknown, meta: SegmentMeta): void {
     const shouldAnchor = this._shouldAnchorSegment(meta);
     const sourceKind = this._hlsSource ? "hls" : this._discreteSegments ? "static" : "single";
-    const canReuse = this._canReuseTsDemuxer(shouldAnchor);
+    const canReuse = this._demuxer !== null && this._remuxer !== null;
     const timestampBase = this._getTsTimestampBase(meta, canReuse);
     Log.v(
       this.TAG,
@@ -441,12 +430,11 @@ class Pipeline {
       return;
     }
 
-    const waitForInitialVideoKeyframe = shouldAnchor || !this._demuxer || !this._remuxer;
     if (this._demuxer) {
       this._demuxer.destroy();
     }
     const demuxer = new TSDemuxer(probeData as ConstructorParameters<typeof TSDemuxer>[0], {
-      waitForInitialVideoKeyframe,
+      waitForInitialVideoKeyframe: true,
     });
     this._demuxer = demuxer;
 

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -331,6 +331,7 @@ class Pipeline {
     );
     this._demuxer?.flushSegmentBoundary();
     this._remuxer?.flushStashedSamples();
+    this._remuxer?.resetVideoPresentationOffset();
   }
 
   private _resetAudioTiming(): void {

--- a/web-ui/src/mpegts/worker/pipeline.ts
+++ b/web-ui/src/mpegts/worker/pipeline.ts
@@ -278,8 +278,10 @@ class Pipeline {
 
         if (this._fmp4Mode) {
           this._flushFmp4Segment(meta);
+        } else if (this._hlsSource) {
+          this._remuxer?.flushStashedSamples();
         } else {
-          this._finishTsSegmentBoundary();
+          this._finishStaticTsSegmentBoundary();
         }
       } catch (e) {
         if (this._runId !== runId || e === CANCELLED) return;
@@ -315,22 +317,21 @@ class Pipeline {
     return meta.resetRemuxer || !this._hlsSource;
   }
 
-  private _getTsTimestampBase(meta: SegmentMeta, reuseDemuxer: boolean): number {
+  private _getTsTimestampBase(meta: SegmentMeta, normalizeStaticSegmentContinuity: boolean): number {
     // Reused TS demuxer/remuxer paths are continuous segment boundaries, same as
     // ordinary HLS-TS segments. Do not add static segment.start to raw PTS/DTS,
     // otherwise remux DTS continues but PTS jumps forward by the segment start.
-    return reuseDemuxer ? 0 : meta.timestampBase;
+    return normalizeStaticSegmentContinuity ? 0 : meta.timestampBase;
   }
 
-  private _finishTsSegmentBoundary(): void {
+  private _finishStaticTsSegmentBoundary(): void {
     // Flush stashed samples at every TS segment boundary so the next segment's first
     // remux batch is not mixed with the previous segment's tail.
-    Log.v(
-      this.TAG,
-      `[segment-debug] finish TS segment: source=${this._hlsSource ? "hls" : this._discreteSegments ? "static" : "single"}`,
-    );
+    Log.v(this.TAG, `[segment-debug] finish TS segment: source=${this._discreteSegments ? "static" : "single"}`);
     this._demuxer?.flushSegmentBoundary();
     this._remuxer?.flushStashedSamples();
+    this._workerAudioDecoder?.reset();
+    this._resetAudioTiming();
   }
 
   private _resetAudioTiming(): void {
@@ -413,21 +414,29 @@ class Pipeline {
   private _setupTSDemuxerRemuxer(probeData: unknown, meta: SegmentMeta): void {
     const shouldAnchor = this._shouldAnchorSegment(meta);
     const sourceKind = this._hlsSource ? "hls" : this._discreteSegments ? "static" : "single";
-    const canReuse = this._demuxer !== null && this._remuxer !== null;
-    const timestampBase = this._getTsTimestampBase(meta, canReuse);
-    Log.v(
-      this.TAG,
-      `[segment-debug] setup TS segment: source=${sourceKind}, reuse=${canReuse}, ` +
-        `start=${meta.start.toFixed(3)}, duration=${meta.duration.toFixed(3)}, ` +
-        `timestampBase=${timestampBase.toFixed(3)}, metaTimestampBase=${meta.timestampBase.toFixed(3)}, ` +
-        `resetRemuxer=${meta.resetRemuxer}, shouldAnchor=${shouldAnchor}`,
-    );
+    const canReuseHls = this._hlsSource !== null && !shouldAnchor && this._demuxer !== null && this._remuxer !== null;
+    const canReuseStatic =
+      this._hlsSource === null && this._discreteSegments && this._demuxer !== null && this._remuxer !== null;
+    const canReuse = canReuseHls || canReuseStatic;
+    const timestampBase = this._getTsTimestampBase(meta, canReuseStatic);
+    if (canReuseStatic) {
+      Log.v(
+        this.TAG,
+        `[segment-debug] setup TS segment: source=${sourceKind}, reuse=${canReuse}, ` +
+          `start=${meta.start.toFixed(3)}, duration=${meta.duration.toFixed(3)}, ` +
+          `timestampBase=${timestampBase.toFixed(3)}, metaTimestampBase=${meta.timestampBase.toFixed(3)}, ` +
+          `resetRemuxer=${meta.resetRemuxer}, shouldAnchor=${shouldAnchor}`,
+      );
+    }
     if (canReuse) {
       this._demuxer?.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0]);
-      if (this._demuxer) {
+      if (this._demuxer && canReuseStatic) {
         this._demuxer.timestampBase = timestampBase * 90000; // seconds → 90kHz ticks
       }
-      this._remuxer?.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
+      this._remuxer?.setTsSegmentContinuityNormalization(canReuseStatic);
+      if (canReuseStatic) {
+        this._remuxer?.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
+      }
       return;
     }
 
@@ -435,7 +444,7 @@ class Pipeline {
       this._demuxer.destroy();
     }
     const demuxer = new TSDemuxer(probeData as ConstructorParameters<typeof TSDemuxer>[0], {
-      waitForInitialVideoKeyframe: true,
+      waitForInitialVideoKeyframe: shouldAnchor || !this._demuxer || !this._remuxer,
     });
     this._demuxer = demuxer;
 
@@ -446,7 +455,10 @@ class Pipeline {
         this._pendingDtsOffsetMs = 0;
       }
     }
-    this._remuxer.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
+    this._remuxer.setTsSegmentContinuityNormalization(false);
+    if (!this._hlsSource) {
+      this._remuxer.debugLogNextVideoSegments(`${sourceKind} segment start ${meta.start.toFixed(3)}s`);
+    }
 
     demuxer.onError = this._onDemuxException.bind(this);
     demuxer.timestampBase = timestampBase * 90000; // seconds → 90kHz ticks

--- a/web-ui/src/mpegts/worker/segment-source.ts
+++ b/web-ui/src/mpegts/worker/segment-source.ts
@@ -6,8 +6,6 @@ export interface SegmentMeta {
   start: number;
   /** Segment duration in seconds (0 if unknown / live). */
   duration: number;
-  /** Value added to demuxed PTS/DTS (seconds). Used by the static (catchup) path where each URL restarts its own timeline. */
-  timestampBase: number;
   /** Destroy and recreate the remuxer before this segment, re-anchoring output at `start` (HLS discontinuity / seek). */
   resetRemuxer: boolean;
   /** fMP4 initialization segment URL (HLS EXT-X-MAP), if any. */
@@ -32,7 +30,6 @@ export class StaticSegmentSource implements SegmentSource {
         url: seg.url,
         start,
         duration: seg.duration ?? 0,
-        timestampBase: start,
         resetRemuxer: false,
       };
       start += seg.duration ?? 0;


### PR DESCRIPTION
## Summary

This PR improves plain MPEG-TS catchup/static segment-list playback across URL boundaries without changing the HLS playback path.

The player now adds a 1 second request overlap between generated catchup segments, reuses TS demux/remux state for static segment continuity, flushes completed samples at static TS segment boundaries, and normalizes only the static TS segment path so small server-side gaps or overlaps do not produce MSE timeline holes.

## Changes

- Add a 1 second overlap when building catchup segment URLs while keeping the playback timeline duration unchanged.
- Reuse TS demuxer/remuxer state for static segment-list continuation.
- Flush demuxed and remuxer-stashed samples before advancing to the next static TS URL.
- Normalize static TS segment gaps/overlaps in the remuxer while keeping ordinary HLS segment handling isolated.
- Remove the obsolete segment `timestampBase` field and temporary segment debug logs.
- Keep `src/embedded_web_data.h` out of this PR.

## Validation

- `pnpm run type-check:tsc`
- `pnpm run lint:biome`
- `pnpm exec vite build web-ui`
- `git diff --check`
