### PR TITLE
feat(player): improve picture-in-picture controls

### DIFF
--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -7,7 +7,6 @@ import {
   PanelRightOpen,
   Pause,
   PictureInPicture,
-  PictureInPicture2,
   Play,
   Tv,
   Volume1,
@@ -45,6 +44,7 @@ interface PlayerControlsProps {
   onFullscreen: () => void;
   // Picture-in-Picture controls
   isPiP?: boolean;
+  isPiPSupported?: boolean;
   onPiPToggle?: () => void;
   // Sidebar controls
   showSidebar?: boolean;
@@ -70,6 +70,7 @@ export function PlayerControls({
   onMuteToggle,
   onFullscreen,
   isPiP = false,
+  isPiPSupported = false,
   onPiPToggle,
   showSidebar = true,
   onToggleSidebar,
@@ -404,19 +405,15 @@ export function PlayerControls({
             )}
           </button>
 
-          {/* Picture-in-Picture - Only show if supported and handler is provided */}
-          {onPiPToggle && document.pictureInPictureEnabled && (
+          {/* Picture-in-Picture - Only show before entering PiP. Exiting uses the browser PiP window controls. */}
+          {onPiPToggle && isPiPSupported && !isPiP && (
             <button
               type="button"
               onClick={onPiPToggle}
               className="rounded-full p-1.5 md:p-2 text-white transition hover:bg-white/20 active:scale-95 cursor-pointer"
-              title={isPiP ? t("exitPictureInPicture") : t("pictureInPicture")}
+              title={t("pictureInPicture")}
             >
-              {isPiP ? (
-                <PictureInPicture2 className="h-5 w-5 md:h-6 md:w-6" />
-              ) : (
-                <PictureInPicture className="h-5 w-5 md:h-6 md:w-6" />
-              )}
+              <PictureInPicture className="h-5 w-5 md:h-6 md:w-6" />
             </button>
           )}
 

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -82,6 +82,45 @@ function ignoreInterruptedPlayError(err: unknown): void {
   if (!isInterruptedPlayError(err)) throw err;
 }
 
+function getEventDocument(event: Event): Document {
+  const target = event.target;
+  if (target && "ownerDocument" in target) {
+    const ownerDocument = (target as { ownerDocument?: Document | null }).ownerDocument;
+    if (ownerDocument) return ownerDocument;
+  }
+  if (target && "document" in target) {
+    const targetDocument = (target as { document?: Document | null }).document;
+    if (targetDocument) return targetDocument;
+  }
+  if (target && "nodeType" in target && (target as { nodeType?: number }).nodeType === 9) {
+    return target as Document;
+  }
+  return document;
+}
+
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!target || !("tagName" in target)) return false;
+  const tagName = String((target as { tagName?: unknown }).tagName).toUpperCase();
+  return (
+    tagName === "INPUT" ||
+    tagName === "TEXTAREA" ||
+    tagName === "SELECT" ||
+    !!(target as { isContentEditable?: boolean }).isContentEditable
+  );
+}
+
+function isDocumentBodyActive(targetDocument: Document): boolean {
+  const activeElement = targetDocument.activeElement;
+  return !activeElement || activeElement === targetDocument.body;
+}
+
+function blurActiveElement(targetDocument: Document): void {
+  const activeElement = targetDocument.activeElement;
+  if (!activeElement || activeElement === targetDocument.body) return;
+  const blur = (activeElement as { blur?: () => void }).blur;
+  if (blur) blur.call(activeElement);
+}
+
 function PlayerTopLeftOverlay({
   visible,
   loading,
@@ -762,6 +801,7 @@ export function VideoPlayer({
     const activeVideo = slotVideoRef(activeId).current;
     const useSeamlessSwitch =
       seamlessSwitch &&
+      !isAnyPictureInPictureActive() &&
       hasStartedPlaybackRef.current &&
       isStreamSwitch &&
       playMode === "live" &&
@@ -998,7 +1038,8 @@ export function VideoPlayer({
   }, []);
 
   const handleKeyDown = useEffectEvent((e: KeyboardEvent) => {
-    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+    const eventDocument = getEventDocument(e);
+    if (isEditableKeyboardTarget(e.target)) {
       return;
     }
 
@@ -1032,7 +1073,7 @@ export function VideoPlayer({
           }
           onChannelNavigate?.(parseInt(digitBuffer, 10));
           setDigitBuffer("");
-        } else if (!document.activeElement || document.activeElement === document.body) {
+        } else if (isDocumentBodyActive(eventDocument)) {
           e.preventDefault();
           onToggleSidebar?.();
         }
@@ -1040,8 +1081,8 @@ export function VideoPlayer({
 
       case "Escape":
         e.preventDefault();
-        if (document.activeElement && document.activeElement !== document.body) {
-          (document.activeElement as HTMLElement).blur();
+        if (!isDocumentBodyActive(eventDocument)) {
+          blurActiveElement(eventDocument);
         } else if (digitBuffer) {
           setDigitBuffer("");
           if (digitTimeoutRef.current) {
@@ -1059,7 +1100,7 @@ export function VideoPlayer({
       case "PageDown":
       case "ChannelDown":
         e.preventDefault();
-        (document.activeElement as HTMLElement)?.blur();
+        blurActiveElement(eventDocument);
         onChannelNavigate?.("prev");
         break;
 
@@ -1067,26 +1108,26 @@ export function VideoPlayer({
       case "PageUp":
       case "ChannelUp":
         e.preventDefault();
-        (document.activeElement as HTMLElement)?.blur();
+        blurActiveElement(eventDocument);
         onChannelNavigate?.("next");
         break;
 
       case "ArrowLeft": {
         e.preventDefault();
-        (document.activeElement as HTMLElement)?.blur();
+        blurActiveElement(eventDocument);
         handleRelativeSeek(-5);
         break;
       }
 
       case "ArrowRight": {
         e.preventDefault();
-        (document.activeElement as HTMLElement)?.blur();
+        blurActiveElement(eventDocument);
         handleRelativeSeek(5);
         break;
       }
 
       case " ":
-        if (document.activeElement && document.activeElement !== document.body) {
+        if (!isDocumentBodyActive(eventDocument)) {
           break;
         }
         e.preventDefault();
@@ -1154,12 +1195,10 @@ export function VideoPlayer({
 
     const cleanupA = attachSlot("a");
     const cleanupB = attachSlot("b");
-    window.addEventListener("keydown", handleKeyDown);
 
     return () => {
       cleanupA();
       cleanupB();
-      window.removeEventListener("keydown", handleKeyDown);
 
       if (stablePlaybackTimeoutRef.current) {
         window.clearTimeout(stablePlaybackTimeoutRef.current);
@@ -1171,6 +1210,21 @@ export function VideoPlayer({
       }
     };
   }, []);
+
+  useEffect(() => {
+    const pipWindow = isDocumentPiP ? documentPiPWindowRef.current : null;
+    const targetWindows = pipWindow && pipWindow !== window ? [window, pipWindow] : [window];
+
+    for (const targetWindow of targetWindows) {
+      targetWindow.addEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      for (const targetWindow of targetWindows) {
+        targetWindow.removeEventListener("keydown", handleKeyDown);
+      }
+    };
+  }, [isDocumentPiP]);
 
   const handleVideoClick = useCallback(() => {
     if (showControls) {
@@ -1295,14 +1349,21 @@ export function VideoPlayer({
     if (!needsUserInteraction) return;
 
     const handler = () => handleUserInteraction();
-    document.addEventListener("click", handler);
-    document.addEventListener("keydown", handler);
+    const pipDocument = isDocumentPiP ? documentPiPWindowRef.current?.document : null;
+    const targetDocuments = pipDocument && pipDocument !== document ? [document, pipDocument] : [document];
+
+    for (const targetDocument of targetDocuments) {
+      targetDocument.addEventListener("click", handler);
+      targetDocument.addEventListener("keydown", handler);
+    }
 
     return () => {
-      document.removeEventListener("click", handler);
-      document.removeEventListener("keydown", handler);
+      for (const targetDocument of targetDocuments) {
+        targetDocument.removeEventListener("click", handler);
+        targetDocument.removeEventListener("keydown", handler);
+      }
     };
-  }, [needsUserInteraction]);
+  }, [needsUserInteraction, isDocumentPiP]);
 
   const isVideoPiP = isPiP && !isDocumentPiP;
   const playerSurface = (

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -941,9 +941,8 @@ export function VideoPlayer({
     setIsPiP(true);
   });
 
-  const handleVideoLeavePiP = useEffectEvent((slotId: SlotId) => {
-    if (slotId !== getActiveSlotId()) return;
-    setIsPiP(false);
+  const handleVideoLeavePiP = useEffectEvent(() => {
+    setIsPiP(isDocumentPiP || Boolean(document.pictureInPictureElement));
   });
 
   // Foreground recovery: iOS pauses web media when the page goes to background
@@ -1138,7 +1137,7 @@ export function VideoPlayer({
         ["timeupdate", () => handleVideoTimeUpdate(slotId)],
         ["ended", () => handleVideoEnded(slotId)],
         ["enterpictureinpicture", () => handleVideoEnterPiP(slotId)],
-        ["leavepictureinpicture", () => handleVideoLeavePiP(slotId)],
+        ["leavepictureinpicture", () => handleVideoLeavePiP()],
         ["error", (event) => handleVideoElementError(slotId, event.timeStamp)],
       ];
 

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -203,6 +203,7 @@ export function VideoPlayer({
   const playerDockRef = useRef<HTMLDivElement>(null);
   const playerSurfaceRef = useRef<HTMLDivElement>(null);
   const documentPiPWindowRef = useRef<Window | null>(null);
+  const isUnmountingRef = useRef(false);
   const [playerPortalHost] = useState(() => {
     const host = document.createElement("div");
     host.style.display = "contents";
@@ -420,6 +421,8 @@ export function VideoPlayer({
   }, [isDocumentPiP, playerPortalHost]);
 
   const restoreDocumentPiPPlayer = useEffectEvent(() => {
+    if (isUnmountingRef.current) return;
+
     const dock = playerDockRef.current;
     if (dock && playerPortalHost.parentNode !== dock) {
       dock.append(playerPortalHost);
@@ -431,7 +434,10 @@ export function VideoPlayer({
 
   useEffect(() => {
     return () => {
-      documentPiPWindowRef.current?.close();
+      isUnmountingRef.current = true;
+      const pipWindow = documentPiPWindowRef.current;
+      documentPiPWindowRef.current = null;
+      pipWindow?.close();
       if (playerPortalHost.parentNode) {
         playerPortalHost.parentNode.removeChild(playerPortalHost);
       }

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1239,6 +1239,8 @@ export function VideoPlayer({
     const video = getActiveVideo();
     if (!video) return;
 
+    let openedDocumentPiPWindow: Window | null = null;
+
     try {
       if (await exitPictureInPicture()) {
         return;
@@ -1251,6 +1253,7 @@ export function VideoPlayer({
 
         const pipWindowOptions = getDocumentPiPWindowOptions(playerElement);
         const pipWindow = await documentPictureInPicture.requestWindow(pipWindowOptions);
+        openedDocumentPiPWindow = pipWindow;
         documentPiPWindowRef.current = pipWindow;
         setupDocumentPiPWindow(pipWindow);
         pipWindow.addEventListener("pagehide", () => restoreDocumentPiPPlayer(), { once: true });
@@ -1267,7 +1270,9 @@ export function VideoPlayer({
 
       await video.requestPictureInPicture();
     } catch (err) {
+      const pipWindow = openedDocumentPiPWindow ?? documentPiPWindowRef.current;
       restoreDocumentPiPPlayer();
+      pipWindow?.close();
       console.error("Picture-in-Picture error:", err);
     }
   });

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1,7 +1,15 @@
 import { clsx } from "clsx";
 import { Play } from "lucide-react";
-import { useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
+import {
+  getDocumentPictureInPicture,
+  getDocumentPiPWindowOptions,
+  isAnyPictureInPictureActive,
+  isPictureInPictureSupported,
+  setupDocumentPiPWindow,
+} from "../../lib/document-picture-in-picture";
 import type { Locale } from "../../lib/locale";
 import { buildCatchupSegments } from "../../lib/m3u-parser";
 import { getMuted, getVolume, saveMuted, saveVolume } from "../../lib/player-storage";
@@ -153,6 +161,14 @@ export function VideoPlayer({
 }: VideoPlayerProps) {
   const t = usePlayerTranslation(locale);
 
+  const playerDockRef = useRef<HTMLDivElement>(null);
+  const playerSurfaceRef = useRef<HTMLDivElement>(null);
+  const documentPiPWindowRef = useRef<Window | null>(null);
+  const [playerPortalHost] = useState(() => {
+    const host = document.createElement("div");
+    host.style.display = "contents";
+    return host;
+  });
   const slotAVideoRef = useRef<HTMLVideoElement>(null);
   const slotBVideoRef = useRef<HTMLVideoElement>(null);
   const slotACanvasRef = useRef<HTMLCanvasElement>(null);
@@ -196,6 +212,7 @@ export function VideoPlayer({
   const [needsUserInteraction, setNeedsUserInteraction] = useState(false);
   const [showControls, setShowControls] = useState(true);
   const [isPiP, setIsPiP] = useState(false);
+  const [isDocumentPiP, setIsDocumentPiP] = useState(false);
   const hideControlsTimeoutRef = useRef<number>(0);
   const [retryCount, setRetryCount] = useState(0);
   const [retryBaseline, setRetryBaseline] = useState(0);
@@ -348,6 +365,39 @@ export function VideoPlayer({
       }
     };
   }, [resetControlsTimer]);
+
+  useLayoutEffect(() => {
+    if (isDocumentPiP) return;
+    const dock = playerDockRef.current;
+    if (!dock) return;
+
+    dock.append(playerPortalHost);
+
+    return () => {
+      if (playerPortalHost.parentNode === dock) {
+        dock.removeChild(playerPortalHost);
+      }
+    };
+  }, [isDocumentPiP, playerPortalHost]);
+
+  const restoreDocumentPiPPlayer = useEffectEvent(() => {
+    const dock = playerDockRef.current;
+    if (dock && playerPortalHost.parentNode !== dock) {
+      dock.append(playerPortalHost);
+    }
+    documentPiPWindowRef.current = null;
+    setIsDocumentPiP(false);
+    setIsPiP(!!document.pictureInPictureElement);
+  });
+
+  useEffect(() => {
+    return () => {
+      documentPiPWindowRef.current?.close();
+      if (playerPortalHost.parentNode) {
+        playerPortalHost.parentNode.removeChild(playerPortalHost);
+      }
+    };
+  }, [playerPortalHost]);
 
   const cancelPendingTransition = useEffectEvent(() => {
     pendingTransitionRef.current = null;
@@ -906,7 +956,7 @@ export function VideoPlayer({
     const activePlayer = getActivePlayer();
     if (!video || !activePlayer || error || needsUserInteraction) return;
     // PiP keeps playing in background; nothing to recover
-    if (document.pictureInPictureElement) return;
+    if (isAnyPictureInPictureActive()) return;
     // Respect an explicit user pause; only recover from OS-initiated interruptions
     if (userPausedRef.current) return;
 
@@ -1148,8 +1198,26 @@ export function VideoPlayer({
     }
   });
 
-  const handleFullscreen = useEffectEvent(() => {
+  const exitPictureInPicture = useEffectEvent(async (): Promise<boolean> => {
+    const documentPictureInPicture = getDocumentPictureInPicture();
+    const pipWindow = documentPictureInPicture?.window ?? documentPiPWindowRef.current;
+    if (pipWindow) {
+      restoreDocumentPiPPlayer();
+      pipWindow.close();
+      return true;
+    }
+
+    if (document.pictureInPictureElement) {
+      await document.exitPictureInPicture();
+      return true;
+    }
+
+    return false;
+  });
+
+  const handleFullscreen = useEffectEvent(async () => {
     const isIOS = /iPhone|iPod/.test(navigator.userAgent);
+    await exitPictureInPicture();
 
     const video = getActiveVideo();
     if (isIOS && video) {
@@ -1172,12 +1240,34 @@ export function VideoPlayer({
     if (!video) return;
 
     try {
-      if (document.pictureInPictureElement) {
-        await document.exitPictureInPicture();
-      } else {
-        await video.requestPictureInPicture();
+      if (await exitPictureInPicture()) {
+        return;
       }
+
+      const documentPictureInPicture = getDocumentPictureInPicture();
+      if (documentPictureInPicture) {
+        const playerElement = playerSurfaceRef.current;
+        if (!playerElement) return;
+
+        const pipWindowOptions = getDocumentPiPWindowOptions(playerElement);
+        const pipWindow = await documentPictureInPicture.requestWindow(pipWindowOptions);
+        documentPiPWindowRef.current = pipWindow;
+        setupDocumentPiPWindow(pipWindow);
+        pipWindow.addEventListener("pagehide", () => restoreDocumentPiPPlayer(), { once: true });
+        setIsDocumentPiP(true);
+        setIsPiP(true);
+        showControlsImmediately();
+        pipWindow.document.body.append(playerPortalHost);
+        return;
+      }
+
+      if (!document.pictureInPictureEnabled || !video.requestPictureInPicture) {
+        return;
+      }
+
+      await video.requestPictureInPicture();
     } catch (err) {
+      restoreDocumentPiPPlayer();
       console.error("Picture-in-Picture error:", err);
     }
   });
@@ -1210,173 +1300,187 @@ export function VideoPlayer({
     };
   }, [needsUserInteraction]);
 
-  return (
+  const isVideoPiP = isPiP && !isDocumentPiP;
+  const playerSurface = (
     <div
       role="application"
-      className="relative w-full bg-black md:h-full pt-[env(safe-area-inset-top)]"
+      ref={playerSurfaceRef}
+      className={clsx(
+        "@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-black",
+        isDocumentPiP ? "h-screen min-h-screen aspect-auto" : "md:aspect-auto md:h-full",
+        !showControls && "cursor-none",
+      )}
       onMouseMove={showControlsImmediately}
       onMouseLeave={hideControlsImmediately}
     >
       {/* Player area sizes the 16:9 frame via container queries; sources stretch to 16:9 inside it. */}
-      <div
-        className={clsx(
-          "@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center md:aspect-auto md:h-full",
-          !showControls && "cursor-none",
-        )}
-      >
-        <div className="relative aspect-video h-auto max-h-full w-full max-w-full overflow-hidden [@container_video_(max-aspect-ratio:_16/9)]:h-auto [@container_video_(max-aspect-ratio:_16/9)]:w-full [@container_video_(min-aspect-ratio:_16/9)]:h-full [@container_video_(min-aspect-ratio:_16/9)]:w-auto">
-          {(visibleSlotId === "a" ? (["b", "a"] as const) : (["a", "b"] as const)).map((slotId) => (
-            <div key={slotId} className="contents">
-              {/* biome-ignore lint/a11y/useMediaCaption: live streaming video has no caption tracks */}
-              <video
-                ref={slotId === "a" ? slotAVideoRef : slotBVideoRef}
-                className={clsx(
-                  "absolute inset-0 size-full min-h-0 min-w-0 object-fill",
-                  // Background slot: opacity (not visibility) keeps requestVideoFrameCallback
-                  // firing so interlace detection can warm up during seamless switch.
-                  visibleSlotId !== slotId && "opacity-0 pointer-events-none",
-                  // Active slot: hide raw video behind the deinterlaced canvas output
-                  visibleSlotId === slotId && deinterlaceActiveSlots[slotId] && "opacity-0",
-                )}
-                playsInline
-                webkit-playsinline="true"
-                x5-playsinline="true"
-                onClick={visibleSlotId === slotId ? handleVideoClick : undefined}
-              />
-              <canvas
-                ref={slotId === "a" ? slotACanvasRef : slotBCanvasRef}
-                className={clsx(
-                  "pointer-events-none absolute inset-0 size-full min-h-0 min-w-0",
-                  (visibleSlotId !== slotId || !deinterlaceActiveSlots[slotId]) && "hidden",
-                )}
-              />
-            </div>
-          ))}
-        </div>
-
-        {!needsUserInteraction && !error && (
-          <PlayerTopLeftOverlay
-            visible={showControls || showLoading}
-            loading={showLoading}
-            loadingText={`${
-              channel && channel.sources.length > 1
-                ? `[${channel.sources[activeSourceIndex]?.label || `${t("source")} ${activeSourceIndex + 1}`}] `
-                : ""
-            }${t("loadingVideo")}${retryCount - retryBaseline > 0 ? ` (${retryCount - retryBaseline}/${MAX_RETRIES})` : ""}`}
-          />
-        )}
-
-        {/* Channel Info and Controls */}
-        {channel && (
-          <div
-            className={clsx(
-              "absolute top-4 right-4 md:top-8 md:right-8 z-10 flex flex-col gap-2 md:gap-3 items-end transition-opacity duration-300",
-              showControls ? "opacity-100" : "opacity-0",
-            )}
-          >
-            <div
+      <div className="relative aspect-video h-auto max-h-full w-full max-w-full overflow-hidden [@container_video_(max-aspect-ratio:_16/9)]:h-auto [@container_video_(max-aspect-ratio:_16/9)]:w-full [@container_video_(min-aspect-ratio:_16/9)]:h-full [@container_video_(min-aspect-ratio:_16/9)]:w-auto">
+        {(visibleSlotId === "a" ? (["b", "a"] as const) : (["a", "b"] as const)).map((slotId) => (
+          <div key={slotId} className="contents">
+            {/* biome-ignore lint/a11y/useMediaCaption: live streaming video has no caption tracks */}
+            <video
+              ref={slotId === "a" ? slotAVideoRef : slotBVideoRef}
               className={clsx(
-                PLAYER_OVERLAY_SURFACE_CLASS,
-                "flex max-w-[calc(100vw-2rem)] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg px-2 py-1.5 md:max-w-none md:gap-2 md:px-3 md:py-2",
+                "absolute inset-0 size-full min-h-0 min-w-0 object-fill",
+                // Background slot: opacity (not visibility) keeps requestVideoFrameCallback
+                // firing so interlace detection can warm up during seamless switch.
+                visibleSlotId !== slotId && "opacity-0 pointer-events-none",
+                // Active slot: hide raw video behind the deinterlaced canvas output.
+                // Traditional video PiP uses the video element itself, so keep it visible and hide canvas instead.
+                visibleSlotId === slotId && deinterlaceActiveSlots[slotId] && !isVideoPiP && "opacity-0",
               )}
-            >
-              {channel.logo && (
-                <img
-                  src={channel.logo}
-                  alt={channel.name}
-                  referrerPolicy="no-referrer"
-                  className="h-8 w-20 md:h-14 md:w-36 object-contain"
-                  onError={(e) => {
-                    (e.target as HTMLImageElement).style.display = "none";
-                  }}
-                />
-              )}
-              <div className="flex items-center justify-center w-full">
-                <div className="flex items-center gap-1.5 md:gap-2 min-w-0">
-                  <span
-                    className={clsx(
-                      "rounded px-1 py-0.5 md:px-1.5 text-[10px] md:text-xs font-medium shrink-0 transition-[color,background-color,box-shadow,scale] duration-300",
-                      digitBuffer
-                        ? "bg-primary text-primary-foreground scale-110 shadow-lg ring-2 ring-primary/50"
-                        : "bg-white/10 text-white/60",
-                    )}
-                  >
-                    {digitBuffer || channel.id}
-                  </span>
-                  <h2 className="text-xs md:text-base font-bold text-white truncate">{channel.name}</h2>
-                  {channel.groups.length > 0 && (
-                    <>
-                      <span className="text-xs md:text-sm text-white/50 hidden sm:inline">·</span>
-                      <div className="text-xs md:text-sm text-white/70 truncate hidden sm:block">
-                        {channel.groups.join(" / ")}
-                      </div>
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {needsUserInteraction && (
-          <button
-            type="button"
-            className="absolute inset-0 z-10 flex cursor-pointer items-center justify-center bg-black/80 p-4 transition-opacity hover:bg-black/85 border-none"
-            onClick={handleUserInteraction}
-          >
-            <div className="flex flex-col items-center gap-4 text-white">
-              <Play className="h-20 w-20 opacity-90 fill-current" />
-              <div className="text-center">
-                <div className="mb-2 text-2xl font-semibold">{t("clickToPlay")}</div>
-                <div className="text-sm text-white/70">{t("autoplayBlocked")}</div>
-              </div>
-            </div>
-          </button>
-        )}
-
-        {error && (
-          <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/90 p-4">
-            <div className="max-w-md rounded-lg bg-red-500/20 p-4 text-white">
-              <div className="mb-2 text-lg font-semibold">{t("playbackError")}</div>
-              <div className="text-sm">{error}</div>
-            </div>
-          </div>
-        )}
-
-        {channel && !error && !needsUserInteraction && (
-          <div
-            role="toolbar"
-            className={clsx(
-              "absolute bottom-0 left-0 right-0 z-10 transition-opacity duration-300",
-              showControls ? "opacity-100" : "opacity-0 has-focus-visible:opacity-100",
-            )}
-            onMouseEnter={showControlsImmediately}
-          >
-            <PlayerControls
-              channel={channel}
-              currentTime={currentVideoTime}
-              currentProgram={currentProgram}
-              isLive={isLive}
-              onSeek={handleSeek}
-              locale={locale}
-              seekStartTime={streamStartTime}
-              isPlaying={isPlaying}
-              onPlayPause={togglePlayPause}
-              volume={volume}
-              onVolumeChange={handleVolumeChange}
-              isMuted={isMuted}
-              onMuteToggle={handleMuteToggle}
-              onFullscreen={handleFullscreen}
-              showSidebar={showSidebar}
-              onToggleSidebar={onToggleSidebar}
-              isPiP={isPiP}
-              onPiPToggle={handlePiPToggle}
-              activeSourceIndex={activeSourceIndex}
-              onSourceChange={onSourceChange}
+              playsInline
+              webkit-playsinline="true"
+              x5-playsinline="true"
+              onClick={visibleSlotId === slotId ? handleVideoClick : undefined}
             />
+            <canvas
+              ref={slotId === "a" ? slotACanvasRef : slotBCanvasRef}
+              className={clsx(
+                "pointer-events-none absolute inset-0 size-full min-h-0 min-w-0",
+                (isVideoPiP || visibleSlotId !== slotId || !deinterlaceActiveSlots[slotId]) && "hidden",
+              )}
+            />
+          </div>
+        ))}
+      </div>
+
+      {!needsUserInteraction && !error && (
+        <PlayerTopLeftOverlay
+          visible={showControls || showLoading}
+          loading={showLoading}
+          loadingText={`${
+            channel && channel.sources.length > 1
+              ? `[${channel.sources[activeSourceIndex]?.label || `${t("source")} ${activeSourceIndex + 1}`}] `
+              : ""
+          }${t("loadingVideo")}${retryCount - retryBaseline > 0 ? ` (${retryCount - retryBaseline}/${MAX_RETRIES})` : ""}`}
+        />
+      )}
+
+      {/* Channel Info and Controls */}
+      {channel && (
+        <div
+          className={clsx(
+            "absolute top-4 right-4 md:top-8 md:right-8 z-10 flex flex-col gap-2 md:gap-3 items-end transition-opacity duration-300",
+            showControls ? "opacity-100" : "opacity-0",
+          )}
+        >
+          <div
+            className={clsx(
+              PLAYER_OVERLAY_SURFACE_CLASS,
+              "flex max-w-[calc(100vw-2rem)] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg px-2 py-1.5 md:max-w-none md:gap-2 md:px-3 md:py-2",
+            )}
+          >
+            {channel.logo && (
+              <img
+                src={channel.logo}
+                alt={channel.name}
+                referrerPolicy="no-referrer"
+                className="h-8 w-20 md:h-14 md:w-36 object-contain"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = "none";
+                }}
+              />
+            )}
+            <div className="flex items-center justify-center w-full">
+              <div className="flex items-center gap-1.5 md:gap-2 min-w-0">
+                <span
+                  className={clsx(
+                    "rounded px-1 py-0.5 md:px-1.5 text-[10px] md:text-xs font-medium shrink-0 transition-[color,background-color,box-shadow,scale] duration-300",
+                    digitBuffer
+                      ? "bg-primary text-primary-foreground scale-110 shadow-lg ring-2 ring-primary/50"
+                      : "bg-white/10 text-white/60",
+                  )}
+                >
+                  {digitBuffer || channel.id}
+                </span>
+                <h2 className="text-xs md:text-base font-bold text-white truncate">{channel.name}</h2>
+                {channel.groups.length > 0 && (
+                  <>
+                    <span className="text-xs md:text-sm text-white/50 hidden sm:inline">·</span>
+                    <div className="text-xs md:text-sm text-white/70 truncate hidden sm:block">
+                      {channel.groups.join(" / ")}
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {needsUserInteraction && (
+        <button
+          type="button"
+          className="absolute inset-0 z-10 flex cursor-pointer items-center justify-center bg-black/80 p-4 transition-opacity hover:bg-black/85 border-none"
+          onClick={handleUserInteraction}
+        >
+          <div className="flex flex-col items-center gap-4 text-white">
+            <Play className="h-20 w-20 opacity-90 fill-current" />
+            <div className="text-center">
+              <div className="mb-2 text-2xl font-semibold">{t("clickToPlay")}</div>
+              <div className="text-sm text-white/70">{t("autoplayBlocked")}</div>
+            </div>
+          </div>
+        </button>
+      )}
+
+      {error && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/90 p-4">
+          <div className="max-w-md rounded-lg bg-red-500/20 p-4 text-white">
+            <div className="mb-2 text-lg font-semibold">{t("playbackError")}</div>
+            <div className="text-sm">{error}</div>
+          </div>
+        </div>
+      )}
+
+      {channel && !error && !needsUserInteraction && (
+        <div
+          role="toolbar"
+          className={clsx(
+            "absolute bottom-0 left-0 right-0 z-10 transition-opacity duration-300",
+            showControls ? "opacity-100" : "opacity-0 has-focus-visible:opacity-100",
+          )}
+          onMouseEnter={showControlsImmediately}
+        >
+          <PlayerControls
+            channel={channel}
+            currentTime={currentVideoTime}
+            currentProgram={currentProgram}
+            isLive={isLive}
+            onSeek={handleSeek}
+            locale={locale}
+            seekStartTime={streamStartTime}
+            isPlaying={isPlaying}
+            onPlayPause={togglePlayPause}
+            volume={volume}
+            onVolumeChange={handleVolumeChange}
+            isMuted={isMuted}
+            onMuteToggle={handleMuteToggle}
+            onFullscreen={handleFullscreen}
+            showSidebar={showSidebar}
+            onToggleSidebar={onToggleSidebar}
+            isPiP={isPiP}
+            isPiPSupported={isPictureInPictureSupported()}
+            onPiPToggle={handlePiPToggle}
+            activeSourceIndex={activeSourceIndex}
+            onSourceChange={onSourceChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="relative w-full bg-black md:h-full pt-[env(safe-area-inset-top)]">
+      <div ref={playerDockRef} className="contents">
+        {isDocumentPiP && (
+          <div className="@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-black px-4 text-center text-sm font-medium text-white/70 md:aspect-auto md:h-full md:text-base">
+            {t("playingInPictureInPicture")}
           </div>
         )}
       </div>
+      {createPortal(playerSurface, playerPortalHost)}
     </div>
   );
 }

--- a/web-ui/src/i18n/player.ts
+++ b/web-ui/src/i18n/player.ts
@@ -36,6 +36,7 @@ const base: TranslationDict = {
   playbackError: "Playback Error",
   clickToPlay: "Click to Play",
   autoplayBlocked: "Browser requires user interaction to start playback",
+  playingInPictureInPicture: "Video is playing in Picture-in-Picture",
 
   // Errors
   failedToLoadPlaylist: "Failed to load playlist",
@@ -78,7 +79,6 @@ const base: TranslationDict = {
   fullscreen: "Fullscreen",
   exitFullscreen: "Exit Fullscreen",
   pictureInPicture: "Picture in Picture",
-  exitPictureInPicture: "Exit Picture in Picture",
 
   // Relative dates
   today: "Today",
@@ -135,6 +135,7 @@ const zhHans: TranslationDict = {
   playbackError: "播放错误",
   clickToPlay: "点击播放",
   autoplayBlocked: "浏览器需要用户交互才能开始播放",
+  playingInPictureInPicture: "视频正在画中画模式下播放",
 
   // 错误信息
   failedToLoadPlaylist: "加载播放列表失败",
@@ -177,7 +178,6 @@ const zhHans: TranslationDict = {
   fullscreen: "全屏",
   exitFullscreen: "退出全屏",
   pictureInPicture: "画中画",
-  exitPictureInPicture: "退出画中画",
 
   // 相对日期
   today: "今天",
@@ -235,6 +235,7 @@ const zhHant: TranslationDict = {
   playbackError: "播放錯誤",
   clickToPlay: "點擊播放",
   autoplayBlocked: "瀏覽器需要用戶互動才能開始播放",
+  playingInPictureInPicture: "影片正在畫中畫模式下播放",
 
   // 錯誤訊息
   failedToLoadPlaylist: "載入播放列表失敗",
@@ -277,7 +278,6 @@ const zhHant: TranslationDict = {
   fullscreen: "全屏",
   exitFullscreen: "退出全屏",
   pictureInPicture: "畫中畫",
-  exitPictureInPicture: "退出畫中畫",
 
   // 相對日期
   today: "今天",

--- a/web-ui/src/lib/document-picture-in-picture.ts
+++ b/web-ui/src/lib/document-picture-in-picture.ts
@@ -24,7 +24,7 @@ export function getDocumentPictureInPicture(): DocumentPictureInPictureControlle
 }
 
 export function isPictureInPictureSupported(): boolean {
-  return getDocumentPictureInPicture() !== null || document.pictureInPictureEnabled;
+  return getDocumentPictureInPicture() !== null || Boolean(document.pictureInPictureEnabled);
 }
 
 export function isAnyPictureInPictureActive(): boolean {

--- a/web-ui/src/lib/document-picture-in-picture.ts
+++ b/web-ui/src/lib/document-picture-in-picture.ts
@@ -1,0 +1,91 @@
+type DocumentPictureInPictureOptions = {
+  preferInitialWindowPlacement?: boolean;
+  width?: number;
+  height?: number;
+};
+
+type DocumentPictureInPictureController = {
+  readonly window: Window | null;
+  requestWindow: (options?: DocumentPictureInPictureOptions) => Promise<Window>;
+};
+
+type WindowWithDocumentPictureInPicture = Window & {
+  readonly documentPictureInPicture?: DocumentPictureInPictureController;
+};
+
+const DOCUMENT_PIP_ASPECT_RATIO = 16 / 9;
+const DOCUMENT_PIP_MIN_WIDTH = 320;
+const DOCUMENT_PIP_MAX_WIDTH = 640;
+const DOCUMENT_PIP_FALLBACK_WIDTH = 480;
+
+export function getDocumentPictureInPicture(): DocumentPictureInPictureController | null {
+  const documentPictureInPicture = (window as WindowWithDocumentPictureInPicture).documentPictureInPicture;
+  return documentPictureInPicture?.requestWindow ? documentPictureInPicture : null;
+}
+
+export function isPictureInPictureSupported(): boolean {
+  return getDocumentPictureInPicture() !== null || document.pictureInPictureEnabled;
+}
+
+export function isAnyPictureInPictureActive(): boolean {
+  return !!(document.pictureInPictureElement || getDocumentPictureInPicture()?.window);
+}
+
+type DocumentPiPWindowSize = {
+  width: number;
+  height: number;
+};
+
+type DocumentPiPWindowOptions = DocumentPiPWindowSize & {
+  preferInitialWindowPlacement: true;
+};
+
+export function getDocumentPiPWindowOptions(playerElement: HTMLElement): DocumentPiPWindowOptions {
+  const rect = playerElement.getBoundingClientRect();
+  const sourceWidth = rect.width > 0 ? rect.width : DOCUMENT_PIP_FALLBACK_WIDTH;
+  const width = Math.round(Math.min(Math.max(sourceWidth, DOCUMENT_PIP_MIN_WIDTH), DOCUMENT_PIP_MAX_WIDTH));
+
+  return {
+    preferInitialWindowPlacement: true,
+    width,
+    height: Math.round(width / DOCUMENT_PIP_ASPECT_RATIO),
+  };
+}
+
+function copyStyleSheetsToWindow(targetWindow: Window): void {
+  const targetDocument = targetWindow.document;
+
+  for (const styleSheet of Array.from(document.styleSheets)) {
+    try {
+      const cssRules = Array.from(styleSheet.cssRules, (rule) => rule.cssText).join("\n");
+      const style = targetDocument.createElement("style");
+      style.textContent = cssRules;
+      targetDocument.head.appendChild(style);
+    } catch {
+      if (!styleSheet.href) continue;
+
+      const link = targetDocument.createElement("link");
+      link.rel = "stylesheet";
+      link.href = styleSheet.href;
+      link.media = styleSheet.media.mediaText;
+      targetDocument.head.appendChild(link);
+    }
+  }
+}
+
+export function setupDocumentPiPWindow(targetWindow: Window): void {
+  const targetDocument = targetWindow.document;
+  targetDocument.title = document.title;
+  targetDocument.documentElement.className = document.documentElement.className;
+  targetDocument.documentElement.style.colorScheme = document.documentElement.style.colorScheme;
+  targetDocument.documentElement.style.width = "100%";
+  targetDocument.documentElement.style.height = "100%";
+  targetDocument.body.className = "overflow-hidden overscroll-none bg-black text-foreground antialiased";
+  targetDocument.body.style.margin = "0";
+  targetDocument.body.style.width = "100%";
+  targetDocument.body.style.height = "100%";
+  targetDocument.body.style.overflow = "hidden";
+  targetDocument.body.style.background = "#000";
+
+  copyStyleSheetsToWindow(targetWindow);
+}


### PR DESCRIPTION
## Summary

This updates the web player Picture-in-Picture flow to prefer Document Picture-in-Picture when available, so the whole player surface moves into the PiP window with controls and overlays. Browsers without Document Picture-in-Picture continue to use the standard video Picture-in-Picture API.

The follow-up cleanup keeps the PiP behavior DRY by centralizing exit handling, moving Document PiP helpers into `web-ui/src/lib/`, and removing unused exit-PiP control text now that the in-player button is hidden while PiP is active. The generated embedded web data is intentionally left out of this PR.

## Validation

- `pnpm exec biome check --write web-ui/src/components/player/video-player.tsx web-ui/src/components/player/player-controls.tsx web-ui/src/lib/document-picture-in-picture.ts web-ui/src/i18n/player.ts`
- `pnpm run type-check:tsc`
- `pnpm run web-ui:build`
- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AGGRESSIVE_OPT=ON`
- `cmake --build build -j$(getconf _NPROCESSORS_ONLN)`
- `git diff --check`
- `git diff --cached --check`