### PR TITLE
feat: enable TCP keepalive with aggressive timers for dead-peer detection

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -23,6 +23,9 @@
 #include <unistd.h>
 
 #define CONNECTION_TCP_USER_TIMEOUT_MS 10000
+#define CONNECTION_TCP_KEEPALIVE_IDLE_SEC 30
+#define CONNECTION_TCP_KEEPALIVE_INTVL_SEC 5
+#define CONNECTION_TCP_KEEPALIVE_CNT 3
 #define CONN_QUEUE_MIN_BUFFERS 64
 #define CONN_QUEUE_BURST_FACTOR 3.0
 #define CONN_QUEUE_BURST_FACTOR_CONGESTED 1.5
@@ -529,6 +532,19 @@ connection_t *connection_create(int fd, int epfd, struct sockaddr_storage *clien
     }
   }
 #endif
+
+  /* Enable TCP keepalive for early dead-peer detection on idle
+   * connections.  Combined with the TCP_USER_TIMEOUT above this
+   * covers both the data-pending and idle cases:
+   *   - Data in-flight & ACK'd but peer gone → TCP_USER_TIMEOUT
+   *   - Socket idle (no data to send)      → keepalive probes
+   *
+   * Total detection window ≈ KEEPALIVE_IDLE_SEC + KEEPALIVE_INTVL_SEC ×
+   * KEEPALIVE_CNT  (30 + 5×3 = 45 seconds with the defaults below). */
+  if (connection_client_is_tcp(c)) {
+    platform_set_tcp_keepalive(c->fd, CONNECTION_TCP_KEEPALIVE_IDLE_SEC, CONNECTION_TCP_KEEPALIVE_INTVL_SEC,
+                               CONNECTION_TCP_KEEPALIVE_CNT);
+  }
 
   /* Enable SO_ZEROCOPY on socket if supported */
   if (config.zerocopy_on_send && connection_client_is_tcp(c)) {

--- a/src/platform_compat.h
+++ b/src/platform_compat.h
@@ -409,6 +409,47 @@ static inline int platform_mcast_group_op(int sock, int family, const struct soc
 #define IPV6_RECVERR 25
 #endif
 
+/* ── TCP keepalive ──────────────────────────────────────────────────
+ * Configure TCP keepalive for early dead-peer detection on TCP
+ * client sockets.  Supports fine-grained control on all three target
+ * platforms:
+ *   - Linux / FreeBSD: TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT
+ *   - macOS:           TCP_KEEPALIVE (idle), TCP_KEEPINTVL, TCP_KEEPCNT
+ *
+ * If fine-grained options are unavailable (older kernel / unusual
+ * platform) the function silently falls back to bare SO_KEEPALIVE
+ * with system-default timing — still strictly better than nothing.
+ *
+ * Call from connection_create() for every TCP client socket.
+ */
+#include <netinet/tcp.h>
+static inline void platform_set_tcp_keepalive(int fd, int idle_sec, int interval_sec, int count) {
+  int keepalive = 1;
+  if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) < 0)
+    return;
+
+  /* macOS uses TCP_KEEPALIVE for the idle timer; Linux/FreeBSD use
+   * TCP_KEEPIDLE.  Both control the same thing in seconds — just a
+   * naming difference. */
+#ifdef __APPLE__
+  if (idle_sec > 0)
+    (void)setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &idle_sec, sizeof(idle_sec));
+#elif defined(TCP_KEEPIDLE)
+  if (idle_sec > 0)
+    (void)setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle_sec, sizeof(idle_sec));
+#endif
+
+#if defined(TCP_KEEPINTVL)
+  if (interval_sec > 0)
+    (void)setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &interval_sec, sizeof(interval_sec));
+#endif
+
+#if defined(TCP_KEEPCNT)
+  if (count > 0)
+    (void)setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count));
+#endif
+}
+
 /* ── clock_gettime ───────────────────────────────────────────────────
  * Available on both Linux and macOS (10.12+). No compatibility shim needed.
  */


### PR DESCRIPTION
## Summary

Enable TCP keepalive on client sockets with aggressive timers so that zombie connections (connections where the peer has disappeared without sending FIN/RST) are detected and cleaned up within a bounded time window.

## Background

Previously the only protection against dead peers was `TCP_USER_TIMEOUT` (10s, Linux-only), which only helps when the kernel has unacknowledged data in the send buffer.  For **idle** connections — or when the peer's kernel ACKs data before the connection dies (e.g. iOS suspend) — `TCP_USER_TIMEOUT` never fires.  This left connections in a zombie state indefinitely.

## Changes

### `src/platform_compat.h`
- Add `#include <netinet/tcp.h>` and a new `platform_set_tcp_keepalive()` inline function
- Handles the macOS naming difference: `TCP_KEEPALIVE` (macOS) vs `TCP_KEEPIDLE` (Linux/FreeBSD)
- `TCP_KEEPINTVL` and `TCP_KEEPCNT` are common across all three platforms
- Gracefully falls back to bare `SO_KEEPALIVE` if any fine-grained option is unavailable

### `src/connection.c`
- Add three keepalive constants (idle=30s, interval=5s, count=3)
- Call `platform_set_tcp_keepalive()` in `connection_create()` for every TCP client socket

## Detection timing

| Mechanism | Detection time | Scope |
|---|---|---|
| `TCP_USER_TIMEOUT` (existing, Linux only) | 10s | Data pending & unacknowledged |
| **TCP keepalive** (new, all platforms) | 30 + 3×5 = **45s** | Idle socket, peer unreachable |
| Both combined | Full coverage | All abnormal-disconnect scenarios |

## Platform support

| Option | Linux | macOS | FreeBSD |
|---|---|---|---|
| `SO_KEEPALIVE` | ✅ | ✅ | ✅ |
| idle timeout | `TCP_KEEPIDLE` | `TCP_KEEPALIVE` | `TCP_KEEPIDLE` |
| probe interval | `TCP_KEEPINTVL` | `TCP_KEEPINTVL` | `TCP_KEEPINTVL` |
| probe count | `TCP_KEEPCNT` | `TCP_KEEPCNT` | `TCP_KEEPCNT` |
