### PR TITLE
ci(docs): reuse documentation preview comments

### DIFF
--- a/.github/workflows/documentation-website.yaml
+++ b/.github/workflows/documentation-website.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
@@ -28,10 +32,21 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_WATER_0A297BF00 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
           skip_app_build: true
           app_location: "docs/.vitepress/dist"
+      - name: Comment PR preview URL
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: documentation-website-preview
+          message: |
+            ### Documentation preview
+
+            The documentation preview has been deployed for this pull request.
+
+            - Preview: ${{ steps.builddeploy.outputs.static_web_app_url }}
+            - Commit: ${{ github.sha }}
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Disable Azure Static Web Apps' built-in PR comments by omitting `repo_token`.
- Add a sticky PR comment step for documentation preview URLs so existing comments are updated instead of duplicated.

## Testing
- `uv run --group dev python -c "..."`
- `pnpm run docs:build`
- `uv run --group dev --with pyyaml python -c "..."`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7858b9c8-8d44-4650-9d9b-2a167deba2e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7858b9c8-8d44-4650-9d9b-2a167deba2e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

