### PR TITLE
docs(agents): add Cursor Cloud setup notes for rtp2httpd dev env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,11 @@ Non-obvious gotchas discovered during setup:
   `ffmpeg -re -f lavfi -i testsrc2=size=1280x720:rate=25 -f lavfi -i sine=frequency=440 -c:v libx264 -tune zerolatency -x264-params "keyint=25:min-keyint=25:scenecut=0:repeat-headers=1" -c:a aac -ac 2 -mpegts_flags +resend_headers -pat_period 0.2 -f rtp_mpegts "rtp://239.255.0.1:9988?localaddr=127.0.0.1&ttl=1&pkt_size=1316"`.
   Without `repeat-headers=1` / `+resend_headers` the player stalls or shows a decode/playback error
   even though the bytes are flowing.
+- **Multi-scenario player dev lab**: `tools/devlab/devlab.py` (run via `uv run python`) starts mock
+  upstreams for HLS live, HLS catchup, and RTSP/mpegts catchup across `h264-mp2` and `hevc-aac`, and
+  writes an rtp2httpd config; see `tools/devlab/README.md`. Catchup video burns the requested
+  `playseek` time into the picture so seek correctness is visible. Two non-obvious gotchas it encodes:
+  (1) the web player's `buildCatchupSegments` expects each `catchup-source` window to return TS, not a
+  sub-`.m3u8`, so catchup endpoints stream TS per window; (2) ffmpeg `drawtext` mis-parses a `box*`
+  option placed before a `text=` containing a `%{...}` expansion, and `%{...:...}` expansions with
+  colon args fight filtergraph escaping — prefer `borderw`/`bordercolor` and colon-free text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,12 @@ Non-obvious gotchas discovered during setup:
   Without `repeat-headers=1` / `+resend_headers` the player stalls or shows a decode/playback error
   even though the bytes are flowing.
 - **Multi-scenario player dev lab**: `tools/devlab/devlab.py` (run via `uv run python`) starts mock
-  upstreams for HLS live, HLS catchup, and RTSP/mpegts catchup across `h264-mp2` and `hevc-aac`, and
-  writes an rtp2httpd config; see `tools/devlab/README.md`. Catchup video burns the requested
-  `playseek` time into the picture so seek correctness is visible. Two non-obvious gotchas it encodes:
+  upstreams for HLS live/catchup, RTSP/mpegts catchup, and RTP multicast (组播) mpegts live, across
+  `h264-mp2`, `hevc-aac`, `hevc-ac3`, `hevc-eac3`; `--ts-file PATH` republishes an arbitrary `.ts`
+  file (stream-copied, looped) as a multicast channel for debugging user-reported streams. It writes
+  an rtp2httpd config (run the daemon with `-r lo` for the multicast channels); see
+  `tools/devlab/README.md`. Catchup video burns the requested `playseek` time into the picture so
+  seek correctness is visible. Two non-obvious gotchas it encodes:
   (1) the web player's `buildCatchupSegments` expects each `catchup-source` window to return TS, not a
   sub-`.m3u8`, so catchup endpoints stream TS per window; (2) ffmpeg `drawtext` mis-parses a `box*`
   option placed before a `text=` containing a `%{...}` expansion, and `%{...:...}` expansions with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,26 +51,12 @@ Toolchain is pre-installed and refreshed by the startup update script (`pnpm ins
 then `uv sync --group dev`). Standard commands live in `package.json` scripts and the `build-run` /
 `e2e` skills — use those rather than reinventing them.
 
-Non-obvious gotchas discovered during setup:
+Non-obvious notes:
 
 - **Node version**: the project pins Node `lts/krypton` (v24) via `.nvmrc`; nvm's default alias is set
   to it, so a login shell resolves Node 24, the corepack `pnpm@11.9.0`, and `uv`. A bare non-login
   shell may instead pick up the system `/exec-daemon/node` (v22) that shadows nvm — run inside a login
   shell (or `nvm use`) when the exact version matters.
-- **`-v` takes a numeric argument**: in this build `-v` is `--verbose <level>` (e.g. `-v 4`), NOT a
-  stackable flag. `./build/rtp2httpd ... -v -v -v` fails with "option requires an argument". Set
-  `verbosity` in the config file or pass `-v <0-4>`.
-- **Loopback multicast**: to stream/receive RTP multicast on this VM (manual testing or multicast e2e
-  tests), start the daemon with `-r lo` so it joins the group on the loopback interface; senders must
-  set `IP_MULTICAST_IF` to `127.0.0.1`. The e2e multicast fixtures already pass `-r lo`.
-- **Decodable stream for the web player**: the e2e RTP helpers emit TS *null* packets, which relay
-  fine but cannot be decoded by `/player`. To actually exercise playback/decoding, feed the daemon a
-  real H.264+AAC MPEG-TS via `ffmpeg` (installed at `/usr/bin/ffmpeg`) over RTP multicast on
-  loopback, then point a channel at that group. A client (the player) joining a live stream mid-GOP
-  can only start decoding once it sees SPS/PPS + PAT/PMT, so the encoder MUST repeat headers:
-  `ffmpeg -re -f lavfi -i testsrc2=size=1280x720:rate=25 -f lavfi -i sine=frequency=440 -c:v libx264 -tune zerolatency -x264-params "keyint=25:min-keyint=25:scenecut=0:repeat-headers=1" -c:a aac -ac 2 -mpegts_flags +resend_headers -pat_period 0.2 -f rtp_mpegts "rtp://239.255.0.1:9988?localaddr=127.0.0.1&ttl=1&pkt_size=1316"`.
-  Without `repeat-headers=1` / `+resend_headers` the player stalls or shows a decode/playback error
-  even though the bytes are flowing.
 - **Multi-scenario player dev lab**: `tools/devlab/devlab.py` (run via `uv run python`) starts mock
   upstreams for HLS live (both HLS-TS and HLS-fMP4 segment specs), HLS/RTSP catchup, and RTP multicast
   (组播) mpegts live, across `h264-mp2`, `h264-aac`, `hevc-aac`, `hevc-ac3`, `hevc-eac3`; `--ts-file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,22 @@ RTP/IPTV multicast-to-HTTP streaming daemon written in C, with a React/TypeScrip
 - Use npm/yarn — this project uses pnpm
 - Use autotools — this project uses CMake
 - Add dependencies without discussing first
+
+## Cursor Cloud specific instructions
+
+Toolchain is pre-installed and refreshed by the startup update script (`pnpm install --frozen-lockfile`
+then `uv sync --group dev`). Standard commands live in `package.json` scripts and the `build-run` /
+`e2e` skills — use those rather than reinventing them.
+
+Non-obvious gotchas discovered during setup:
+
+- **Node version**: the project pins Node `lts/krypton` (v24) via `.nvmrc`; nvm's default alias is set
+  to it, so a login shell resolves Node 24, the corepack `pnpm@11.9.0`, and `uv`. A bare non-login
+  shell may instead pick up the system `/exec-daemon/node` (v22) that shadows nvm — run inside a login
+  shell (or `nvm use`) when the exact version matters.
+- **`-v` takes a numeric argument**: in this build `-v` is `--verbose <level>` (e.g. `-v 4`), NOT a
+  stackable flag. `./build/rtp2httpd ... -v -v -v` fails with "option requires an argument". Set
+  `verbosity` in the config file or pass `-v <0-4>`.
+- **Loopback multicast**: to stream/receive RTP multicast on this VM (manual testing or multicast e2e
+  tests), start the daemon with `-r lo` so it joins the group on the loopback interface; senders must
+  set `IP_MULTICAST_IF` to `127.0.0.1`. The e2e multicast fixtures already pass `-r lo`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,9 @@ Non-obvious gotchas discovered during setup:
   Without `repeat-headers=1` / `+resend_headers` the player stalls or shows a decode/playback error
   even though the bytes are flowing.
 - **Multi-scenario player dev lab**: `tools/devlab/devlab.py` (run via `uv run python`) starts mock
-  upstreams for HLS live/catchup, RTSP/mpegts catchup, and RTP multicast (组播) mpegts live, across
-  `h264-mp2`, `hevc-aac`, `hevc-ac3`, `hevc-eac3`; `--ts-file PATH` republishes an arbitrary `.ts`
+  upstreams for HLS live (both HLS-TS and HLS-fMP4 segment specs), HLS/RTSP catchup, and RTP multicast
+  (组播) mpegts live, across `h264-mp2`, `h264-aac`, `hevc-aac`, `hevc-ac3`, `hevc-eac3`; `--ts-file
+  PATH` republishes an arbitrary `.ts`
   file (stream-copied, looped) as a multicast channel for debugging user-reported streams. It writes
   an rtp2httpd config (run the daemon with `-r lo` for the multicast channels); see
   `tools/devlab/README.md`. Catchup video burns the requested `playseek` time into the picture so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,11 @@ Non-obvious gotchas discovered during setup:
 - **Loopback multicast**: to stream/receive RTP multicast on this VM (manual testing or multicast e2e
   tests), start the daemon with `-r lo` so it joins the group on the loopback interface; senders must
   set `IP_MULTICAST_IF` to `127.0.0.1`. The e2e multicast fixtures already pass `-r lo`.
+- **Decodable stream for the web player**: the e2e RTP helpers emit TS *null* packets, which relay
+  fine but cannot be decoded by `/player`. To actually exercise playback/decoding, feed the daemon a
+  real H.264+AAC MPEG-TS via `ffmpeg` (installed at `/usr/bin/ffmpeg`) over RTP multicast on
+  loopback, then point a channel at that group. A client (the player) joining a live stream mid-GOP
+  can only start decoding once it sees SPS/PPS + PAT/PMT, so the encoder MUST repeat headers:
+  `ffmpeg -re -f lavfi -i testsrc2=size=1280x720:rate=25 -f lavfi -i sine=frequency=440 -c:v libx264 -tune zerolatency -x264-params "keyint=25:min-keyint=25:scenecut=0:repeat-headers=1" -c:a aac -ac 2 -mpegts_flags +resend_headers -pat_period 0.2 -f rtp_mpegts "rtp://239.255.0.1:9988?localaddr=127.0.0.1&ttl=1&pkt_size=1316"`.
+  Without `repeat-headers=1` / `+resend_headers` the player stalls or shows a decode/playback error
+  even though the bytes are flowing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,8 @@ Non-obvious notes:
   an rtp2httpd config (run the daemon with `-r lo` for the multicast channels); see
   `tools/devlab/README.md`. Catchup video burns the requested `playseek` time into the picture so
   seek correctness is visible. Two non-obvious gotchas it encodes:
-  (1) the web player's `buildCatchupSegments` expects each `catchup-source` window to return TS, not a
-  sub-`.m3u8`, so catchup endpoints stream TS per window; (2) ffmpeg `drawtext` mis-parses a `box*`
+  (1) the web player's `buildCatchupSegments` expands `catchup-source` per time window — HLS catchup
+  returns an HLS VOD `m3u8`+`.ts` per window (the loader detects the nested playlist), while
+  mpegts/RTSP catchup streams continuous TS per window; (2) ffmpeg `drawtext` mis-parses a `box*`
   option placed before a `text=` containing a `%{...}` expansion, and `%{...:...}` expansions with
   colon args fight filtergraph escaping — prefer `borderw`/`bordercolor` and colon-free text.

--- a/tools/devlab/README.md
+++ b/tools/devlab/README.md
@@ -15,8 +15,8 @@ needs to support:
 
 - `h264-mp2`  = H.264 video + MPEG-1/2 Layer II audio
 - `hevc-aac`  = H.265/HEVC video + AAC audio
-- `hevc-ac3`  = H.265/HEVC video + AC-3 audio   (北京卫视 4K style)
-- `hevc-eac3` = H.265/HEVC video + E-AC-3 audio (北京卫视 4K style)
+- `hevc-ac3`  = H.265/HEVC video + AC-3 audio
+- `hevc-eac3` = H.265/HEVC video + E-AC-3 audio
 
 HLS live is offered in both segment specs: **HLS-TS** (MPEG-TS `.ts` segments)
 and **HLS-fMP4** (an `init.mp4` referenced via `#EXT-X-MAP` + `.m4s` fragments).

--- a/tools/devlab/README.md
+++ b/tools/devlab/README.md
@@ -1,0 +1,63 @@
+# devlab — mock IPTV upstreams for web-player development
+
+`devlab.py` spins up self-contained upstream servers (no external network) that
+rtp2httpd can proxy, so you can develop the web player against the scenarios it
+needs to support:
+
+| Scenario        | Delivery            | rtp2httpd proxy | Codecs                    |
+| --------------- | ------------------- | --------------- | ------------------------- |
+| HLS live        | HTTP `.m3u8` + TS   | `/http`         | `h264-mp2`, `hevc-aac`    |
+| HLS catchup     | HTTP TS (`playseek`)| `/http`         | `h264-mp2`, `hevc-aac`    |
+| mpegts catchup  | RTSP TS (`playseek`)| `/rtsp`         | `h264-mp2`, `hevc-aac`    |
+
+(Plain multicast mpegts live is already covered without this lab — see the
+`build-run` skill.)
+
+- `h264-mp2` = H.264 video + MPEG-1/2 Layer II audio
+- `hevc-aac` = H.265/HEVC video + AAC audio
+
+## Catchup correctness is visible
+
+Catchup video burns the **requested** `playseek` begin time into every frame
+(`SEEK <yyyy-mm-dd hh-mm-ss> UTC`) plus an advancing elapsed counter. Request a
+`playseek` starting at 08:30:00 and the picture shows `SEEK 2026-06-30 08-30-00
+UTC` — proving the time → picture mapping end to end.
+
+## Usage
+
+```bash
+# 1. start the upstreams (writes /tmp/r2h-devlab.conf)
+uv run python tools/devlab/devlab.py
+
+# 2. in another shell, run rtp2httpd against the generated config
+./build/rtp2httpd -c /tmp/r2h-devlab.conf -r lo
+
+# 3. open the player and pick a channel
+#    http://127.0.0.1:5140/player
+```
+
+Requires `ffmpeg` on PATH (`libx264`, `libx265`, `aac`, `mp2`). Defaults: HTTP
+origin `127.0.0.1:8881`, RTSP origin `127.0.0.1:8554`, rtp2httpd port `5140`.
+Run `uv run python tools/devlab/devlab.py --help` for options.
+
+## Verifying a scenario without the browser
+
+```bash
+# live codecs
+ffprobe -v error -show_entries stream=codec_type,codec_name \
+  "http://127.0.0.1:5140/HLS/HLS%20%28hevc-aac%29"
+
+# catchup: extract a frame and confirm the burned SEEK time matches the request
+ffmpeg -ss 9 -i "http://127.0.0.1:5140/mpegts/mpegts%20%28h264-mp2%29/catchup?playseek=20260630083000-20260630093000" \
+  -frames:v 1 -y /tmp/seek.png
+```
+
+## Notes
+
+- HEVC video playback in the browser depends on the browser's Media Source
+  Extensions HEVC support; Chromium on Linux often lacks it even though the
+  stream/relay is correct. Use `ffprobe`/frame extraction to validate the relay.
+- The catchup endpoints stream TS per requested window (what the player's
+  `buildCatchupSegments` expects), so playback starts immediately. An additional
+  HLS-VOD catchup endpoint (`/catchup/<profile>/index.m3u8?playseek=...`) exists
+  for testing the daemon's `.m3u8` rewrite directly via curl.

--- a/tools/devlab/README.md
+++ b/tools/devlab/README.md
@@ -8,7 +8,7 @@ needs to support:
 | --------------- | ----------------------- | --------------- | ----------------------------------- |
 | HLS-TS live     | HTTP `.m3u8` + `.ts`    | `/http`         | `h264-mp2`, `hevc-aac`              |
 | HLS-fMP4 live   | HTTP `.m3u8` + `.m4s`   | `/http`         | `h264-aac`, `hevc-aac`              |
-| HLS catchup     | HTTP TS (`playseek`)    | `/http`         | all of the above                    |
+| HLS catchup     | HTTP HLS VOD (`playseek`)| `/http`        | all of the above                    |
 | mpegts catchup  | RTSP TS (`playseek`)    | `/rtsp`         | `h264-mp2`, `hevc-aac`              |
 | mpegts live     | RTP multicast (组播)    | `/rtp` (`-r lo`)| `h264-mp2`, `hevc-ac3`, `hevc-eac3` |
 | external file   | RTP multicast (looped)  | `/rtp` (`-r lo`)| whatever the `.ts` file contains    |
@@ -21,6 +21,12 @@ needs to support:
 HLS live is offered in both segment specs: **HLS-TS** (MPEG-TS `.ts` segments)
 and **HLS-fMP4** (an `init.mp4` referenced via `#EXT-X-MAP` + `.m4s` fragments).
 fMP4 carries AAC audio (MP2-in-MP4 is unsupported), so fMP4 channels use AAC.
+
+**HLS catchup** is a real HLS VOD: each `playseek` window returns an
+`index.m3u8` (`#EXT-X-PLAYLIST-TYPE:VOD`) listing fixed-duration `.ts` slices.
+The playlist is produced instantly; each slice is encoded lazily on first
+request with that slice's absolute wall-clock time burned in, so even a
+multi-hour window is time-correct without pre-encoding the whole thing.
 
 Multicast channels use groups `239.255.0.20+` on `--mcast-port` (default 5004);
 rtp2httpd must be run with `-r lo` to join them on loopback.
@@ -79,7 +85,7 @@ ffmpeg -ss 9 -i "http://127.0.0.1:5140/mpegts/mpegts%20%28h264-mp2%29/catchup?pl
   both even though the stream/relay is correct. Use `ffprobe`/frame extraction
   to validate the relay (the `hevc-ac3`/`hevc-eac3` channels are mainly for
   relay/transmux development and capable players/devices).
-- The catchup endpoints stream TS per requested window (what the player's
-  `buildCatchupSegments` expects), so playback starts immediately. An additional
-  HLS-VOD catchup endpoint (`/catchup/<profile>/index.m3u8?playseek=...`) exists
-  for testing the daemon's `.m3u8` rewrite directly via curl.
+- HLS catchup is an HLS VOD (`m3u8` + `.ts` slices); the player expands
+  `catchup-source` per window via `buildCatchupSegments` and the loader detects
+  the nested playlist (HLS mode). mpegts/RTSP catchup instead streams continuous
+  TS per window.

--- a/tools/devlab/README.md
+++ b/tools/devlab/README.md
@@ -4,17 +4,32 @@
 rtp2httpd can proxy, so you can develop the web player against the scenarios it
 needs to support:
 
-| Scenario        | Delivery            | rtp2httpd proxy | Codecs                    |
-| --------------- | ------------------- | --------------- | ------------------------- |
-| HLS live        | HTTP `.m3u8` + TS   | `/http`         | `h264-mp2`, `hevc-aac`    |
-| HLS catchup     | HTTP TS (`playseek`)| `/http`         | `h264-mp2`, `hevc-aac`    |
-| mpegts catchup  | RTSP TS (`playseek`)| `/rtsp`         | `h264-mp2`, `hevc-aac`    |
+| Scenario        | Delivery                | rtp2httpd proxy | Codecs                              |
+| --------------- | ----------------------- | --------------- | ----------------------------------- |
+| HLS live        | HTTP `.m3u8` + TS       | `/http`         | `h264-mp2`, `hevc-aac`              |
+| HLS catchup     | HTTP TS (`playseek`)    | `/http`         | `h264-mp2`, `hevc-aac`              |
+| mpegts catchup  | RTSP TS (`playseek`)    | `/rtsp`         | `h264-mp2`, `hevc-aac`              |
+| mpegts live     | RTP multicast (组播)    | `/rtp` (`-r lo`)| `h264-mp2`, `hevc-ac3`, `hevc-eac3` |
+| external file   | RTP multicast (looped)  | `/rtp` (`-r lo`)| whatever the `.ts` file contains    |
 
-(Plain multicast mpegts live is already covered without this lab — see the
-`build-run` skill.)
+- `h264-mp2`  = H.264 video + MPEG-1/2 Layer II audio
+- `hevc-aac`  = H.265/HEVC video + AAC audio
+- `hevc-ac3`  = H.265/HEVC video + AC-3 audio   (北京卫视 4K style)
+- `hevc-eac3` = H.265/HEVC video + E-AC-3 audio (北京卫视 4K style)
 
-- `h264-mp2` = H.264 video + MPEG-1/2 Layer II audio
-- `hevc-aac` = H.265/HEVC video + AAC audio
+Multicast channels use groups `239.255.0.20+` on `--mcast-port` (default 5004);
+rtp2httpd must be run with `-r lo` to join them on loopback.
+
+## Debugging a user-provided .ts file
+
+Publish any external `.ts` as a multicast live channel (stream-copied, so the
+exact codecs/bitstream are relayed) — useful for reproducing a stream attached
+to a bug report:
+
+```bash
+uv run python tools/devlab/devlab.py --ts-file /path/to/user-report.ts
+# adds a "file <name>" channel proxied through rtp2httpd
+```
 
 ## Catchup correctness is visible
 
@@ -54,9 +69,11 @@ ffmpeg -ss 9 -i "http://127.0.0.1:5140/mpegts/mpegts%20%28h264-mp2%29/catchup?pl
 
 ## Notes
 
-- HEVC video playback in the browser depends on the browser's Media Source
-  Extensions HEVC support; Chromium on Linux often lacks it even though the
-  stream/relay is correct. Use `ffprobe`/frame extraction to validate the relay.
+- HEVC video and AC-3/E-AC-3 audio playback in the browser depend on the
+  browser's Media Source Extensions support; Chromium on Linux usually lacks
+  both even though the stream/relay is correct. Use `ffprobe`/frame extraction
+  to validate the relay (the `hevc-ac3`/`hevc-eac3` channels are mainly for
+  relay/transmux development and capable players/devices).
 - The catchup endpoints stream TS per requested window (what the player's
   `buildCatchupSegments` expects), so playback starts immediately. An additional
   HLS-VOD catchup endpoint (`/catchup/<profile>/index.m3u8?playseek=...`) exists

--- a/tools/devlab/README.md
+++ b/tools/devlab/README.md
@@ -6,8 +6,9 @@ needs to support:
 
 | Scenario        | Delivery                | rtp2httpd proxy | Codecs                              |
 | --------------- | ----------------------- | --------------- | ----------------------------------- |
-| HLS live        | HTTP `.m3u8` + TS       | `/http`         | `h264-mp2`, `hevc-aac`              |
-| HLS catchup     | HTTP TS (`playseek`)    | `/http`         | `h264-mp2`, `hevc-aac`              |
+| HLS-TS live     | HTTP `.m3u8` + `.ts`    | `/http`         | `h264-mp2`, `hevc-aac`              |
+| HLS-fMP4 live   | HTTP `.m3u8` + `.m4s`   | `/http`         | `h264-aac`, `hevc-aac`              |
+| HLS catchup     | HTTP TS (`playseek`)    | `/http`         | all of the above                    |
 | mpegts catchup  | RTSP TS (`playseek`)    | `/rtsp`         | `h264-mp2`, `hevc-aac`              |
 | mpegts live     | RTP multicast (组播)    | `/rtp` (`-r lo`)| `h264-mp2`, `hevc-ac3`, `hevc-eac3` |
 | external file   | RTP multicast (looped)  | `/rtp` (`-r lo`)| whatever the `.ts` file contains    |
@@ -16,6 +17,10 @@ needs to support:
 - `hevc-aac`  = H.265/HEVC video + AAC audio
 - `hevc-ac3`  = H.265/HEVC video + AC-3 audio   (北京卫视 4K style)
 - `hevc-eac3` = H.265/HEVC video + E-AC-3 audio (北京卫视 4K style)
+
+HLS live is offered in both segment specs: **HLS-TS** (MPEG-TS `.ts` segments)
+and **HLS-fMP4** (an `init.mp4` referenced via `#EXT-X-MAP` + `.m4s` fragments).
+fMP4 carries AAC audio (MP2-in-MP4 is unsupported), so fMP4 channels use AAC.
 
 Multicast channels use groups `239.255.0.20+` on `--mcast-port` (default 5004);
 rtp2httpd must be run with `-r lo` to join them on loopback.

--- a/tools/devlab/devlab.py
+++ b/tools/devlab/devlab.py
@@ -13,8 +13,8 @@ Codec combinations covered:
 
   * ``h264-mp2``   : H.264 video + MPEG-1/2 Layer II audio
   * ``hevc-aac``   : H.265/HEVC video + AAC audio
-  * ``hevc-ac3``   : H.265/HEVC video + AC-3 audio   (北京卫视 4K style)
-  * ``hevc-eac3``  : H.265/HEVC video + E-AC-3 audio (北京卫视 4K style)
+  * ``hevc-ac3``   : H.265/HEVC video + AC-3 audio
+  * ``hevc-eac3``  : H.265/HEVC video + E-AC-3 audio
 
 Any external .ts file can also be published as a multicast live channel
 (looped, stream-copied) via ``--ts-file PATH`` -- handy for debugging a stream
@@ -50,7 +50,7 @@ from urllib.parse import parse_qs, urlparse
 FONT = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
 # Profiles used for RTSP scenarios (must be browser-friendly enough to test).
 PROFILES = ("h264-mp2", "hevc-aac")
-# Profiles offered as multicast (组播) live channels, incl. 北京卫视 4K style combos.
+# Profiles offered as multicast (组播) live channels.
 MCAST_PROFILES = ("h264-mp2", "hevc-ac3", "hevc-eac3")
 
 # HLS live channels covering both segment specs: HLS-TS (MPEG-TS segments) and
@@ -721,8 +721,8 @@ def main() -> int:
     # Multicast (组播) live: generated codec profiles + any external .ts files.
     mcast_labels = {
         "h264-mp2": "mcast (h264-mp2)",
-        "hevc-ac3": "BTV-4K sim (hevc-ac3)",
-        "hevc-eac3": "BTV-4K sim (hevc-eac3)",
+        "hevc-ac3": "mcast (hevc-ac3)",
+        "hevc-eac3": "mcast (hevc-eac3)",
     }
     senders: list[MulticastLive] = []
     mcast_channels: list[tuple[str, str, str]] = []

--- a/tools/devlab/devlab.py
+++ b/tools/devlab/devlab.py
@@ -7,21 +7,27 @@ can proxy, covering the scenarios needed to develop the web player:
   * HLS live           (HTTP, .m3u8 + TS segments)
   * HLS catchup        (HTTP, time-shift driven by the ``playseek`` query)
   * mpegts catchup     (RTSP time-shift driven by ``playseek`` on the URI)
+  * mpegts live        (RTP multicast / 组播, joined by rtp2httpd via ``-r lo``)
 
-Each scenario is generated for two codec combinations:
+Codec combinations covered:
 
-  * ``h264-mp2``  : H.264 video + MPEG-1/2 Layer II audio
-  * ``hevc-aac``  : H.265/HEVC video + AAC audio
+  * ``h264-mp2``   : H.264 video + MPEG-1/2 Layer II audio
+  * ``hevc-aac``   : H.265/HEVC video + AAC audio
+  * ``hevc-ac3``   : H.265/HEVC video + AC-3 audio   (北京卫视 4K style)
+  * ``hevc-eac3``  : H.265/HEVC video + E-AC-3 audio (北京卫视 4K style)
 
-Catchup correctness is made *visible*: catchup video burns the requested wall
-clock into every frame using ffmpeg ``drawtext`` with ``%{pts:gmtime:<begin>}``.
-So if you request ``playseek`` starting at 12:00:00 UTC, the picture shows a
-clock that starts at 12:00:00 UTC and advances -- proving the time -> picture
-mapping end to end.
+Any external .ts file can also be published as a multicast live channel
+(looped, stream-copied) via ``--ts-file PATH`` -- handy for debugging a stream
+a user attached to an issue.
+
+Catchup correctness is made *visible*: catchup video burns the requested time
+into every frame (``SEEK <yyyy-mm-dd hh-mm-ss> UTC`` + an advancing counter).
+So if you request ``playseek`` starting at 12:00:00 UTC, the picture shows
+``SEEK 2026-06-30 12-00-00 UTC`` -- proving the time -> picture mapping.
 
 The script only starts the *upstreams* and writes an rtp2httpd config; it does
-not launch rtp2httpd itself (run that separately, see ``--print-run-cmd``).
-Requires ``ffmpeg`` on PATH (or pass ``--ffmpeg``).
+not launch rtp2httpd itself (it prints the run command). Requires ``ffmpeg`` on
+PATH (or pass ``--ffmpeg``); multicast channels need ``rtp2httpd ... -r lo``.
 """
 
 from __future__ import annotations
@@ -42,7 +48,10 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
 FONT = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+# Profiles used for HLS/RTSP scenarios (must be browser-friendly enough to test).
 PROFILES = ("h264-mp2", "hevc-aac")
+# Profiles offered as multicast (组播) live channels, incl. 北京卫视 4K style combos.
+MCAST_PROFILES = ("h264-mp2", "hevc-ac3", "hevc-eac3")
 
 # ---------------------------------------------------------------------------
 # ffmpeg argument helpers
@@ -52,7 +61,7 @@ PROFILES = ("h264-mp2", "hevc-aac")
 def video_args(profile: str) -> list[str]:
     """Encoder args for the video stream of *profile* (keyframe every second,
     headers repeated so a client joining mid-stream can start decoding)."""
-    if profile == "h264-mp2":
+    if profile.startswith("h264"):
         return [
             "-c:v",
             "libx264",
@@ -88,10 +97,10 @@ def video_args(profile: str) -> list[str]:
 
 
 def audio_args(profile: str) -> list[str]:
-    """Encoder args for the audio stream of *profile*."""
-    if profile == "h264-mp2":
-        return ["-c:a", "mp2", "-b:a", "192k", "-ar", "48000", "-ac", "2"]
-    return ["-c:a", "aac", "-b:a", "128k", "-ar", "48000", "-ac", "2"]
+    """Encoder args for the audio stream of *profile* (codec from the suffix)."""
+    acodec = profile.split("-", 1)[1]  # mp2 | aac | ac3 | eac3
+    bitrate = {"mp2": "192k", "aac": "128k", "ac3": "192k", "eac3": "192k"}.get(acodec, "128k")
+    return ["-c:a", acodec, "-b:a", bitrate, "-ar", "48000", "-ac", "2"]
 
 
 def _esc(text: str) -> str:
@@ -125,12 +134,12 @@ def catchup_filter(profile: str, begin_epoch: int) -> str:
     return f"{label},{seek},{elapsed}"
 
 
-def lavfi_inputs() -> list[str]:
+def lavfi_inputs(size: str = "1280x720") -> list[str]:
     return [
         "-f",
         "lavfi",
         "-i",
-        "testsrc2=size=1280x720:rate=25",
+        f"testsrc2=size={size}:rate=25",
         "-f",
         "lavfi",
         "-i",
@@ -537,17 +546,81 @@ class RTSPOrigin:
 
 
 # ---------------------------------------------------------------------------
+# Multicast (组播) live sender
+# ---------------------------------------------------------------------------
+
+
+class MulticastLive:
+    """Streams RTP/MPEG-TS to a multicast group (rtp2httpd joins it via -r lo).
+
+    Either generates content for a codec *profile* (with a LIVE overlay) or
+    stream-copies an arbitrary external .ts *ts_file* (looped) so a real-world
+    stream from a bug report can be replayed for debugging.
+    """
+
+    def __init__(
+        self,
+        ffmpeg: str,
+        host: str,
+        group: str,
+        port: int,
+        profile: str | None = None,
+        ts_file: str | None = None,
+        size: str = "960x540",
+    ):
+        self.ffmpeg = ffmpeg
+        self.host = host
+        self.group = group
+        self.port = port
+        self.profile = profile
+        self.ts_file = ts_file
+        self.size = size
+        self.proc: subprocess.Popen[bytes] | None = None
+
+    def url(self) -> str:
+        return f"rtp://{self.group}:{self.port}"
+
+    def _cmd(self) -> list[str]:
+        common = [self.ffmpeg, "-hide_banner", "-loglevel", "error"]
+        out = f"{self.url()}?localaddr={self.host}&ttl=1&pkt_size=1316"
+        if self.ts_file:
+            # Stream-copy the original bitstream so the exact codecs are relayed.
+            return [*common, "-re", "-stream_loop", "-1", "-i", self.ts_file, "-c", "copy", "-f", "rtp_mpegts", out]
+        prof = self.profile or "h264-mp2"
+        return [
+            *common,
+            "-re",
+            *lavfi_inputs(self.size),
+            "-vf",
+            live_filter(prof),
+            *video_args(prof),
+            *audio_args(prof),
+            "-f",
+            "rtp_mpegts",
+            out,
+        ]
+
+    def start(self) -> None:
+        self.proc = subprocess.Popen(self._cmd(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def stop(self) -> None:
+        if self.proc and self.proc.poll() is None:
+            self.proc.terminate()
+
+
+# ---------------------------------------------------------------------------
 # Config generation
 # ---------------------------------------------------------------------------
 
 
-def build_services_m3u(http_hostport: str, rtsp_hostport: str) -> str:
-    """Build the [services] M3U covering all scenarios x both codecs.
+def build_services_m3u(http_hostport: str, rtsp_hostport: str, mcast_channels: list[tuple[str, str, str]]) -> str:
+    """Build the [services] M3U covering all scenarios.
 
-    Each HLS channel is HLS-live (``.m3u8``) with HTTP catchup; each mpegts
-    channel is RTSP-live with RTSP catchup. Catchup sources stream TS per time
-    window (what the web player's ``buildCatchupSegments`` expects) so playback
-    starts immediately and the requested time is burned into the picture.
+    HLS channels are HLS-live (``.m3u8``) with HTTP catchup; RTSP channels are
+    mpegts-live with RTSP catchup. Catchup sources stream TS per time window
+    (what the web player's ``buildCatchupSegments`` expects) so playback starts
+    immediately and the requested time is burned into the picture. ``mcast_channels``
+    are RTP-multicast (组播) live channels passed as ``(group_title, name, rtp_url)``.
     """
     tpl = "playseek={utc:YmdHMS}-{utcend:YmdHMS}"
     lines = ["#EXTM3U"]
@@ -565,6 +638,8 @@ def build_services_m3u(http_hostport: str, rtsp_hostport: str) -> str:
             f'#EXTINF:-1 group-title="mpegts" catchup="default" catchup-source="{src}",mpegts ({prof})',
             f"rtsp://{rtsp_hostport}/live/{prof}",
         ]
+    for group_title, name, rtp_url in mcast_channels:
+        lines += [f'#EXTINF:-1 group-title="{group_title}",{name}', rtp_url]
     return "\n".join(lines) + "\n"
 
 
@@ -589,6 +664,15 @@ def main() -> int:
     ap.add_argument("--ffmpeg", default=shutil.which("ffmpeg") or "ffmpeg")
     ap.add_argument("--config", default="/tmp/r2h-devlab.conf")
     ap.add_argument("--workdir", default=tempfile.mkdtemp(prefix="r2h-devlab-"))
+    ap.add_argument("--mcast-port", type=int, default=5004, help="UDP port for multicast (组播) live channels")
+    ap.add_argument("--mcast-base", type=int, default=20, help="last octet of first 239.255.0.x multicast group")
+    ap.add_argument(
+        "--ts-file",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="publish an external .ts file as a multicast live channel (repeatable; for debugging)",
+    )
     args = ap.parse_args()
 
     if not shutil.which(args.ffmpeg) and not os.path.isfile(args.ffmpeg):
@@ -611,11 +695,41 @@ def main() -> int:
     rtsp = RTSPOrigin(args.ffmpeg, args.host, args.rtsp_port)
     rtsp.start()
 
+    # Multicast (组播) live: generated codec profiles + any external .ts files.
+    mcast_labels = {
+        "h264-mp2": "mcast (h264-mp2)",
+        "hevc-ac3": "BTV-4K sim (hevc-ac3)",
+        "hevc-eac3": "BTV-4K sim (hevc-eac3)",
+    }
+    senders: list[MulticastLive] = []
+    mcast_channels: list[tuple[str, str, str]] = []
+    octet = args.mcast_base
+    for prof in MCAST_PROFILES:
+        group = f"239.255.0.{octet}"
+        octet += 1
+        s = MulticastLive(args.ffmpeg, args.host, group, args.mcast_port, profile=prof)
+        senders.append(s)
+        mcast_channels.append(("mpegts (multicast)", mcast_labels.get(prof, f"mcast ({prof})"), s.url()))
+    for path in args.ts_file:
+        if not os.path.isfile(path):
+            print(f"WARNING: --ts-file not found, skipping: {path}", file=sys.stderr)
+            continue
+        group = f"239.255.0.{octet}"
+        octet += 1
+        s = MulticastLive(args.ffmpeg, args.host, group, args.mcast_port, ts_file=path)
+        senders.append(s)
+        mcast_channels.append(("mpegts (file)", f"file {os.path.basename(path)}", s.url()))
+    for s in senders:
+        s.start()
+
     http_hostport = f"{args.host}:{args.http_port}"
     rtsp_hostport = f"{args.host}:{args.rtsp_port}"
-    write_config(args.config, args.r2h_port, build_services_m3u(http_hostport, rtsp_hostport))
+    write_config(args.config, args.r2h_port, build_services_m3u(http_hostport, rtsp_hostport, mcast_channels))
 
     print(f"devlab up: HTTP {http_hostport}  RTSP {rtsp_hostport}  workdir {args.workdir}")
+    print(
+        f"multicast live channels: {len(mcast_channels)} (groups 239.255.0.{args.mcast_base}+, port {args.mcast_port})"
+    )
     print(f"wrote rtp2httpd config: {args.config}")
     print(f"run rtp2httpd:  ./build/rtp2httpd -c {args.config} -r lo")
     print("Ctrl-C to stop.")
@@ -630,6 +744,8 @@ def main() -> int:
         rtsp.stop()
         for gen in live:
             gen.stop()
+        for s in senders:
+            s.stop()
     return 0
 
 

--- a/tools/devlab/devlab.py
+++ b/tools/devlab/devlab.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""Local dev lab: mock IPTV upstreams for rtp2httpd web-player development.
+
+Spins up self-contained upstream servers (no external network) that rtp2httpd
+can proxy, covering the scenarios needed to develop the web player:
+
+  * HLS live           (HTTP, .m3u8 + TS segments)
+  * HLS catchup        (HTTP, time-shift driven by the ``playseek`` query)
+  * mpegts catchup     (RTSP time-shift driven by ``playseek`` on the URI)
+
+Each scenario is generated for two codec combinations:
+
+  * ``h264-mp2``  : H.264 video + MPEG-1/2 Layer II audio
+  * ``hevc-aac``  : H.265/HEVC video + AAC audio
+
+Catchup correctness is made *visible*: catchup video burns the requested wall
+clock into every frame using ffmpeg ``drawtext`` with ``%{pts:gmtime:<begin>}``.
+So if you request ``playseek`` starting at 12:00:00 UTC, the picture shows a
+clock that starts at 12:00:00 UTC and advances -- proving the time -> picture
+mapping end to end.
+
+The script only starts the *upstreams* and writes an rtp2httpd config; it does
+not launch rtp2httpd itself (run that separately, see ``--print-run-cmd``).
+Requires ``ffmpeg`` on PATH (or pass ``--ffmpeg``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+FONT = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+PROFILES = ("h264-mp2", "hevc-aac")
+
+# ---------------------------------------------------------------------------
+# ffmpeg argument helpers
+# ---------------------------------------------------------------------------
+
+
+def video_args(profile: str) -> list[str]:
+    """Encoder args for the video stream of *profile* (keyframe every second,
+    headers repeated so a client joining mid-stream can start decoding)."""
+    if profile == "h264-mp2":
+        return [
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-tune",
+            "zerolatency",
+            "-profile:v",
+            "high",
+            "-pix_fmt",
+            "yuv420p",
+            "-x264-params",
+            "keyint=25:min-keyint=25:scenecut=0:repeat-headers=1",
+            "-b:v",
+            "2M",
+        ]
+    return [
+        "-c:v",
+        "libx265",
+        "-preset",
+        "ultrafast",
+        "-tune",
+        "zerolatency",
+        "-pix_fmt",
+        "yuv420p",
+        "-tag:v",
+        "hvc1",
+        "-x265-params",
+        "keyint=25:min-keyint=25:scenecut=0:repeat-headers=1",
+        "-b:v",
+        "2M",
+    ]
+
+
+def audio_args(profile: str) -> list[str]:
+    """Encoder args for the audio stream of *profile*."""
+    if profile == "h264-mp2":
+        return ["-c:a", "mp2", "-b:a", "192k", "-ar", "48000", "-ac", "2"]
+    return ["-c:a", "aac", "-b:a", "128k", "-ar", "48000", "-ac", "2"]
+
+
+def _esc(text: str) -> str:
+    """Escape a literal string for an ffmpeg drawtext ``text=`` value."""
+    return text.replace("\\", "\\\\").replace(":", r"\:").replace("'", r"\'")
+
+
+def _drawtext(text: str, y: int, expansion: bool) -> str:
+    # Use border (not box) for legibility: ffmpeg's drawtext mis-parses a box*
+    # option that precedes a text= value containing a %{...} expansion.
+    style = f"fontfile={FONT}:fontcolor=white:fontsize=44:borderw=4:bordercolor=black:x=24:y={y}"
+    if expansion:
+        return f"drawtext={style}:text={text}"
+    return f"drawtext={style}:text={_esc(text)}"
+
+
+def live_filter(profile: str) -> str:
+    label = _drawtext(f"LIVE {profile}", 24, expansion=False)
+    clock = _drawtext(r"%{localtime}", 88, expansion=True)
+    return f"{label},{clock}"
+
+
+def catchup_filter(profile: str, begin_epoch: int) -> str:
+    # Burn the *requested* time into the picture so seek correctness is visible:
+    # SEEK shows the playseek begin time; the elapsed counter shows it advancing.
+    # (Colon-free time format avoids ffmpeg drawtext expansion/escaping pitfalls.)
+    iso = datetime.fromtimestamp(begin_epoch, timezone.utc).strftime("%Y-%m-%d %H-%M-%S")
+    label = _drawtext(f"CATCHUP {profile}", 24, expansion=False)
+    seek = _drawtext(f"SEEK {iso} UTC", 88, expansion=False)
+    elapsed = _drawtext(r"+%{pts}s", 152, expansion=True)
+    return f"{label},{seek},{elapsed}"
+
+
+def lavfi_inputs() -> list[str]:
+    return [
+        "-f",
+        "lavfi",
+        "-i",
+        "testsrc2=size=1280x720:rate=25",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=440:sample_rate=48000",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Time parsing for playseek
+# ---------------------------------------------------------------------------
+
+
+def parse_playseek_begin(playseek: str) -> int:
+    """Return the begin time of a playseek value as a UTC epoch (seconds).
+
+    Accepts the formats rtp2httpd forwards to upstreams: compact
+    ``yyyyMMddHHmmss`` (optionally ``GMT``/``Z`` suffixed) and unix seconds.
+    Falls back to "now" if the value cannot be parsed.
+    """
+    begin = playseek.split("-")[0].strip() if playseek else ""
+    begin = begin.replace("GMT", "").replace("Z", "").replace("T", "")
+    if begin.isdigit() and len(begin) <= 10:
+        return int(begin)
+    if len(begin) >= 14 and begin[:14].isdigit():
+        dt = datetime.strptime(begin[:14], "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
+    return int(time.time())
+
+
+# ---------------------------------------------------------------------------
+# Live HLS generators (background ffmpeg per profile)
+# ---------------------------------------------------------------------------
+
+
+class LiveHLS:
+    """Runs a background ffmpeg that continuously writes a live HLS playlist."""
+
+    def __init__(self, ffmpeg: str, profile: str, outdir: str):
+        self.ffmpeg = ffmpeg
+        self.profile = profile
+        self.outdir = outdir
+        self.proc: subprocess.Popen[bytes] | None = None
+
+    def start(self) -> None:
+        os.makedirs(self.outdir, exist_ok=True)
+        cmd = [
+            self.ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-re",
+            *lavfi_inputs(),
+            "-vf",
+            live_filter(self.profile),
+            *video_args(self.profile),
+            *audio_args(self.profile),
+            "-f",
+            "hls",
+            "-hls_time",
+            "2",
+            "-hls_list_size",
+            "6",
+            "-hls_flags",
+            "delete_segments+append_list+omit_endlist",
+            "-hls_segment_filename",
+            os.path.join(self.outdir, "seg_%05d.ts"),
+            os.path.join(self.outdir, "index.m3u8"),
+        ]
+        self.proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def stop(self) -> None:
+        if self.proc and self.proc.poll() is None:
+            self.proc.terminate()
+
+
+# ---------------------------------------------------------------------------
+# Catchup HLS VOD generation (on demand, cached by begin time)
+# ---------------------------------------------------------------------------
+
+
+class CatchupHLS:
+    """Generates short VOD HLS trees on demand, one per (profile, begin)."""
+
+    def __init__(self, ffmpeg: str, root: str, duration: int = 120):
+        self.ffmpeg = ffmpeg
+        self.root = root
+        self.duration = duration
+        self._locks: dict[str, threading.Lock] = {}
+        self._guard = threading.Lock()
+
+    def _lock_for(self, key: str) -> threading.Lock:
+        with self._guard:
+            return self._locks.setdefault(key, threading.Lock())
+
+    def ensure(self, profile: str, begin_epoch: int) -> str:
+        """Generate (if needed) the VOD for (profile, begin) and return its dir."""
+        key = f"{profile}-{begin_epoch}"
+        outdir = os.path.join(self.root, key)
+        with self._lock_for(key):
+            ready = os.path.join(outdir, "index.m3u8")
+            if os.path.exists(ready):
+                return outdir
+            tmp = outdir + ".tmp"
+            shutil.rmtree(tmp, ignore_errors=True)
+            os.makedirs(tmp, exist_ok=True)
+            cmd = [
+                self.ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                *lavfi_inputs(),
+                "-t",
+                str(self.duration),
+                "-vf",
+                catchup_filter(profile, begin_epoch),
+                *video_args(profile),
+                *audio_args(profile),
+                "-f",
+                "hls",
+                "-hls_time",
+                "2",
+                "-hls_list_size",
+                "0",
+                "-hls_playlist_type",
+                "vod",
+                "-hls_segment_filename",
+                os.path.join(tmp, "seg_%05d.ts"),
+                os.path.join(tmp, "index.m3u8"),
+            ]
+            subprocess.run(cmd, check=True)
+            os.replace(tmp, outdir)
+            return outdir
+
+
+# ---------------------------------------------------------------------------
+# HTTP origin server
+# ---------------------------------------------------------------------------
+
+
+def make_http_handler(
+    host: str, port: int, live_root: str, catchup: CatchupHLS, ffmpeg: str
+) -> type[BaseHTTPRequestHandler]:
+    base = f"http://{host}:{port}"
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002 (http.server API)
+            pass
+
+        def _send(self, code: int, ctype: str, body: bytes) -> None:
+            self.send_response(code)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _serve_file(self, path: str) -> None:
+            if not os.path.isfile(path):
+                self._send(404, "text/plain", b"not found")
+                return
+            ctype = "application/vnd.apple.mpegurl" if path.endswith(".m3u8") else "video/mp2t"
+            with open(path, "rb") as fh:
+                self._send(200, ctype, fh.read())
+
+        def _live(self, parts: list[str]) -> None:
+            # /live/<profile>/<file>
+            profile, fname = parts[1], parts[2]
+            self._serve_file(os.path.join(live_root, profile, fname))
+
+        def _catchup_playlist(self, profile: str, qs: dict[str, list[str]]) -> None:
+            playseek = (qs.get("playseek") or qs.get("tvdr") or [""])[0]
+            begin = parse_playseek_begin(playseek)
+            outdir = catchup.ensure(profile, begin)
+            with open(os.path.join(outdir, "index.m3u8"), encoding="utf-8") as fh:
+                text = fh.read()
+            # Rewrite relative segment names to absolute URLs that embed begin, so
+            # rtp2httpd rewrites them onto its /http proxy and they never collide.
+            text = re.sub(
+                r"^(seg_\d+\.ts)$",
+                lambda m: f"{base}/catchup-seg/{profile}/{begin}/{m.group(1)}",
+                text,
+                flags=re.MULTILINE,
+            )
+            self._send(200, "application/vnd.apple.mpegurl", text.encode())
+
+        def _catchup_ts(self, profile: str, qs: dict[str, list[str]]) -> None:
+            playseek = (qs.get("playseek") or qs.get("tvdr") or [""])[0]
+            begin = parse_playseek_begin(playseek)
+            cmd = [
+                ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-re",
+                *lavfi_inputs(),
+                "-t",
+                "120",
+                "-vf",
+                catchup_filter(profile, begin),
+                *video_args(profile),
+                *audio_args(profile),
+                "-f",
+                "mpegts",
+                "-",
+            ]
+            self.send_response(200)
+            self.send_header("Content-Type", "video/mp2t")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            assert proc.stdout is not None
+            try:
+                while True:
+                    chunk = proc.stdout.read(65536)
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+            except BrokenPipeError, ConnectionError:
+                pass
+            finally:
+                if proc.poll() is None:
+                    proc.terminate()
+
+        def do_GET(self) -> None:  # noqa: N802 (http.server API)
+            parsed = urlparse(self.path)
+            qs = parse_qs(parsed.query)
+            parts = [p for p in parsed.path.split("/") if p]
+            try:
+                if len(parts) == 3 and parts[0] == "live":
+                    self._live(parts)
+                elif len(parts) >= 2 and parts[0] == "catchup" and parts[-1] == "index.m3u8":
+                    self._catchup_playlist(parts[1], qs)
+                elif len(parts) == 4 and parts[0] == "catchup-seg":
+                    self._serve_file(os.path.join(catchup.root, f"{parts[1]}-{parts[2]}", parts[3]))
+                elif len(parts) == 2 and parts[0] == "catchup-ts":
+                    self._catchup_ts(parts[1], qs)
+                else:
+                    self._send(404, "text/plain", b"not found")
+            except BrokenPipeError, ConnectionError:
+                pass
+
+    return Handler
+
+
+# ---------------------------------------------------------------------------
+# RTSP origin server (mpegts catchup + live)
+# ---------------------------------------------------------------------------
+
+
+class RTSPOrigin:
+    """Minimal RTSP server that streams real ffmpeg MPEG-TS over interleaved TCP.
+
+    Honors ``playseek`` taken from the request URI: when present the streamed
+    video burns the requested wall clock into the picture.
+    """
+
+    def __init__(self, ffmpeg: str, host: str, port: int):
+        self.ffmpeg = ffmpeg
+        self.host = host
+        self.port = port
+        self._sock: socket.socket | None = None
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind((self.host, self.port))
+        self._sock.listen(8)
+        self._sock.settimeout(1.0)
+        self._thread = threading.Thread(target=self._accept, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._sock:
+            self._sock.close()
+
+    def _accept(self) -> None:
+        assert self._sock is not None
+        while not self._stop.is_set():
+            try:
+                conn, _addr = self._sock.accept()
+            except TimeoutError, OSError:
+                continue
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    @staticmethod
+    def _profile_from_uri(uri: str) -> str:
+        path = urlparse(uri).path
+        for p in PROFILES:
+            if p in path:
+                return p
+        return "h264-mp2"
+
+    def _ffmpeg_cmd(self, uri: str) -> list[str]:
+        profile = self._profile_from_uri(uri)
+        qs = parse_qs(urlparse(uri).query)
+        playseek = (qs.get("playseek") or qs.get("tvdr") or [""])[0]
+        if playseek:
+            vf = catchup_filter(profile, parse_playseek_begin(playseek))
+        else:
+            vf = live_filter(profile)
+        return [
+            self.ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-re",
+            *lavfi_inputs(),
+            "-vf",
+            vf,
+            *video_args(profile),
+            *audio_args(profile),
+            "-f",
+            "mpegts",
+            "-",
+        ]
+
+    def _handle(self, conn: socket.socket) -> None:
+        conn.settimeout(15.0)
+        play_uri = ""
+        try:
+            while not self._stop.is_set():
+                data = b""
+                while b"\r\n\r\n" not in data:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        return
+                    data += chunk
+                req = data.decode(errors="replace")
+                line0 = req.split("\r\n")[0].split()
+                method = line0[0] if line0 else ""
+                uri = line0[1] if len(line0) > 1 else ""
+                cseq = "1"
+                for ln in req.split("\r\n"):
+                    if ln.lower().startswith("cseq:"):
+                        cseq = ln.split(":", 1)[1].strip()
+                if method == "OPTIONS":
+                    conn.sendall(
+                        f"RTSP/1.0 200 OK\r\nCSeq: {cseq}\r\n"
+                        "Public: OPTIONS, DESCRIBE, SETUP, PLAY, TEARDOWN\r\n\r\n".encode()
+                    )
+                elif method == "DESCRIBE":
+                    sdp = (
+                        "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=devlab\r\n"
+                        "c=IN IP4 0.0.0.0\r\nt=0 0\r\n"
+                        "m=video 0 RTP/AVP 33\r\na=control:*\r\n"
+                    )
+                    conn.sendall(
+                        (
+                            f"RTSP/1.0 200 OK\r\nCSeq: {cseq}\r\n"
+                            f"Content-Base: {uri}\r\n"
+                            "Content-Type: application/sdp\r\n"
+                            f"Content-Length: {len(sdp)}\r\n\r\n{sdp}"
+                        ).encode()
+                    )
+                elif method == "SETUP":
+                    conn.sendall(
+                        f"RTSP/1.0 200 OK\r\nCSeq: {cseq}\r\n"
+                        "Transport: RTP/AVP/TCP;unicast;interleaved=0-1\r\nSession: devlab1\r\n\r\n".encode()
+                    )
+                elif method == "PLAY":
+                    play_uri = uri
+                    conn.sendall(f"RTSP/1.0 200 OK\r\nCSeq: {cseq}\r\nSession: devlab1\r\n\r\n".encode())
+                    self._pump(conn, play_uri)
+                    return
+                elif method == "TEARDOWN":
+                    conn.sendall(f"RTSP/1.0 200 OK\r\nCSeq: {cseq}\r\nSession: devlab1\r\n\r\n".encode())
+                    return
+        except TimeoutError, ConnectionError, OSError:
+            pass
+        finally:
+            conn.close()
+
+    def _pump(self, conn: socket.socket, uri: str) -> None:
+        """Stream ffmpeg MPEG-TS as RTP (PT 33) framed over interleaved TCP."""
+        proc = subprocess.Popen(self._ffmpeg_cmd(uri), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        assert proc.stdout is not None
+        seq = 0
+        ts = 0
+        buf = b""
+        payload = 1316  # 7 * 188-byte TS packets per RTP datagram
+        try:
+            while not self._stop.is_set():
+                chunk = proc.stdout.read(payload)
+                if not chunk:
+                    break
+                buf += chunk
+                while len(buf) >= payload:
+                    pkt, buf = buf[:payload], buf[payload:]
+                    header = struct.pack("!BBHII", 0x80, 33, seq & 0xFFFF, ts & 0xFFFFFFFF, 0x0DEFACED)
+                    rtp = header + pkt
+                    conn.sendall(b"\x24" + struct.pack("!BH", 0, len(rtp)) + rtp)
+                    seq += 1
+                    ts += 3600
+        except BrokenPipeError, ConnectionError, OSError:
+            pass
+        finally:
+            if proc.poll() is None:
+                proc.terminate()
+
+
+# ---------------------------------------------------------------------------
+# Config generation
+# ---------------------------------------------------------------------------
+
+
+def build_services_m3u(http_hostport: str, rtsp_hostport: str) -> str:
+    """Build the [services] M3U covering all scenarios x both codecs.
+
+    Each HLS channel is HLS-live (``.m3u8``) with HTTP catchup; each mpegts
+    channel is RTSP-live with RTSP catchup. Catchup sources stream TS per time
+    window (what the web player's ``buildCatchupSegments`` expects) so playback
+    starts immediately and the requested time is burned into the picture.
+    """
+    tpl = "playseek={utc:YmdHMS}-{utcend:YmdHMS}"
+    lines = ["#EXTM3U"]
+    for prof in PROFILES:
+        # HLS live (.m3u8) + HLS catchup (HTTP TS window): covers HLS 直播 + HLS 回看
+        src = f"http://{http_hostport}/catchup-ts/{prof}?{tpl}"
+        lines += [
+            f'#EXTINF:-1 group-title="HLS" catchup="default" catchup-source="{src}",HLS ({prof})',
+            f"http://{http_hostport}/live/{prof}/index.m3u8",
+        ]
+    for prof in PROFILES:
+        # mpegts live (RTSP) + mpegts catchup (RTSP TS window): covers mpegts 回看
+        src = f"rtsp://{rtsp_hostport}/catchup/{prof}?{tpl}"
+        lines += [
+            f'#EXTINF:-1 group-title="mpegts" catchup="default" catchup-source="{src}",mpegts ({prof})',
+            f"rtsp://{rtsp_hostport}/live/{prof}",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def write_config(path: str, listen_port: int, services_m3u: str) -> None:
+    indented = "\n".join(services_m3u.splitlines())
+    content = f"[global]\nverbosity = 3\nmaxclients = 20\n\n[bind]\n* {listen_port}\n\n[services]\n{indented}\n"
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--http-port", type=int, default=8881)
+    ap.add_argument("--rtsp-port", type=int, default=8554)
+    ap.add_argument("--r2h-port", type=int, default=5140, help="port rtp2httpd will listen on (for config)")
+    ap.add_argument("--ffmpeg", default=shutil.which("ffmpeg") or "ffmpeg")
+    ap.add_argument("--config", default="/tmp/r2h-devlab.conf")
+    ap.add_argument("--workdir", default=tempfile.mkdtemp(prefix="r2h-devlab-"))
+    args = ap.parse_args()
+
+    if not shutil.which(args.ffmpeg) and not os.path.isfile(args.ffmpeg):
+        print(f"ERROR: ffmpeg not found ({args.ffmpeg})", file=sys.stderr)
+        return 1
+
+    live_root = os.path.join(args.workdir, "live")
+    catchup_root = os.path.join(args.workdir, "catchup")
+    os.makedirs(catchup_root, exist_ok=True)
+
+    live = [LiveHLS(args.ffmpeg, p, os.path.join(live_root, p)) for p in PROFILES]
+    for gen in live:
+        gen.start()
+
+    catchup = CatchupHLS(args.ffmpeg, catchup_root)
+    handler = make_http_handler(args.host, args.http_port, live_root, catchup, args.ffmpeg)
+    httpd = ThreadingHTTPServer((args.host, args.http_port), handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+
+    rtsp = RTSPOrigin(args.ffmpeg, args.host, args.rtsp_port)
+    rtsp.start()
+
+    http_hostport = f"{args.host}:{args.http_port}"
+    rtsp_hostport = f"{args.host}:{args.rtsp_port}"
+    write_config(args.config, args.r2h_port, build_services_m3u(http_hostport, rtsp_hostport))
+
+    print(f"devlab up: HTTP {http_hostport}  RTSP {rtsp_hostport}  workdir {args.workdir}")
+    print(f"wrote rtp2httpd config: {args.config}")
+    print(f"run rtp2httpd:  ./build/rtp2httpd -c {args.config} -r lo")
+    print("Ctrl-C to stop.")
+
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.shutdown()
+        rtsp.stop()
+        for gen in live:
+            gen.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/devlab/devlab.py
+++ b/tools/devlab/devlab.py
@@ -48,10 +48,21 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
 FONT = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
-# Profiles used for HLS/RTSP scenarios (must be browser-friendly enough to test).
+# Profiles used for RTSP scenarios (must be browser-friendly enough to test).
 PROFILES = ("h264-mp2", "hevc-aac")
 # Profiles offered as multicast (组播) live channels, incl. 北京卫视 4K style combos.
 MCAST_PROFILES = ("h264-mp2", "hevc-ac3", "hevc-eac3")
+
+# HLS live channels covering both segment specs: HLS-TS (MPEG-TS segments) and
+# HLS-fMP4 (fragmented MP4: an init.mp4 + .m4s segments). fMP4 carries AAC audio
+# (MP2-in-MP4 is not well supported), so the fMP4 rows use *-aac profiles.
+# Tuple: (channel_label, profile, seg_type, live_key).
+HLS_CHANNELS = (
+    ("HLS-TS (h264-mp2)", "h264-mp2", "mpegts", "h264-mp2-ts"),
+    ("HLS-TS (hevc-aac)", "hevc-aac", "mpegts", "hevc-aac-ts"),
+    ("HLS-fMP4 (h264-aac)", "h264-aac", "fmp4", "h264-aac-fmp4"),
+    ("HLS-fMP4 (hevc-aac)", "hevc-aac", "fmp4", "hevc-aac-fmp4"),
+)
 
 # ---------------------------------------------------------------------------
 # ffmpeg argument helpers
@@ -175,16 +186,47 @@ def parse_playseek_begin(playseek: str) -> int:
 
 
 class LiveHLS:
-    """Runs a background ffmpeg that continuously writes a live HLS playlist."""
+    """Runs a background ffmpeg that continuously writes a live HLS playlist.
 
-    def __init__(self, ffmpeg: str, profile: str, outdir: str):
+    ``seg_type`` selects the HLS specification: ``mpegts`` (HLS-TS, .ts segments)
+    or ``fmp4`` (HLS-fMP4, an init.mp4 + .m4s fragments referenced via EXT-X-MAP).
+    """
+
+    def __init__(self, ffmpeg: str, profile: str, outdir: str, seg_type: str = "mpegts"):
         self.ffmpeg = ffmpeg
         self.profile = profile
         self.outdir = outdir
+        self.seg_type = seg_type
         self.proc: subprocess.Popen[bytes] | None = None
 
     def start(self) -> None:
         os.makedirs(self.outdir, exist_ok=True)
+        hls_opts = [
+            "-f",
+            "hls",
+            "-hls_time",
+            "2",
+            "-hls_list_size",
+            "6",
+            "-hls_flags",
+            "delete_segments+append_list+omit_endlist",
+        ]
+        if self.seg_type == "fmp4":
+            hls_opts += [
+                "-hls_segment_type",
+                "fmp4",
+                "-hls_fmp4_init_filename",
+                "init.mp4",
+                "-hls_segment_filename",
+                os.path.join(self.outdir, "seg_%05d.m4s"),
+            ]
+        else:
+            hls_opts += [
+                "-hls_segment_type",
+                "mpegts",
+                "-hls_segment_filename",
+                os.path.join(self.outdir, "seg_%05d.ts"),
+            ]
         cmd = [
             self.ffmpeg,
             "-hide_banner",
@@ -196,16 +238,7 @@ class LiveHLS:
             live_filter(self.profile),
             *video_args(self.profile),
             *audio_args(self.profile),
-            "-f",
-            "hls",
-            "-hls_time",
-            "2",
-            "-hls_list_size",
-            "6",
-            "-hls_flags",
-            "delete_segments+append_list+omit_endlist",
-            "-hls_segment_filename",
-            os.path.join(self.outdir, "seg_%05d.ts"),
+            *hls_opts,
             os.path.join(self.outdir, "index.m3u8"),
         ]
         self.proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -302,7 +335,12 @@ def make_http_handler(
             if not os.path.isfile(path):
                 self._send(404, "text/plain", b"not found")
                 return
-            ctype = "application/vnd.apple.mpegurl" if path.endswith(".m3u8") else "video/mp2t"
+            if path.endswith(".m3u8"):
+                ctype = "application/vnd.apple.mpegurl"
+            elif path.endswith((".mp4", ".m4s")):
+                ctype = "video/mp4"  # fMP4 init.mp4 + .m4s fragments
+            else:
+                ctype = "video/mp2t"
             with open(path, "rb") as fh:
                 self._send(200, ctype, fh.read())
 
@@ -624,12 +662,13 @@ def build_services_m3u(http_hostport: str, rtsp_hostport: str, mcast_channels: l
     """
     tpl = "playseek={utc:YmdHMS}-{utcend:YmdHMS}"
     lines = ["#EXTM3U"]
-    for prof in PROFILES:
-        # HLS live (.m3u8) + HLS catchup (HTTP TS window): covers HLS 直播 + HLS 回看
+    for label, prof, _seg_type, key in HLS_CHANNELS:
+        # HLS live (.m3u8, TS or fMP4 segments) + HLS catchup (HTTP TS window):
+        # covers HLS 直播 + HLS 回看 across both segment specs.
         src = f"http://{http_hostport}/catchup-ts/{prof}?{tpl}"
         lines += [
-            f'#EXTINF:-1 group-title="HLS" catchup="default" catchup-source="{src}",HLS ({prof})',
-            f"http://{http_hostport}/live/{prof}/index.m3u8",
+            f'#EXTINF:-1 group-title="HLS" catchup="default" catchup-source="{src}",{label}',
+            f"http://{http_hostport}/live/{key}/index.m3u8",
         ]
     for prof in PROFILES:
         # mpegts live (RTSP) + mpegts catchup (RTSP TS window): covers mpegts 回看
@@ -683,7 +722,10 @@ def main() -> int:
     catchup_root = os.path.join(args.workdir, "catchup")
     os.makedirs(catchup_root, exist_ok=True)
 
-    live = [LiveHLS(args.ffmpeg, p, os.path.join(live_root, p)) for p in PROFILES]
+    live = [
+        LiveHLS(args.ffmpeg, prof, os.path.join(live_root, key), seg_type)
+        for _label, prof, seg_type, key in HLS_CHANNELS
+    ]
     for gen in live:
         gen.start()
 

--- a/tools/devlab/devlab.py
+++ b/tools/devlab/devlab.py
@@ -33,8 +33,8 @@ PATH (or pass ``--ffmpeg``); multicast channels need ``rtp2httpd ... -r lo``.
 from __future__ import annotations
 
 import argparse
+import math
 import os
-import re
 import shutil
 import socket
 import struct
@@ -163,21 +163,37 @@ def lavfi_inputs(size: str = "1280x720") -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def parse_playseek_begin(playseek: str) -> int:
-    """Return the begin time of a playseek value as a UTC epoch (seconds).
+def _parse_time_token(tok: str) -> int:
+    """Parse one playseek time token to a UTC epoch (seconds).
 
     Accepts the formats rtp2httpd forwards to upstreams: compact
     ``yyyyMMddHHmmss`` (optionally ``GMT``/``Z`` suffixed) and unix seconds.
-    Falls back to "now" if the value cannot be parsed.
+    Falls back to "now" if the token cannot be parsed.
     """
-    begin = playseek.split("-")[0].strip() if playseek else ""
-    begin = begin.replace("GMT", "").replace("Z", "").replace("T", "")
-    if begin.isdigit() and len(begin) <= 10:
-        return int(begin)
-    if len(begin) >= 14 and begin[:14].isdigit():
-        dt = datetime.strptime(begin[:14], "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+    tok = tok.replace("GMT", "").replace("Z", "").replace("T", "").strip()
+    if tok.isdigit() and len(tok) <= 10:
+        return int(tok)
+    if len(tok) >= 14 and tok[:14].isdigit():
+        dt = datetime.strptime(tok[:14], "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
         return int(dt.timestamp())
     return int(time.time())
+
+
+def parse_playseek_begin(playseek: str) -> int:
+    """Return the begin time of a playseek value as a UTC epoch (seconds)."""
+    return _parse_time_token(playseek.split("-")[0]) if playseek else int(time.time())
+
+
+def parse_playseek_range(playseek: str) -> tuple[int, int]:
+    """Return ``(begin, end)`` UTC epochs for a ``BEGIN-END`` playseek value.
+
+    rtp2httpd forwards compact ``yyyyMMddHHmmss`` times (no internal dashes) so a
+    plain ``-`` split is safe. A missing/!invalid end defaults to begin + 60s.
+    """
+    toks = [t for t in playseek.split("-") if t.strip()] if playseek else []
+    begin = _parse_time_token(toks[0]) if toks else int(time.time())
+    end = _parse_time_token(toks[1]) if len(toks) >= 2 else begin + 60
+    return begin, (end if end > begin else begin + 60)
 
 
 # ---------------------------------------------------------------------------
@@ -249,62 +265,57 @@ class LiveHLS:
 
 
 # ---------------------------------------------------------------------------
-# Catchup HLS VOD generation (on demand, cached by begin time)
+# HLS VOD catchup (m3u8 + .ts slices, slices encoded lazily on demand)
 # ---------------------------------------------------------------------------
 
 
 class CatchupHLS:
-    """Generates short VOD HLS trees on demand, one per (profile, begin)."""
+    """Serves catchup as a real HLS VOD: an ``index.m3u8`` listing fixed-duration
+    ``.ts`` slices for the requested ``playseek`` window.
 
-    def __init__(self, ffmpeg: str, root: str, duration: int = 120):
+    The playlist is produced instantly (just text); each ``.ts`` slice is encoded
+    on demand when the client fetches it, with that slice's absolute wall-clock
+    time burned in -- so the VOD is time-correct without pre-encoding the whole
+    (possibly hours-long) window.
+    """
+
+    def __init__(self, ffmpeg: str, seg_dur: int = 6, max_segs: int = 900):
         self.ffmpeg = ffmpeg
-        self.root = root
-        self.duration = duration
-        self._locks: dict[str, threading.Lock] = {}
-        self._guard = threading.Lock()
+        self.seg_dur = seg_dur
+        self.max_segs = max_segs
 
-    def _lock_for(self, key: str) -> threading.Lock:
-        with self._guard:
-            return self._locks.setdefault(key, threading.Lock())
+    def playlist(self, base: str, profile: str, begin: int, end: int) -> str:
+        nseg = min(self.max_segs, max(1, math.ceil((end - begin) / self.seg_dur)))
+        lines = [
+            "#EXTM3U",
+            "#EXT-X-VERSION:3",
+            f"#EXT-X-TARGETDURATION:{self.seg_dur}",
+            "#EXT-X-MEDIA-SEQUENCE:0",
+            "#EXT-X-PLAYLIST-TYPE:VOD",
+        ]
+        for i in range(nseg):
+            lines += [f"#EXTINF:{self.seg_dur}.000,", f"{base}/catchup-seg/{profile}/{begin}/{i}.ts"]
+        lines.append("#EXT-X-ENDLIST")
+        return "\n".join(lines) + "\n"
 
-    def ensure(self, profile: str, begin_epoch: int) -> str:
-        """Generate (if needed) the VOD for (profile, begin) and return its dir."""
-        key = f"{profile}-{begin_epoch}"
-        outdir = os.path.join(self.root, key)
-        with self._lock_for(key):
-            ready = os.path.join(outdir, "index.m3u8")
-            if os.path.exists(ready):
-                return outdir
-            tmp = outdir + ".tmp"
-            shutil.rmtree(tmp, ignore_errors=True)
-            os.makedirs(tmp, exist_ok=True)
-            cmd = [
-                self.ffmpeg,
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                *lavfi_inputs(),
-                "-t",
-                str(self.duration),
-                "-vf",
-                catchup_filter(profile, begin_epoch),
-                *video_args(profile),
-                *audio_args(profile),
-                "-f",
-                "hls",
-                "-hls_time",
-                "2",
-                "-hls_list_size",
-                "0",
-                "-hls_playlist_type",
-                "vod",
-                "-hls_segment_filename",
-                os.path.join(tmp, "seg_%05d.ts"),
-                os.path.join(tmp, "index.m3u8"),
-            ]
-            subprocess.run(cmd, check=True)
-            os.replace(tmp, outdir)
-            return outdir
+    def segment_cmd(self, profile: str, begin: int, idx: int) -> list[str]:
+        seg_start = begin + idx * self.seg_dur
+        return [
+            self.ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            *lavfi_inputs(),
+            "-t",
+            str(self.seg_dur),
+            "-vf",
+            catchup_filter(profile, seg_start),
+            *video_args(profile),
+            *audio_args(profile),
+            "-f",
+            "mpegts",
+            "-",
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -312,9 +323,7 @@ class CatchupHLS:
 # ---------------------------------------------------------------------------
 
 
-def make_http_handler(
-    host: str, port: int, live_root: str, catchup: CatchupHLS, ffmpeg: str
-) -> type[BaseHTTPRequestHandler]:
+def make_http_handler(host: str, port: int, live_root: str, catchup: CatchupHLS) -> type[BaseHTTPRequestHandler]:
     base = f"http://{host}:{port}"
 
     class Handler(BaseHTTPRequestHandler):
@@ -351,45 +360,20 @@ def make_http_handler(
 
         def _catchup_playlist(self, profile: str, qs: dict[str, list[str]]) -> None:
             playseek = (qs.get("playseek") or qs.get("tvdr") or [""])[0]
-            begin = parse_playseek_begin(playseek)
-            outdir = catchup.ensure(profile, begin)
-            with open(os.path.join(outdir, "index.m3u8"), encoding="utf-8") as fh:
-                text = fh.read()
-            # Rewrite relative segment names to absolute URLs that embed begin, so
-            # rtp2httpd rewrites them onto its /http proxy and they never collide.
-            text = re.sub(
-                r"^(seg_\d+\.ts)$",
-                lambda m: f"{base}/catchup-seg/{profile}/{begin}/{m.group(1)}",
-                text,
-                flags=re.MULTILINE,
-            )
+            begin, end = parse_playseek_range(playseek)
+            # Absolute slice URLs (embed begin) so rtp2httpd rewrites them onto its
+            # /http proxy and they never collide across windows.
+            text = catchup.playlist(base, profile, begin, end)
             self._send(200, "application/vnd.apple.mpegurl", text.encode())
 
-        def _catchup_ts(self, profile: str, qs: dict[str, list[str]]) -> None:
-            playseek = (qs.get("playseek") or qs.get("tvdr") or [""])[0]
-            begin = parse_playseek_begin(playseek)
-            cmd = [
-                ffmpeg,
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                "-re",
-                *lavfi_inputs(),
-                "-t",
-                "120",
-                "-vf",
-                catchup_filter(profile, begin),
-                *video_args(profile),
-                *audio_args(profile),
-                "-f",
-                "mpegts",
-                "-",
-            ]
+        def _catchup_seg(self, profile: str, begin: int, idx: int) -> None:
             self.send_response(200)
             self.send_header("Content-Type", "video/mp2t")
             self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            proc = subprocess.Popen(
+                catchup.segment_cmd(profile, begin, idx), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+            )
             assert proc.stdout is not None
             try:
                 while True:
@@ -413,9 +397,8 @@ def make_http_handler(
                 elif len(parts) >= 2 and parts[0] == "catchup" and parts[-1] == "index.m3u8":
                     self._catchup_playlist(parts[1], qs)
                 elif len(parts) == 4 and parts[0] == "catchup-seg":
-                    self._serve_file(os.path.join(catchup.root, f"{parts[1]}-{parts[2]}", parts[3]))
-                elif len(parts) == 2 and parts[0] == "catchup-ts":
-                    self._catchup_ts(parts[1], qs)
+                    # /catchup-seg/<profile>/<begin>/<idx>.ts
+                    self._catchup_seg(parts[1], int(parts[2]), int(parts[3].removesuffix(".ts")))
                 else:
                     self._send(404, "text/plain", b"not found")
             except BrokenPipeError, ConnectionError:
@@ -663,9 +646,9 @@ def build_services_m3u(http_hostport: str, rtsp_hostport: str, mcast_channels: l
     tpl = "playseek={utc:YmdHMS}-{utcend:YmdHMS}"
     lines = ["#EXTM3U"]
     for label, prof, _seg_type, key in HLS_CHANNELS:
-        # HLS live (.m3u8, TS or fMP4 segments) + HLS catchup (HTTP TS window):
-        # covers HLS 直播 + HLS 回看 across both segment specs.
-        src = f"http://{http_hostport}/catchup-ts/{prof}?{tpl}"
+        # HLS live (.m3u8, TS or fMP4 segments) + HLS catchup (HLS VOD m3u8+ts per
+        # window): covers HLS 直播 + HLS 回看 across both segment specs.
+        src = f"http://{http_hostport}/catchup/{prof}/index.m3u8?{tpl}"
         lines += [
             f'#EXTINF:-1 group-title="HLS" catchup="default" catchup-source="{src}",{label}',
             f"http://{http_hostport}/live/{key}/index.m3u8",
@@ -719,8 +702,6 @@ def main() -> int:
         return 1
 
     live_root = os.path.join(args.workdir, "live")
-    catchup_root = os.path.join(args.workdir, "catchup")
-    os.makedirs(catchup_root, exist_ok=True)
 
     live = [
         LiveHLS(args.ffmpeg, prof, os.path.join(live_root, key), seg_type)
@@ -729,8 +710,8 @@ def main() -> int:
     for gen in live:
         gen.start()
 
-    catchup = CatchupHLS(args.ffmpeg, catchup_root)
-    handler = make_http_handler(args.host, args.http_port, live_root, catchup, args.ffmpeg)
+    catchup = CatchupHLS(args.ffmpeg)
+    handler = make_http_handler(args.host, args.http_port, live_root, catchup)
     httpd = ThreadingHTTPServer((args.host, args.http_port), handler)
     threading.Thread(target=httpd.serve_forever, daemon=True).start()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the rtp2httpd development environment for Cursor Cloud agents and adds a reusable web-player dev lab (`tools/devlab/`) covering the IPTV scenarios needed to develop the player. Durable notes live in `AGENTS.md`.

Repo changes:
- `tools/devlab/devlab.py` + `README.md`: mock IPTV upstreams.
- `AGENTS.md` (`## Cursor Cloud specific instructions`): Node + dev-lab notes.

Startup update script (deps only): `pnpm install --frozen-lockfile` then `uv sync --group dev`.

## Dev lab scenarios

| Scenario | Delivery | Proxy | Codecs |
| --- | --- | --- | --- |
| HLS-TS live | HTTP `.m3u8` + `.ts` | `/http` | `h264-mp2`, `hevc-aac` |
| HLS-fMP4 live | HTTP `.m3u8` + `init.mp4`/`.m4s` | `/http` | `h264-aac`, `hevc-aac` |
| HLS catchup | HTTP **HLS VOD** (`m3u8`+`.ts`, `playseek`) | `/http` | per channel |
| mpegts catchup | RTSP TS (`playseek`) | `/rtsp` | `h264-mp2`, `hevc-aac` |
| mpegts live (组播) | RTP multicast | `/rtp` (`-r lo`) | `h264-mp2`, `hevc-ac3`, `hevc-eac3` |
| external `.ts` file | RTP multicast (looped, copy) | `/rtp` (`-r lo`) | as-is (`--ts-file`) |

- HLS live covers both segment specs (HLS-TS, HLS-fMP4 via `#EXT-X-MAP`+`.m4s`).
- HLS catchup is a real **HLS VOD**: each `playseek` window returns an `index.m3u8` (`#EXT-X-PLAYLIST-TYPE:VOD`) listing fixed-duration `.ts` slices, encoded lazily on demand with each slice's absolute wall-clock time burned in (so multi-hour windows stay time-correct without pre-encoding). mpegts/RTSP catchup streams continuous TS per window.
- HEVC video + AC-3/E-AC-3 audio relay correctly (ffprobe) but don't decode in this VM's Chromium MSE (browser limitation).

## Verification

- `pnpm run lint`, `pnpm run type-check`, `./scripts/run-e2e.sh` (495 passed), build — all pass.
- ffprobe through the daemon confirms codecs for every channel; the daemon rewrites HLS `.ts`/`.m4s`/`EXT-X-MAP` URIs and HLS-VOD-catchup slice URLs onto its `/http` proxy.
- Player: HLS-TS live, HLS-fMP4 live, HLS-VOD catchup (timeshift), multicast live, and external `.ts` file all play (H.264 channels).

<a href="https://cursor.com/agents/bc-04e49916-e0f4-4026-9b32-0cc1280f0a98/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frtp2httpd_devlab_hls_vod_catchup.mp4"><img src="https://cursor.com/artifacts/c/art-0fb9a8c8-b6e9-42f3-815d-7bb21eef0ed2" alt="rtp2httpd_devlab_hls_vod_catchup.mp4" /></a>

![HLS VOD catchup slice (SEEK 08-30-18 UTC) via daemon](https://cursor.com/artifacts/c/art-075fa6ca-d790-4d05-9e13-e5b9b85d5c2b)
![HLS VOD catchup playing in player](https://cursor.com/artifacts/c/art-78396fdd-20ec-4b98-843f-6e4a7779b5f2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04e49916-e0f4-4026-9b32-0cc1280f0a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04e49916-e0f4-4026-9b32-0cc1280f0a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

