### PR TITLE
test(e2e): stabilize RTSP user-agent config checks

### DIFF
--- a/e2e/test_config.py
+++ b/e2e/test_config.py
@@ -27,6 +27,17 @@ _INLINE_M3U = """\
 rtp://239.0.0.1:1234
 """
 
+_RTSP_DURATION_SDP = (
+    "v=0\r\n"
+    "o=- 0 0 IN IP4 127.0.0.1\r\n"
+    "s=T\r\n"
+    "c=IN IP4 0.0.0.0\r\n"
+    "t=0 0\r\n"
+    "a=range:npt=0.000-60.000\r\n"
+    "m=video 0 RTP/AVP 33\r\n"
+    "a=control:*\r\n"
+)
+
 
 def _build_config(
     port: int,
@@ -181,22 +192,24 @@ def _assert_udpxy_state(port: int, expected_enabled: bool):
 
 
 def _assert_rtsp_user_agent(port: int, expected_user_agent: str):
-    rtsp = MockRTSPServer(num_packets=50)
+    rtsp = MockRTSPServer(custom_sdp=_RTSP_DURATION_SDP)
     rtsp.start()
     try:
-        status, _, body = stream_get(
+        status, _, body = http_get(
             "127.0.0.1",
             port,
-            "/rtsp/127.0.0.1:%d/stream" % rtsp.port,
-            read_bytes=1024,
+            "/rtsp/127.0.0.1:%d/stream?r2h-duration=1" % rtsp.port,
             timeout=10.0,
         )
         assert status == 200, f"Expected 200, got {status}"
-        assert len(body) > 0, "Expected RTSP stream body"
+        assert b'"duration"' in body, "Expected RTSP duration response"
 
         option_reqs = [req for req in rtsp.requests_detailed if req["method"] == "OPTIONS"]
         assert option_reqs, "Expected OPTIONS request"
         assert option_reqs[0]["headers"].get("User-Agent") == expected_user_agent
+        describe_reqs = [req for req in rtsp.requests_detailed if req["method"] == "DESCRIBE"]
+        assert describe_reqs, "Expected DESCRIBE request"
+        assert describe_reqs[0]["headers"].get("User-Agent") == expected_user_agent
     finally:
         rtsp.stop()
 


### PR DESCRIPTION
## What changed

This narrows the RTSP user-agent configuration assertion in the E2E config suite. The test now uses an RTSP duration query to trigger OPTIONS and DESCRIBE, then verifies the upstream User-Agent header on both requests.

## Why

The previous assertion used a full RTSP streaming request, so a transient SETUP, PLAY, or media forwarding timeout on the FreeBSD VM could fail the config-priority test before it ever checked the header. The new path still covers the configured User-Agent reaching the RTSP request layer, but avoids depending on full media playback.

## Validation

Ran ruff, collect-only, focused config tests in serial and parallel, and the full E2E suite locally. Full E2E passed with 487 passed and 8 skipped.