### PR TITLE
feat(web-ui): note 1080p-only scope for deinterlace & enhancement toggles

### DIFF
--- a/web-ui/src/components/player/settings-dropdown.tsx
+++ b/web-ui/src/components/player/settings-dropdown.tsx
@@ -118,24 +118,34 @@ function SettingsDropdownComponent({
               />
             </div>
 
-            {/* Automatic deinterlacing (heuristic detection, ≤1080 content only) */}
-            <div className="flex items-center justify-between px-1">
-              <span className="text-xs font-medium text-muted-foreground">{t("deinterlace")}</span>
-              <Switch
-                checked={autoDeinterlace}
-                onCheckedChange={onAutoDeinterlaceChange}
-                aria-label={t("deinterlace")}
-              />
-            </div>
+            {/* Video processing group: deinterlace + picture enhancement.
+                Both only take effect for 1080p-and-below content, so the
+                resolution caveat is stated once as a shared group note. */}
+            <div className="space-y-3 border-t border-border pt-3">
+              <div className="px-1">
+                <span className="block text-xs font-medium text-muted-foreground">{t("videoProcessing")}</span>
+                <span className="block text-[11px] text-muted-foreground/70 mt-0.5">{t("resolutionLimitHint")}</span>
+              </div>
 
-            {/* Picture enhancement (WebGL post-processing inside the render gate) */}
-            <div className="flex items-center justify-between px-1">
-              <span className="text-xs font-medium text-muted-foreground">{t("pictureEnhancement")}</span>
-              <Switch
-                checked={pictureEnhancement}
-                onCheckedChange={onPictureEnhancementChange}
-                aria-label={t("pictureEnhancement")}
-              />
+              {/* Automatic deinterlacing (heuristic detection, ≤1080 content only) */}
+              <div className="flex items-center justify-between px-1">
+                <span className="text-xs font-medium text-muted-foreground">{t("deinterlace")}</span>
+                <Switch
+                  checked={autoDeinterlace}
+                  onCheckedChange={onAutoDeinterlaceChange}
+                  aria-label={t("deinterlace")}
+                />
+              </div>
+
+              {/* Picture enhancement (WebGL post-processing inside the render gate) */}
+              <div className="flex items-center justify-between px-1">
+                <span className="text-xs font-medium text-muted-foreground">{t("pictureEnhancement")}</span>
+                <Switch
+                  checked={pictureEnhancement}
+                  onCheckedChange={onPictureEnhancementChange}
+                  aria-label={t("pictureEnhancement")}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/web-ui/src/i18n/player.ts
+++ b/web-ui/src/i18n/player.ts
@@ -98,6 +98,8 @@ const base: TranslationDict = {
   themeLight: "Light",
   themeDark: "Dark",
   seamlessSwitch: "Seamless switch",
+  videoProcessing: "Video Processing",
+  resolutionLimitHint: "1080p and below only",
   deinterlace: "Auto Deinterlacing",
   pictureEnhancement: "Picture Enhancement",
 };
@@ -198,6 +200,8 @@ const zhHans: TranslationDict = {
   themeLight: "浅色",
   themeDark: "深色",
   seamlessSwitch: "无缝换台",
+  videoProcessing: "画质处理",
+  resolutionLimitHint: "仅 1080P 及以下生效",
   deinterlace: "自动反交错",
   pictureEnhancement: "画质增强",
 };
@@ -299,6 +303,8 @@ const zhHant: TranslationDict = {
   themeLight: "淺色",
   themeDark: "深色",
   seamlessSwitch: "無縫換台",
+  videoProcessing: "畫質處理",
+  resolutionLimitHint: "僅 1080P 及以下生效",
   deinterlace: "自動反交錯",
   pictureEnhancement: "畫質增強",
 };


### PR DESCRIPTION
## 背景

播放器设置里的「自动反交错」和「画质增强」两个开关，仅对 **1080P 及以下**分辨率的内容生效，但此前 UI 未向用户明示，容易误以为对 4K 等高分辨率流也起作用。

## 改动

- 在 `settings-dropdown.tsx` 中，将这两个开关归入一个「画质处理 / Video Processing」分组，顶部加分组标题与一条共用说明「仅 1080P 及以下生效」，并用 `border-t` 与上方的「无缝换台」分隔。
- 分组说明只写一次，避免两项各写一遍的重复。
- 新增 i18n key `videoProcessing` / `resolutionLimitHint`，补齐 en / zh-Hans / zh-Hant 三种语言。

纯展示层改动，不涉及开关的状态、存储或渲染管线逻辑。未重建 web-ui，`src/embedded_web_data.h` 未改动。

## 验证

- `pnpm run type-check:tsc` 通过
- `biome check` 对两个改动文件无问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)