### PR TITLE
fix(player): stabilize iOS Safari controls toggle on tap

### DIFF
--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -42,13 +42,9 @@ import type { Channel, EPGProgram } from "../../types/player";
 import { PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
 import { PlayerControls } from "./player-controls";
 
-/** Window after touchstart during which synthesized mouse events are ignored. */
+/** Ignore WebKit mouse events synthesized from a finger tap (they race click toggle). */
 const TOUCH_MOUSE_SUPPRESS_MS = 700;
 
-/**
- * True for mouse events that WebKit synthesizes from a finger tap.
- * Prefer InputDeviceCapabilities when present; otherwise use a recent touchstart timestamp.
- */
 function isTouchDerivedMouseEvent(event: ReactMouseEvent, lastTouchAt: number): boolean {
   const native = event.nativeEvent as MouseEvent & {
     sourceCapabilities?: { firesTouchEvents?: boolean } | null;
@@ -430,23 +426,9 @@ export function VideoPlayer({
     setShowControls(false);
   }, []);
 
+  // Desktop hover wakes controls; touch-synthesized mousemove is ignored so it
+  // cannot race the click toggle. Auto-hide is timer-only (no mouseleave hide).
   const handlePlayerMouseMove = useCallback(
-    (event: ReactMouseEvent) => {
-      if (isTouchDerivedMouseEvent(event, lastTouchAtRef.current)) return;
-      showControlsImmediately();
-    },
-    [showControlsImmediately],
-  );
-
-  const handlePlayerMouseLeave = useCallback(
-    (event: ReactMouseEvent) => {
-      if (isTouchDerivedMouseEvent(event, lastTouchAtRef.current)) return;
-      hideControlsImmediately();
-    },
-    [hideControlsImmediately],
-  );
-
-  const handleControlsMouseEnter = useCallback(
     (event: ReactMouseEvent) => {
       if (isTouchDerivedMouseEvent(event, lastTouchAtRef.current)) return;
       showControlsImmediately();
@@ -1467,7 +1449,6 @@ export function VideoPlayer({
         !showControls && "cursor-none",
       )}
       onMouseMove={handlePlayerMouseMove}
-      onMouseLeave={handlePlayerMouseLeave}
       onTouchStart={markTouchInteraction}
     >
       {/* Player area sizes the 16:9 frame via container queries; sources stretch to 16:9 inside it. */}
@@ -1600,7 +1581,6 @@ export function VideoPlayer({
               ? "opacity-100"
               : "opacity-0 pointer-events-none has-focus-visible:opacity-100 has-focus-visible:pointer-events-auto",
           )}
-          onMouseEnter={handleControlsMouseEnter}
         >
           <PlayerControls
             channel={channel}

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1,6 +1,14 @@
 import { clsx } from "clsx";
 import { Play } from "lucide-react";
-import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from "react";
+import {
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import {
@@ -33,6 +41,23 @@ import mp2WasmUrl from "../../mpegts/wasm/minimp3/mp2_decoder.wasm?url";
 import type { Channel, EPGProgram } from "../../types/player";
 import { PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
 import { PlayerControls } from "./player-controls";
+
+/** Window after touchstart during which synthesized mouse events are ignored. */
+const TOUCH_MOUSE_SUPPRESS_MS = 700;
+
+/**
+ * True for mouse events that WebKit synthesizes from a finger tap.
+ * Prefer InputDeviceCapabilities when present; otherwise use a recent touchstart timestamp.
+ */
+function isTouchDerivedMouseEvent(event: ReactMouseEvent, lastTouchAt: number): boolean {
+  const native = event.nativeEvent as MouseEvent & {
+    sourceCapabilities?: { firesTouchEvents?: boolean } | null;
+  };
+  if (native.sourceCapabilities?.firesTouchEvents) {
+    return true;
+  }
+  return Date.now() - lastTouchAt < TOUCH_MOUSE_SUPPRESS_MS;
+}
 
 interface VideoPlayerProps {
   channel: Channel | null;
@@ -254,9 +279,12 @@ export function VideoPlayer({
   const [isLive, setIsLive] = useState(true);
   const [needsUserInteraction, setNeedsUserInteraction] = useState(false);
   const [showControls, setShowControls] = useState(true);
+  const showControlsRef = useRef(showControls);
   const [isPiP, setIsPiP] = useState(false);
   const [isDocumentPiP, setIsDocumentPiP] = useState(false);
   const hideControlsTimeoutRef = useRef<number>(0);
+  /** Ignore mouse move/leave synthesized from touch (iOS Safari wakes then immediately hides controls). */
+  const lastTouchAtRef = useRef(0);
   const [retryCount, setRetryCount] = useState(0);
   const [retryBaseline, setRetryBaseline] = useState(0);
   /** Synchronous flag: segments reload is error recovery, not a user/channel switch. */
@@ -382,11 +410,13 @@ export function VideoPlayer({
       window.clearTimeout(hideControlsTimeoutRef.current);
     }
     hideControlsTimeoutRef.current = window.setTimeout(() => {
+      showControlsRef.current = false;
       setShowControls(false);
     }, 3000);
   }, []);
 
   const showControlsImmediately = useCallback(() => {
+    showControlsRef.current = true;
     setShowControls(true);
     resetControlsTimer();
   }, [resetControlsTimer]);
@@ -396,7 +426,36 @@ export function VideoPlayer({
       window.clearTimeout(hideControlsTimeoutRef.current);
       hideControlsTimeoutRef.current = 0;
     }
+    showControlsRef.current = false;
     setShowControls(false);
+  }, []);
+
+  const handlePlayerMouseMove = useCallback(
+    (event: ReactMouseEvent) => {
+      if (isTouchDerivedMouseEvent(event, lastTouchAtRef.current)) return;
+      showControlsImmediately();
+    },
+    [showControlsImmediately],
+  );
+
+  const handlePlayerMouseLeave = useCallback(
+    (event: ReactMouseEvent) => {
+      if (isTouchDerivedMouseEvent(event, lastTouchAtRef.current)) return;
+      hideControlsImmediately();
+    },
+    [hideControlsImmediately],
+  );
+
+  const handleControlsMouseEnter = useCallback(
+    (event: ReactMouseEvent) => {
+      if (isTouchDerivedMouseEvent(event, lastTouchAtRef.current)) return;
+      showControlsImmediately();
+    },
+    [showControlsImmediately],
+  );
+
+  const markTouchInteraction = useCallback(() => {
+    lastTouchAtRef.current = Date.now();
   }, []);
 
   // Start auto-hide timer on mount
@@ -1242,12 +1301,14 @@ export function VideoPlayer({
   }, [isDocumentPiP]);
 
   const handleVideoClick = useCallback(() => {
-    if (showControls) {
+    // Use the ref so a touch-synthesized mousemove that already scheduled a show
+    // cannot race a stale closed-over showControls and double-toggle.
+    if (showControlsRef.current) {
       hideControlsImmediately();
     } else {
       showControlsImmediately();
     }
-  }, [showControls, hideControlsImmediately, showControlsImmediately]);
+  }, [hideControlsImmediately, showControlsImmediately]);
 
   const handleMuteToggle = useEffectEvent(() => {
     const video = getActiveVideo();
@@ -1405,8 +1466,9 @@ export function VideoPlayer({
         isDocumentPiP ? "h-screen min-h-screen aspect-auto" : "md:aspect-auto md:h-full",
         !showControls && "cursor-none",
       )}
-      onMouseMove={showControlsImmediately}
-      onMouseLeave={hideControlsImmediately}
+      onMouseMove={handlePlayerMouseMove}
+      onMouseLeave={handlePlayerMouseLeave}
+      onTouchStart={markTouchInteraction}
     >
       {/* Player area sizes the 16:9 frame via container queries; sources stretch to 16:9 inside it. */}
       <div className="relative aspect-video h-auto max-h-full w-full max-w-full overflow-hidden [@container_video_(max-aspect-ratio:_16/9)]:h-auto [@container_video_(max-aspect-ratio:_16/9)]:w-full [@container_video_(min-aspect-ratio:_16/9)]:h-full [@container_video_(min-aspect-ratio:_16/9)]:w-auto">
@@ -1457,7 +1519,7 @@ export function VideoPlayer({
         <div
           className={clsx(
             "absolute top-4 right-4 md:top-8 md:right-8 z-10 flex flex-col gap-2 md:gap-3 items-end transition-opacity duration-300",
-            showControls ? "opacity-100" : "opacity-0",
+            showControls ? "opacity-100" : "opacity-0 pointer-events-none",
           )}
         >
           <div
@@ -1534,9 +1596,11 @@ export function VideoPlayer({
           role="toolbar"
           className={clsx(
             "absolute bottom-0 left-0 right-0 z-10 transition-opacity duration-300",
-            showControls ? "opacity-100" : "opacity-0 has-focus-visible:opacity-100",
+            showControls
+              ? "opacity-100"
+              : "opacity-0 pointer-events-none has-focus-visible:opacity-100 has-focus-visible:pointer-events-auto",
           )}
-          onMouseEnter={showControlsImmediately}
+          onMouseEnter={handleControlsMouseEnter}
         >
           <PlayerControls
             channel={channel}

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -387,7 +387,7 @@ export function VideoPlayer({
   }, []);
 
   // Wake / keep-alive: mouseenter + mousemove (including touch-synthesized move on iOS).
-  // Auto-hide is timer-only; video click no longer toggles.
+  // Auto-hide is timer-only.
   const showControlsImmediately = useCallback(() => {
     setShowControls(true);
     resetControlsTimer();

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1,14 +1,6 @@
 import { clsx } from "clsx";
 import { Play } from "lucide-react";
-import {
-  type MouseEvent as ReactMouseEvent,
-  useCallback,
-  useEffect,
-  useEffectEvent,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import {
@@ -41,19 +33,6 @@ import mp2WasmUrl from "../../mpegts/wasm/minimp3/mp2_decoder.wasm?url";
 import type { Channel, EPGProgram } from "../../types/player";
 import { PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
 import { PlayerControls } from "./player-controls";
-
-/** Ignore WebKit mouse events synthesized from a finger tap (they race click toggle). */
-const TOUCH_MOUSE_SUPPRESS_MS = 700;
-
-function isTouchDerivedMouseEvent(event: ReactMouseEvent, lastTouchAt: number): boolean {
-  const native = event.nativeEvent as MouseEvent & {
-    sourceCapabilities?: { firesTouchEvents?: boolean } | null;
-  };
-  if (native.sourceCapabilities?.firesTouchEvents) {
-    return true;
-  }
-  return Date.now() - lastTouchAt < TOUCH_MOUSE_SUPPRESS_MS;
-}
 
 interface VideoPlayerProps {
   channel: Channel | null;
@@ -275,12 +254,9 @@ export function VideoPlayer({
   const [isLive, setIsLive] = useState(true);
   const [needsUserInteraction, setNeedsUserInteraction] = useState(false);
   const [showControls, setShowControls] = useState(true);
-  const showControlsRef = useRef(showControls);
   const [isPiP, setIsPiP] = useState(false);
   const [isDocumentPiP, setIsDocumentPiP] = useState(false);
   const hideControlsTimeoutRef = useRef<number>(0);
-  /** Ignore mouse move/leave synthesized from touch (iOS Safari wakes then immediately hides controls). */
-  const lastTouchAtRef = useRef(0);
   const [retryCount, setRetryCount] = useState(0);
   const [retryBaseline, setRetryBaseline] = useState(0);
   /** Synchronous flag: segments reload is error recovery, not a user/channel switch. */
@@ -406,13 +382,13 @@ export function VideoPlayer({
       window.clearTimeout(hideControlsTimeoutRef.current);
     }
     hideControlsTimeoutRef.current = window.setTimeout(() => {
-      showControlsRef.current = false;
       setShowControls(false);
     }, 3000);
   }, []);
 
+  // Wake / keep-alive: mouseenter + mousemove (including touch-synthesized move on iOS).
+  // Auto-hide is timer-only; video click no longer toggles.
   const showControlsImmediately = useCallback(() => {
-    showControlsRef.current = true;
     setShowControls(true);
     resetControlsTimer();
   }, [resetControlsTimer]);
@@ -422,22 +398,7 @@ export function VideoPlayer({
       window.clearTimeout(hideControlsTimeoutRef.current);
       hideControlsTimeoutRef.current = 0;
     }
-    showControlsRef.current = false;
     setShowControls(false);
-  }, []);
-
-  // Desktop hover wakes controls; touch-synthesized mousemove is ignored so it
-  // cannot race the click toggle. Auto-hide is timer-only (no mouseleave hide).
-  const handlePlayerMouseMove = useCallback(
-    (event: ReactMouseEvent) => {
-      if (isTouchDerivedMouseEvent(event, lastTouchAtRef.current)) return;
-      showControlsImmediately();
-    },
-    [showControlsImmediately],
-  );
-
-  const markTouchInteraction = useCallback(() => {
-    lastTouchAtRef.current = Date.now();
   }, []);
 
   // Start auto-hide timer on mount
@@ -1282,16 +1243,6 @@ export function VideoPlayer({
     };
   }, [isDocumentPiP]);
 
-  const handleVideoClick = useCallback(() => {
-    // Use the ref so a touch-synthesized mousemove that already scheduled a show
-    // cannot race a stale closed-over showControls and double-toggle.
-    if (showControlsRef.current) {
-      hideControlsImmediately();
-    } else {
-      showControlsImmediately();
-    }
-  }, [hideControlsImmediately, showControlsImmediately]);
-
   const handleMuteToggle = useEffectEvent(() => {
     const video = getActiveVideo();
     if (video) {
@@ -1448,8 +1399,8 @@ export function VideoPlayer({
         isDocumentPiP ? "h-screen min-h-screen aspect-auto" : "md:aspect-auto md:h-full",
         !showControls && "cursor-none",
       )}
-      onMouseMove={handlePlayerMouseMove}
-      onTouchStart={markTouchInteraction}
+      onMouseEnter={showControlsImmediately}
+      onMouseMove={showControlsImmediately}
     >
       {/* Player area sizes the 16:9 frame via container queries; sources stretch to 16:9 inside it. */}
       <div className="relative aspect-video h-auto max-h-full w-full max-w-full overflow-hidden [@container_video_(max-aspect-ratio:_16/9)]:h-auto [@container_video_(max-aspect-ratio:_16/9)]:w-full [@container_video_(min-aspect-ratio:_16/9)]:h-full [@container_video_(min-aspect-ratio:_16/9)]:w-auto">
@@ -1470,7 +1421,6 @@ export function VideoPlayer({
               playsInline
               webkit-playsinline="true"
               x5-playsinline="true"
-              onClick={visibleSlotId === slotId ? handleVideoClick : undefined}
             />
             <canvas
               ref={slotId === "a" ? slotACanvasRef : slotBCanvasRef}
@@ -1581,6 +1531,7 @@ export function VideoPlayer({
               ? "opacity-100"
               : "opacity-0 pointer-events-none has-focus-visible:opacity-100 has-focus-visible:pointer-events-auto",
           )}
+          onMouseEnter={showControlsImmediately}
         >
           <PlayerControls
             channel={channel}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Simplify player controls visibility to fix flaky show/hide on iOS Safari.

Previously, video click toggle raced with touch-synthesized `mousemove`/`mouseleave`, so a single tap could show then immediately hide controls. The new model drops click toggle and leave-based hide entirely.

## Controls visibility

**Show / keep alive** (resets 3s timer):
- `mouseenter` / `mousemove` on the player surface (includes iOS tap-synthesized mouse events)
- `mouseenter` on the controls toolbar
- Keyboard digit entry / Escape when hidden
- Channel switch / Document PiP entry

**Hide**:
- 3s idle timer (only automatic path)
- Escape when controls are visible

## Test results (local)

Verified on Chromium against `devlab` + `rtp2httpd` (`http://127.0.0.1:5140/player`, channel `HLS-TS (h264-mp2)`), with strict timing (~0.4s after each action):

| Scenario | Result |
|----------|--------|
| Idle ~3s → auto-hide | PASS |
| `mousemove` over video → show | PASS |
| Leave to sidebar → stay visible; hide after ~3s idle | PASS |
| Click video center → no toggle; hide after ~3s idle | PASS |
| Escape → show/hide | PASS |
| Still mouse on toolbar → hides after ~3s (expected: enter resets once, no hover-hold) | PASS |

Not retested on a physical iOS Safari device in this run; touch wake relies on WebKit synthesizing `mousemove` from taps, which is the same path exercised above for show/keep-alive.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00ac3952-6951-46f1-b41e-998a525e6e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00ac3952-6951-46f1-b41e-998a525e6e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

