### PR TITLE
ci(e2e): add FreeBSD workflow coverage

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ${{ matrix.os }}
@@ -46,4 +49,4 @@ jobs:
             export UV_PYTHON_DOWNLOADS=never
             cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AGGRESSIVE_OPT=ON
             cmake --build build -j$(sysctl -n hw.ncpu)
-            ./scripts/run-e2e.sh
+            R2H_E2E_NO_DEV=1 ./scripts/run-e2e.sh

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   e2e:
     runs-on: ${{ matrix.os }}
-    name: Run
+    name: Run (${{ matrix.os }})
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -27,3 +27,23 @@ jobs:
 
       - name: Run E2E tests
         run: ./scripts/run-e2e.sh
+
+  e2e-freebsd:
+    runs-on: ubuntu-latest
+    name: Run (freebsd)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run E2E tests in FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg install -y bash cmake python314 uv
+          run: |
+            export UV_PYTHON=/usr/local/bin/python3.14
+            export UV_PYTHON_DOWNLOADS=never
+            cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AGGRESSIVE_OPT=ON
+            cmake --build build -j$(sysctl -n hw.ncpu)
+            ./scripts/run-e2e.sh

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -43,7 +43,7 @@ jobs:
           usesh: true
           copyback: false
           prepare: |
-            pkg install -y bash cmake python314 uv
+            pkg install -y bash cmake curl python314 uv
           run: |
             export UV_PYTHON=/usr/local/bin/python3.14
             export UV_PYTHON_DOWNLOADS=never

--- a/e2e/helpers/constants.py
+++ b/e2e/helpers/constants.py
@@ -9,5 +9,5 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 BINARY_PATH = PROJECT_ROOT / "build" / "rtp2httpd"
 FIXTURES_DIR = PROJECT_ROOT / "tools" / "fixtures"
 
-LOOPBACK_IF = "lo0" if sys.platform == "darwin" else "lo"
+LOOPBACK_IF = "lo0" if sys.platform == "darwin" or sys.platform.startswith("freebsd") else "lo"
 MCAST_ADDR = "239.255.0.1"

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -11,6 +11,7 @@
 #   ./scripts/run-e2e.sh -m "not multicast"# Skip multicast tests
 #   ./scripts/run-e2e.sh -x                # Stop on first failure
 #   ./scripts/run-e2e.sh --co              # Collect & list tests (dry run)
+#   R2H_E2E_NO_DEV=1 ./scripts/run-e2e.sh  # Skip dependency-group dev tools
 #
 set -euo pipefail
 
@@ -91,8 +92,13 @@ echo ""
 
 cd "$PROJECT_ROOT"
 
+UV_RUN_ARGS=()
+if [[ "${R2H_E2E_NO_DEV:-0}" == "1" ]]; then
+    UV_RUN_ARGS+=(--no-dev)
+fi
+
 if [[ "$PARALLEL" == "1" ]]; then
-    exec uv run pytest "$TEST_PATH" -v "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
+    exec uv run "${UV_RUN_ARGS[@]}" pytest "$TEST_PATH" -v "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
 else
-    exec uv run pytest "$TEST_PATH" -v -n "$PARALLEL" --dist loadscope "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
+    exec uv run "${UV_RUN_ARGS[@]}" pytest "$TEST_PATH" -v -n "$PARALLEL" --dist loadscope "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
 fi

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -92,13 +92,13 @@ echo ""
 
 cd "$PROJECT_ROOT"
 
-UV_RUN_ARGS=()
+UV_RUN_CMD=(uv run)
 if [[ "${R2H_E2E_NO_DEV:-0}" == "1" ]]; then
-    UV_RUN_ARGS+=(--no-dev)
+    UV_RUN_CMD+=(--no-dev)
 fi
 
 if [[ "$PARALLEL" == "1" ]]; then
-    exec uv run "${UV_RUN_ARGS[@]}" pytest "$TEST_PATH" -v "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
+    exec "${UV_RUN_CMD[@]}" pytest "$TEST_PATH" -v "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
 else
-    exec uv run "${UV_RUN_ARGS[@]}" pytest "$TEST_PATH" -v -n "$PARALLEL" --dist loadscope "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
+    exec "${UV_RUN_CMD[@]}" pytest "$TEST_PATH" -v -n "$PARALLEL" --dist loadscope "${PYTEST_ARGS[@]+"${PYTEST_ARGS[@]}"}"
 fi

--- a/tools/devlab/devlab.py
+++ b/tools/devlab/devlab.py
@@ -756,8 +756,7 @@ def build_services_m3u(http_hostport: str, rtsp_hostport: str, mcast_channels: l
         # mpegts-over-RTSP live + RTSP TS catchup window: covers mpegts 回看
         src = f"rtsp://{rtsp_hostport}/catchup/{prof}?{tpl}"
         extinf = (
-            f'#EXTINF:-1 group-title="mpegts (RTSP)" catchup="default" '
-            f'catchup-source="{src}",mpegts (RTSP) ({prof})'
+            f'#EXTINF:-1 group-title="mpegts (RTSP)" catchup="default" catchup-source="{src}",mpegts (RTSP) ({prof})'
         )
         lines += [
             extinf,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a FreeBSD e2e job using `vmactions/freebsd-vm@v1`.
- Install FreeBSD VM dependencies and run the same build plus e2e wrapper path.
- Treat FreeBSD loopback as `lo0` in e2e helpers so multicast tests use the correct interface.
- Add explicit workflow token permissions, avoid dev dependency installs in the FreeBSD e2e run, and keep the runner compatible with macOS Bash 3.2.

## Testing
- `uv run ruff check e2e/helpers/constants.py`
- `uv run python -c "import importlib.util, pathlib, sys; sys.platform = 'freebsd15'; path = pathlib.Path('e2e/helpers/constants.py'); spec = importlib.util.spec_from_file_location('constants_under_test', path); module = importlib.util.module_from_spec(spec); spec.loader.exec_module(module); assert module.LOOPBACK_IF == 'lo0', module.LOOPBACK_IF; print(module.LOOPBACK_IF)"`
- `uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-tests.yaml', encoding='utf-8')); print('workflow yaml ok')"`
- `bash -n scripts/run-e2e.sh`
- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AGGRESSIVE_OPT=ON && cmake --build build -j$(getconf _NPROCESSORS_ONLN)`
- `pnpm run type-check`
- `pnpm run lint`
- `git diff --check`
- `./scripts/run-e2e.sh --co`
- `UV_PROJECT_ENVIRONMENT="/tmp/r2h-e2e-no-dev-${RANDOM}" R2H_E2E_NO_DEV=1 ./scripts/run-e2e.sh --co`
- `UV_PROJECT_ENVIRONMENT="/tmp/r2h-e2e-no-dev-run-${RANDOM}" R2H_E2E_NO_DEV=1 ./scripts/run-e2e.sh -p 1 test_auth.py`
- `./scripts/run-e2e.sh -p 1 -m "not multicast and not slow"`
- `./scripts/run-e2e.sh -p 1 -m "multicast"`

Note: the FreeBSD VM job itself runs in GitHub Actions via `vmactions/freebsd-vm@v1`; local validation covered workflow syntax, dependency selection, and runnable e2e paths available in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d68aaac3-b402-4fd3-92ca-f7d6a3a7aa3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d68aaac3-b402-4fd3-92ca-f7d6a3a7aa3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

