### PR TITLE
fix(web-ui): fall back to video PiP when Document PiP is blocked in iframe

### DIFF
--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -7,6 +7,7 @@ import {
   getDocumentPictureInPicture,
   getDocumentPiPWindowOptions,
   isAnyPictureInPictureActive,
+  isDocumentPictureInPictureBlockedError,
   isPictureInPictureSupported,
   setupDocumentPiPWindow,
 } from "../../lib/document-picture-in-picture";
@@ -1302,6 +1303,13 @@ export function VideoPlayer({
     }
   });
 
+  const requestVideoPictureInPicture = useEffectEvent(async (video: HTMLVideoElement) => {
+    if (!document.pictureInPictureEnabled || !video.requestPictureInPicture) {
+      return;
+    }
+    await video.requestPictureInPicture();
+  });
+
   const handlePiPToggle = useEffectEvent(async () => {
     const video = getActiveVideo();
     if (!video) return;
@@ -1319,7 +1327,19 @@ export function VideoPlayer({
         if (!playerElement) return;
 
         const pipWindowOptions = getDocumentPiPWindowOptions(playerElement);
-        const pipWindow = await documentPictureInPicture.requestWindow(pipWindowOptions);
+        let pipWindow: Window;
+        try {
+          pipWindow = await documentPictureInPicture.requestWindow(pipWindowOptions);
+        } catch (err) {
+          // Document PiP is only allowed from a top-level browsing context. When the
+          // player is embedded in an iframe, requestWindow rejects with NotAllowedError —
+          // fall back to the traditional video Picture-in-Picture API instead.
+          if (isDocumentPictureInPictureBlockedError(err)) {
+            await requestVideoPictureInPicture(video);
+            return;
+          }
+          throw err;
+        }
         openedDocumentPiPWindow = pipWindow;
         documentPiPWindowRef.current = pipWindow;
         setupDocumentPiPWindow(pipWindow);
@@ -1331,11 +1351,7 @@ export function VideoPlayer({
         return;
       }
 
-      if (!document.pictureInPictureEnabled || !video.requestPictureInPicture) {
-        return;
-      }
-
-      await video.requestPictureInPicture();
+      await requestVideoPictureInPicture(video);
     } catch (err) {
       const pipWindow = openedDocumentPiPWindow ?? documentPiPWindowRef.current;
       restoreDocumentPiPPlayer();

--- a/web-ui/src/lib/document-picture-in-picture.ts
+++ b/web-ui/src/lib/document-picture-in-picture.ts
@@ -27,6 +27,17 @@ export function isPictureInPictureSupported(): boolean {
   return getDocumentPictureInPicture() !== null || Boolean(document.pictureInPictureEnabled);
 }
 
+/**
+ * Document Picture-in-Picture (`requestWindow`) is only permitted from a top-level
+ * browsing context. When the player runs inside an iframe the call rejects with a
+ * `NotAllowedError` DOMException ("Opening a PiP window is only allowed from a
+ * top-level browsing context"). Detect that so callers can fall back to the
+ * traditional video Picture-in-Picture API.
+ */
+export function isDocumentPictureInPictureBlockedError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "NotAllowedError";
+}
+
 export function isAnyPictureInPictureActive(): boolean {
   return !!(document.pictureInPictureElement || getDocumentPictureInPicture()?.window);
 }


### PR DESCRIPTION
## Problem

When the web player runs inside an iframe, triggering Picture-in-Picture via the Document Picture-in-Picture API fails with:

```
Picture-in-Picture error: NotAllowedError: Failed to execute 'requestWindow' on 'DocumentPictureInPicture': Opening a PiP window is only allowed from a top-level browsing context
```

Document PiP's `requestWindow()` is only permitted from a top-level browsing context. Previously this rejection surfaced only as a logged error in the outer `catch`, leaving PiP silently broken for embedded players.

## Fix

- Add `isDocumentPictureInPictureBlockedError()` to `document-picture-in-picture.ts` to detect the `NotAllowedError` DOMException.
- In `handlePiPToggle`, wrap `requestWindow()` in a `try/catch`. When the blocked-context error is detected, fall back to the traditional video `requestPictureInPicture()` API (which iframes may use via `allow="picture-in-picture"`). Other errors are re-thrown to the existing handler.
- Extract the video-PiP path into a small `requestVideoPictureInPicture` helper so both the non-Document-PiP branch and the fallback share it.

## Verification

- `pnpm exec tsc --noEmit` → exit 0
- `pnpm exec biome check` on both changed files → no issues

`src/embedded_web_data.h` is intentionally not rebuilt/committed (per project conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)