### PR TITLE
feat(ikuai): package multi-arch binaries

### DIFF
--- a/ikuai-support/rtp2httpd/manifest.json
+++ b/ikuai-support/rtp2httpd/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "rtp2httpd",
-  "version": "3.12.2",
+  "version": "3.14.2",
   "display_name": "rtp2httpd",
   "description": "面向 IPTV 场景的组播、RTSP、HTTP 流媒体转发服务，内置状态页面和 Web 播放器。可替代 udpxy 和 msd_lite。",
   "type": "0",

--- a/ikuai-support/rtp2httpd/scripts/POST_INST.sh
+++ b/ikuai-support/rtp2httpd/scripts/POST_INST.sh
@@ -7,10 +7,18 @@ INSTALL_LOG="$PKG_DIR/log/install.log"
 
 mkdir -p "$PKG_DIR/log"
 
-if [ -f "$PKG_DIR/app/bin/rtp2httpd" ]; then
-  chmod 755 "$PKG_DIR/app/bin/rtp2httpd"
-else
-  printf '%s POST_INST warning: app/bin/rtp2httpd is missing\n' "$(date '+%Y-%m-%d %H:%M:%S')" >> "$INSTALL_LOG"
+missing=0
+for arch in aarch64 x86_64; do
+  bin="$PKG_DIR/app/bin/rtp2httpd-$arch"
+  if [ -f "$bin" ]; then
+    chmod 755 "$bin"
+  else
+    printf '%s POST_INST warning: app/bin/rtp2httpd-%s is missing\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$arch" >> "$INSTALL_LOG"
+    missing=1
+  fi
+done
+
+if [ "$missing" -eq 1 ]; then
   exit 0
 fi
 

--- a/ikuai-support/rtp2httpd/scripts/PRE_INST.sh
+++ b/ikuai-support/rtp2httpd/scripts/PRE_INST.sh
@@ -7,8 +7,11 @@ INSTALL_LOG="$PKG_DIR/log/install.log"
 
 mkdir -p "$PKG_DIR/app/bin" "$PKG_DIR/app/cache" "$PKG_DIR/app/config" "$PKG_DIR/app/data" "$PKG_DIR/log"
 
-if [ -f "$PKG_DIR/app/bin/rtp2httpd" ]; then
-  chmod 755 "$PKG_DIR/app/bin/rtp2httpd"
-fi
+for arch in aarch64 x86_64; do
+  bin="$PKG_DIR/app/bin/rtp2httpd-$arch"
+  if [ -f "$bin" ]; then
+    chmod 755 "$bin"
+  fi
+done
 
 printf '%s PRE_INST completed\n' "$(date '+%Y-%m-%d %H:%M:%S')" >> "$INSTALL_LOG"

--- a/ikuai-support/rtp2httpd/scripts/start.sh
+++ b/ikuai-support/rtp2httpd/scripts/start.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
 PKG_DIR=$(dirname "$SCRIPT_DIR")
 CONFIG_ENV="$PKG_DIR/app/.env"
 RUNTIME_ENV="$PKG_DIR/app/environment"
-BIN="$PKG_DIR/app/bin/rtp2httpd"
+BIN_DIR="$PKG_DIR/app/bin"
 CONFIG_FILE="$PKG_DIR/app/config/rtp2httpd.conf"
 PIDFILE="$PKG_DIR/app/cache/rtp2httpd.pid"
 RUN_LOG="$PKG_DIR/log/run.log"
@@ -13,6 +13,26 @@ RUN_LOG="$PKG_DIR/log/run.log"
 log() {
   mkdir -p "$PKG_DIR/log"
   printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$RUN_LOG"
+}
+
+select_binary() {
+  machine=$(uname -m 2>/dev/null || true)
+
+  case "$machine" in
+  aarch64 | arm64) bin="$BIN_DIR/rtp2httpd-aarch64" ;;
+  x86_64 | amd64) bin="$BIN_DIR/rtp2httpd-x86_64" ;;
+  *)
+    log "Unsupported platform architecture: ${machine:-unknown}"
+    exit 1
+    ;;
+  esac
+
+  if [ ! -x "$bin" ]; then
+    log "Binary is missing or not executable: $bin"
+    exit 1
+  fi
+
+  printf '%s' "$bin"
 }
 
 # Build a log-safe command line, redacting secret flag values.
@@ -89,10 +109,7 @@ load_env_file "$RUNTIME_ENV"
 : "${RTP2HTTPD_RTSP_USER_AGENT:=}"
 : "${RTP2HTTPD_EXTRA_ARGS:=}"
 
-if [ ! -x "$BIN" ]; then
-  log "Binary is missing or not executable: $BIN"
-  exit 1
-fi
+BIN=$(select_binary)
 
 if [ -f "$PIDFILE" ]; then
   OLD_PID=$(cat "$PIDFILE" 2>/dev/null || true)

--- a/ikuai-support/rtp2httpd/scripts/stop.sh
+++ b/ikuai-support/rtp2httpd/scripts/stop.sh
@@ -3,13 +3,33 @@ set -eu
 
 SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
 PKG_DIR=$(dirname "$SCRIPT_DIR")
-BIN="$PKG_DIR/app/bin/rtp2httpd"
+BIN_DIR="$PKG_DIR/app/bin"
 PIDFILE="$PKG_DIR/app/cache/rtp2httpd.pid"
 RUN_LOG="$PKG_DIR/log/run.log"
 
 log() {
   mkdir -p "$PKG_DIR/log"
   printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$RUN_LOG"
+}
+
+select_binary() {
+  machine=$(uname -m 2>/dev/null || true)
+
+  case "$machine" in
+  aarch64 | arm64) bin="$BIN_DIR/rtp2httpd-aarch64" ;;
+  x86_64 | amd64) bin="$BIN_DIR/rtp2httpd-x86_64" ;;
+  *)
+    log "Unsupported platform architecture: ${machine:-unknown}"
+    return 1
+    ;;
+  esac
+
+  if [ ! -x "$bin" ]; then
+    log "Binary is missing or not executable: $bin"
+    return 1
+  fi
+
+  printf '%s' "$bin"
 }
 
 pid_belongs_to_us() {
@@ -47,6 +67,8 @@ if [ -z "$PID" ] || ! kill -0 "$PID" 2>/dev/null; then
   log "rtp2httpd is not running: stale pid file removed"
   exit 0
 fi
+
+BIN=$(select_binary) || exit 1
 
 if [ -d "/proc/$PID" ] && ! pid_belongs_to_us "$PID"; then
   rm -f "$PIDFILE"

--- a/scripts/build-ikuai-ipkg.sh
+++ b/scripts/build-ikuai-ipkg.sh
@@ -16,24 +16,63 @@ ICON_SOURCE="$PROJECT_ROOT/web-ui/public/assets/icon.png"
 
 VERSION=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/p' "$MANIFEST" | head -1)
 VERSION=${1:-$VERSION}
-ARCH=${2:-x86_64}
 
 if [ -z "$VERSION" ]; then
   echo "Version is required" >&2
   exit 1
 fi
 
-BINARY_NAME="rtp2httpd-$VERSION-$ARCH"
-RELEASE_URL="https://github.com/stackia/rtp2httpd/releases/download/v$VERSION/$BINARY_NAME"
+download_binary() {
+  arch=$1
+  output=$2
+  binary_name="rtp2httpd-$VERSION-$arch"
+  release_url="https://github.com/stackia/rtp2httpd/releases/download/v$VERSION/$binary_name"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL "$release_url" -o "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "$output" "$release_url"
+  else
+    echo "curl or wget is required unless local binary paths are set" >&2
+    exit 1
+  fi
+}
+
+binary_path_for_arch() {
+  arch=$1
+
+  case "$arch" in
+  aarch64) path=${BINARY_PATH_AARCH64:-} ;;
+  x86_64) path=${BINARY_PATH_X86_64:-} ;;
+  *)
+    echo "Unsupported arch: $arch" >&2
+    exit 1
+    ;;
+  esac
+
+  if [ -z "$path" ] && [ -n "${BINARY_DIR:-}" ]; then
+    for candidate in \
+      "$BINARY_DIR/rtp2httpd-$VERSION-$arch" \
+      "$BINARY_DIR/rtp2httpd-$arch" \
+      "$BINARY_DIR/$arch/rtp2httpd"; do
+      if [ -f "$candidate" ]; then
+        path=$candidate
+        break
+      fi
+    done
+  fi
+
+  printf '%s' "$path"
+}
 
 rm -rf "$STAGING_ROOT"
 mkdir -p "$STAGING_PACKAGE" "$DIST_DIR"
 cp -R "$PACKAGE_SRC"/. "$STAGING_PACKAGE"/
 find "$STAGING_PACKAGE" -name .gitkeep -exec rm -f {} +
+rm -f "$STAGING_PACKAGE/app/bin/rtp2httpd"
 
-# Keep the staged manifest in sync with the requested version and arch.
+# Keep the staged manifest in sync with the requested version.
 sed -e "s/\"version\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"version\": \"$VERSION\"/" \
-  -e "s/\"image\"[[:space:]]*:[[:space:]]*\"[^\"]*\"/\"image\": \"$BINARY_NAME\"/" \
   "$MANIFEST" > "$STAGING_PACKAGE/manifest.json"
 
 if [ ! -f "$ICON_SOURCE" ]; then
@@ -44,27 +83,33 @@ mkdir -p "$STAGING_PACKAGE/ui/ico"
 rm -f "$STAGING_PACKAGE/ui/ico/app.png"
 cp "$ICON_SOURCE" "$STAGING_PACKAGE/ui/ico/app.png"
 
-if [ -n "${BINARY_PATH:-}" ]; then
-  if [ ! -f "$BINARY_PATH" ]; then
-    echo "BINARY_PATH does not exist: $BINARY_PATH" >&2
-    exit 1
-  fi
-  cp "$BINARY_PATH" "$STAGING_PACKAGE/app/bin/rtp2httpd"
-else
-  if command -v curl >/dev/null 2>&1; then
-    curl -fL "$RELEASE_URL" -o "$STAGING_PACKAGE/app/bin/rtp2httpd"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -O "$STAGING_PACKAGE/app/bin/rtp2httpd" "$RELEASE_URL"
-  else
-    echo "curl or wget is required unless BINARY_PATH is set" >&2
-    exit 1
-  fi
-fi
+for arch in aarch64 x86_64; do
+  output="$STAGING_PACKAGE/app/bin/rtp2httpd-$arch"
+  binary_path=$(binary_path_for_arch "$arch")
 
-chmod 755 "$STAGING_PACKAGE/app/bin/rtp2httpd"
+  if [ -n "$binary_path" ]; then
+    if [ ! -f "$binary_path" ]; then
+      echo "Binary path does not exist for $arch: $binary_path" >&2
+      exit 1
+    fi
+    cp "$binary_path" "$output"
+  else
+    download_binary "$arch" "$output"
+  fi
+
+  chmod 755 "$output"
+done
+
+for required_arch in aarch64 x86_64; do
+  if [ ! -x "$STAGING_PACKAGE/app/bin/rtp2httpd-$required_arch" ]; then
+    echo "Required binary is missing: app/bin/rtp2httpd-$required_arch" >&2
+    exit 1
+  fi
+done
+
 chmod 755 "$STAGING_PACKAGE"/scripts/*.sh
 
-OUTPUT="$DIST_DIR/rtp2httpd-$VERSION-$ARCH.ipkg"
+OUTPUT="$DIST_DIR/rtp2httpd-$VERSION-ikuai.ipkg"
 (
   cd "$STAGING_ROOT"
   tar -czf "$OUTPUT" rtp2httpd


### PR DESCRIPTION
## Summary

Updates the iKuai package support so a single package carries both Linux static binaries and chooses the correct one at runtime.

## Changes

- Bumps the iKuai app manifest version to 3.14.2.
- Packages both `rtp2httpd-aarch64` and `rtp2httpd-x86_64` into the iKuai ipkg.
- Selects the runtime binary based on `uname -m` in the iKuai start/stop scripts.
- Updates install hooks to chmod and check both architecture-specific binaries.

## Validation

- `sh -n scripts/build-ikuai-ipkg.sh`
- `sh -n ikuai-support/rtp2httpd/scripts/*.sh`
- `git diff --check`
- Built `ikuai-support/dist/rtp2httpd-3.14.2-ikuai.ipkg` from the real v3.14.2 release assets and verified the package contains executable `rtp2httpd-aarch64` and `rtp2httpd-x86_64` binaries plus manifest version `3.14.2`.