### PR TITLE
fix(web-ui): fix A/V desync and audio replay loop on background/foreground transitions

### DIFF
--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1020,8 +1020,11 @@ export function VideoPlayer({
     // Note: video.paused may still report false in this state.
     const mediaDead = video.error !== null;
     const behindLiveMs = Date.now() - (streamStartTime.getTime() + currentVideoTime * 1000);
+    // Beyond this lag a live-edge reload beats letting live-sync chase at 2x
+    // for tens of seconds; tied to the sync config rather than a magic 10s.
+    const staleLiveMs = (defaultConfig.liveSyncMaxLatency + 5) * 1000;
 
-    if (playMode === "live" && (mediaDead || behindLiveMs > 10000)) {
+    if (playMode === "live" && (mediaDead || behindLiveMs > staleLiveMs)) {
       // Dead session or stale buffer — rebuild the stream at the live edge
       console.log("Reloading at live edge after background suspension");
       shouldAutoPlayRef.current = true;

--- a/web-ui/src/mpegts/audio/pcm-audio-player.ts
+++ b/web-ui/src/mpegts/audio/pcm-audio-player.ts
@@ -218,25 +218,46 @@ export class PCMAudioPlayer {
     this.context.onstatechange = () => {
       const state = this.context?.state as string | undefined;
       Log.v(TAG, `AudioContext state changed to: ${state}`);
+
+      if (state === "interrupted") {
+        // WebKit-only: the OS revoked the audio session (backgrounding, but
+        // also e.g. an incoming call while the tab stays visible — no
+        // visibilitychange in that case). Unambiguous background signal on
+        // its own, independent of visibilitychange ordering.
+        this.cancelChain();
+        this.pendingChunks = [];
+        this.inputCursor = null;
+        this.resetDriftState();
+        this.setSyncState("background");
+        return;
+      }
+
       if (state !== "running") {
-        // Clock frozen ("suspended", or WebKit's "interrupted" when iOS moves
-        // Safari to background). Everything scheduled on it would burst out as
-        // stale audio on resume — drop the chain now, keep the seek buffer.
+        // "suspended": either the pre-first-activation autoplay gate or our
+        // own deliberate suspend() in pause() — neither implies backgrounding,
+        // so syncState is left untouched. Drop the chain so resume doesn't
+        // burst out stale audio.
         this.cancelChain();
         this.pendingChunks = [];
         this.inputCursor = null;
         this.resetDriftState();
         return;
       }
+
+      // state === "running"
       playbackUnlocked = true;
-      // Clock is live again, but video.currentTime is not proven yet (iOS
-      // rebuilds the media pipeline after background) — never anchor here.
-      // BACKGROUND free-runs; RECOVERING anchors on the next timeupdate.
-      if (document.visibilityState === "hidden") {
-        this.setSyncState("background");
+      if (this.syncState === "background") {
+        // Confirmed a real background period happened (via "interrupted"
+        // above, and/or visibilitychange->hidden already set this). Only
+        // anchor once the page is visible too — video.currentTime is not
+        // proven yet while the media pipeline may still be rebuilding.
+        this.setSyncState(document.visibilityState === "hidden" ? "background" : "recovering");
         this.pump();
-      } else {
-        this.setSyncState("recovering");
+      } else if (this.canScheduleAudio()) {
+        // First activation (autoplay gate lifting) or resume from our own
+        // pause() — the video clock was never untrusted; anchor immediately,
+        // same as before the sync state machine existed.
+        this.resyncFromBuffer(this.videoElement?.currentTime ?? 0);
       }
     };
 

--- a/web-ui/src/mpegts/audio/pcm-audio-player.ts
+++ b/web-ui/src/mpegts/audio/pcm-audio-player.ts
@@ -988,19 +988,22 @@ export class PCMAudioPlayer {
 
   /** Remove buffered audio that is too far behind the current playback position.
    *  Same strategy as MSE SourceBuffer cleanup: relative to currentTime.
-   *  Outside ACTIVE the video clock may be frozen (background free-run), so the
-   *  audio playhead is the reference — otherwise the buffer grows unbounded. */
+   *  Outside ACTIVE, video.currentTime may be frozen (background free-run —
+   *  exactly the case motivating this state), so it must not be the fallback
+   *  reference: that would stop advancing and let the buffer grow unbounded.
+   *  Prefer the live audio playhead, then the newest buffered timestamp —
+   *  both keep advancing as data arrives even if every clock is stalled. */
   private cleanupBuffer(): void {
     if (this.audioBuffer.length === 0 || !this.videoElement) return;
 
-    const videoTime =
+    const referenceTime =
       this.syncState === "active"
         ? this.videoElement.currentTime
-        : (this.audioStreamTimeNow() ?? this.videoElement.currentTime);
+        : (this.audioStreamTimeNow() ?? this.audioBuffer[this.audioBuffer.length - 1].endTime);
 
-    if (videoTime - this.audioBuffer[0].time < this.config.bufferCleanupMaxBackward) return;
+    if (referenceTime - this.audioBuffer[0].time < this.config.bufferCleanupMaxBackward) return;
 
-    const cutoff = videoTime - this.config.bufferCleanupMinBackward;
+    const cutoff = referenceTime - this.config.bufferCleanupMinBackward;
     let removeCount = 0;
     for (let i = 0; i < this.audioBuffer.length; i++) {
       if (this.audioBuffer[i].endTime < cutoff) {
@@ -1055,6 +1058,16 @@ export class PCMAudioPlayer {
     }
 
     this.refillPendingFromBuffer(targetTime);
+    if (this.pendingChunks.length === 0) {
+      // findChunkIndexByTime clamps to the nearest chunk instead of returning
+      // -1 for a target before/after all buffered data (e.g. the video clock
+      // moved outside the retained window during a long background stay), so
+      // startIndex >= 0 above does not guarantee targetTime is covered. Treat
+      // "nothing to schedule" the same as "not in buffer" so callers (notably
+      // completeRecovery) escalate instead of silently leaving audio muted.
+      Log.v(TAG, "Resync target not covered by buffer, waiting for new data");
+      return false;
+    }
     Log.v(TAG, `Resync at ${targetTime.toFixed(3)}s, refilled ${this.pendingChunks.length} chunks`);
     this.pump();
     return true;

--- a/web-ui/src/mpegts/audio/pcm-audio-player.ts
+++ b/web-ui/src/mpegts/audio/pcm-audio-player.ts
@@ -46,6 +46,9 @@ export function markPlaybackUnlocked(): void {
  *  Also bounds how long a ratio change takes to reach the speakers, so it is
  *  kept small (rate changes during live-sync catch-up respond within this). */
 const SCHEDULE_AHEAD = 0.6;
+/** Schedule-ahead while the page is hidden: background timer throttling (1s on
+ *  mobile, up to 1/min on Chrome) would underrun the small foreground window. */
+const BACKGROUND_SCHEDULE_AHEAD = 4.0;
 /** Delay before the first chunk when (re)starting the scheduling chain. */
 const CHAIN_RESTART_DELAY = 0.04;
 /** Drift beyond this is treated as an emergency discontinuity and rebuilt from buffer. */
@@ -74,6 +77,22 @@ const MAX_PENDING_CHUNKS = 600;
 const PENDING_REFILL_WINDOW_SEC = 2.0;
 /** Control ticks between verbose drift diagnostics (~10s). */
 const DRIFT_LOG_TICKS = 40;
+/** RECOVERING must anchor within this window or escalate via onResyncFailed. */
+const RECOVERY_TIMEOUT_MS = 4000;
+
+/**
+ * Lifecycle-driven sync state. The drift control loop and hard resync only run
+ * in ACTIVE — while the page is hidden or the media pipeline is being rebuilt,
+ * video.currentTime is not a trustworthy clock and correcting against it would
+ * replay/skip audio (e.g. the 1.5s hard-resync loop against a frozen video
+ * clock after returning from background on iOS).
+ *
+ *  - ACTIVE:     foreground, video clock trusted; full drift control.
+ *  - BACKGROUND: page hidden; audio free-runs, no drift correction.
+ *  - RECOVERING: waiting for proof that the video clock is live again (first
+ *    timeupdate while visible, or seeked); then one deterministic resync.
+ */
+type SyncState = "active" | "background" | "recovering";
 
 interface AudioChunk {
   samples: Float32Array;
@@ -136,6 +155,11 @@ export class PCMAudioPlayer {
   private isBuffering: boolean = false;
   private isSeeking: boolean = false;
 
+  // Lifecycle-driven sync state (see SyncState docs)
+  private syncState: SyncState = "active";
+  private recoveryTimer: ReturnType<typeof setTimeout> | null = null;
+  private boundOnVisibilityChange: (() => void) | null = null;
+
   // Bound event handlers for cleanup
   private boundOnVideoSeeking: (() => void) | null = null;
   private boundOnVideoSeeked: (() => void) | null = null;
@@ -151,6 +175,11 @@ export class PCMAudioPlayer {
 
   /** Called when AudioContext is blocked by autoplay policy (needs user interaction). */
   onSuspended: (() => void) | null = null;
+
+  /** Called when a post-background/interruption resync could not be completed
+   *  (video clock never came back, or the target left the audio buffer) —
+   *  the stream needs to be rebuilt by the app layer. */
+  onResyncFailed: (() => void) | null = null;
 
   constructor(config: PlayerConfig) {
     this.config = config;
@@ -187,9 +216,27 @@ export class PCMAudioPlayer {
     this.updateGain();
 
     this.context.onstatechange = () => {
-      Log.v(TAG, `AudioContext state changed to: ${this.context?.state}`);
-      if (this.context?.state === "running" && this.canScheduleAudio()) {
-        this.resyncFromBuffer(this.videoElement?.currentTime ?? 0);
+      const state = this.context?.state as string | undefined;
+      Log.v(TAG, `AudioContext state changed to: ${state}`);
+      if (state !== "running") {
+        // Clock frozen ("suspended", or WebKit's "interrupted" when iOS moves
+        // Safari to background). Everything scheduled on it would burst out as
+        // stale audio on resume — drop the chain now, keep the seek buffer.
+        this.cancelChain();
+        this.pendingChunks = [];
+        this.inputCursor = null;
+        this.resetDriftState();
+        return;
+      }
+      playbackUnlocked = true;
+      // Clock is live again, but video.currentTime is not proven yet (iOS
+      // rebuilds the media pipeline after background) — never anchor here.
+      // BACKGROUND free-runs; RECOVERING anchors on the next timeupdate.
+      if (document.visibilityState === "hidden") {
+        this.setSyncState("background");
+        this.pump();
+      } else {
+        this.setSyncState("recovering");
       }
     };
 
@@ -212,6 +259,12 @@ export class PCMAudioPlayer {
       this.setMuted(video.muted);
     };
     this.boundOnTimeUpdate = () => {
+      // timeupdate only fires when currentTime actually advanced — while
+      // visible, it is the proof that the video pipeline is alive again.
+      if (this.syncState === "recovering" && document.visibilityState !== "hidden") {
+        this.completeRecovery("timeupdate");
+        return;
+      }
       this.controlTick();
       this.pump();
     };
@@ -244,6 +297,12 @@ export class PCMAudioPlayer {
     video.addEventListener("playing", this.boundOnVideoPlaying);
     video.addEventListener("canplay", this.boundOnVideoCanPlay);
 
+    this.boundOnVisibilityChange = this.onVisibilityChange.bind(this);
+    document.addEventListener("visibilitychange", this.boundOnVisibilityChange);
+    if (document.visibilityState === "hidden") {
+      this.setSyncState("background");
+    }
+
     this.controlTimer = setInterval(() => {
       this.controlTick();
       this.pump();
@@ -254,6 +313,14 @@ export class PCMAudioPlayer {
     if (this.controlTimer) {
       clearInterval(this.controlTimer);
       this.controlTimer = null;
+    }
+    if (this.recoveryTimer) {
+      clearTimeout(this.recoveryTimer);
+      this.recoveryTimer = null;
+    }
+    if (this.boundOnVisibilityChange) {
+      document.removeEventListener("visibilitychange", this.boundOnVisibilityChange);
+      this.boundOnVisibilityChange = null;
     }
     if (this.videoElement) {
       if (this.boundOnVideoSeeking) this.videoElement.removeEventListener("seeking", this.boundOnVideoSeeking);
@@ -366,11 +433,15 @@ export class PCMAudioPlayer {
       return;
     }
 
-    if (ctx.state === "suspended") {
+    if (ctx.state !== "running") {
+      // "suspended" may just be autoplay policy — try to resume. WebKit's
+      // "interrupted" (iOS background) also lands here: resume() is a no-op
+      // until the system ends the interruption, and nothing must be scheduled
+      // on the frozen clock meanwhile.
       void ctx
         .resume()
         .then(() => {
-          if (ctx.state === "running") {
+          if ((ctx.state as string) === "running") {
             playbackUnlocked = true;
             this.pump();
           } else if (!playbackUnlocked) {
@@ -387,14 +458,22 @@ export class PCMAudioPlayer {
 
     while (true) {
       if (this.pendingChunks.length === 0) {
+        // RECOVERING with no running chain: the only refill anchor available
+        // is video.currentTime, which is exactly the clock we do not trust
+        // yet — hold off until completeRecovery() anchors deterministically.
+        if (this.syncState === "recovering" && this.inputCursor === null) {
+          break;
+        }
         this.refillPendingFromBuffer(this.inputCursor ?? this.videoElement?.currentTime ?? 0);
       }
       if (this.pendingChunks.length === 0) {
         break;
       }
 
-      // Throttle: keep at most SCHEDULE_AHEAD seconds scheduled ahead
-      if (this.nextStartTime - ctx.currentTime >= SCHEDULE_AHEAD) {
+      // Throttle: keep at most the schedule-ahead window scheduled. Hidden
+      // pages get a larger window to ride out background timer throttling.
+      const scheduleAhead = this.syncState === "background" ? BACKGROUND_SCHEDULE_AHEAD : SCHEDULE_AHEAD;
+      if (this.nextStartTime - ctx.currentTime >= scheduleAhead) {
         break;
       }
 
@@ -441,6 +520,87 @@ export class PCMAudioPlayer {
     Log.w(TAG, "AudioContext blocked by autoplay policy, waiting for user interaction");
     this.onSuspended?.();
     this.videoElement?.pause();
+  }
+
+  // ==================== Sync state machine ====================
+
+  private setSyncState(next: SyncState): void {
+    if (this.syncState === next) {
+      return;
+    }
+    Log.v(TAG, `Sync state: ${this.syncState} -> ${next}`);
+    this.syncState = next;
+
+    if (this.recoveryTimer) {
+      clearTimeout(this.recoveryTimer);
+      this.recoveryTimer = null;
+    }
+    if (next === "recovering") {
+      // Failure exit: the anchor event never arrives when the media pipeline
+      // died in background (decoder rebuild failed, buffer gone). One-shot,
+      // bound to this state — cleared on any transition out.
+      this.recoveryTimer = setTimeout(() => {
+        this.recoveryTimer = null;
+        this.onRecoveryTimeout();
+      }, RECOVERY_TIMEOUT_MS);
+    }
+  }
+
+  private onVisibilityChange(): void {
+    if (document.visibilityState === "hidden") {
+      // Video decode is about to be suspended; its clock is no longer a sync
+      // reference. Audio free-runs (Control Center playback keeps it alive).
+      this.setSyncState("background");
+    } else {
+      // Pipeline rebuild starts now; wait for proof (timeupdate) before anchoring.
+      this.setSyncState("recovering");
+    }
+  }
+
+  /** Anchor point: video.currentTime is authoritative again. */
+  private completeRecovery(reason: string): void {
+    const video = this.videoElement;
+    this.setSyncState("active");
+    if (!video) {
+      return;
+    }
+
+    // Chain survived (e.g. Android: AudioContext keeps running in background)
+    // and is already close — keep it and let drift control absorb the rest,
+    // instead of an audible rebuild on every tab switch.
+    const audioTime = this.audioStreamTimeNow();
+    if (audioTime !== null && Math.abs(audioTime - video.currentTime) < HARD_RESYNC_THRESHOLD) {
+      Log.v(TAG, `Recovery (${reason}): chain intact, drift ${(audioTime - video.currentTime).toFixed(3)}s`);
+      this.resetDriftState();
+      this.softSyncUntil = (this.context?.currentTime ?? 0) + SOFT_SYNC_WINDOW_SEC;
+      return;
+    }
+
+    Log.v(TAG, `Recovery anchor (${reason}) at ${video.currentTime.toFixed(3)}s`);
+    // Re-enter soft-sync so residual drift converges fast (±35%) instead of
+    // lingering at the steady-state ±10% cap for many seconds.
+    this.softSyncUntil = (this.context?.currentTime ?? 0) + SOFT_SYNC_WINDOW_SEC;
+    const anchored = this.resyncFromBuffer(video.currentTime);
+    if (!anchored && this.audioBuffer.length > 0) {
+      // Buffer exists but no longer covers the video position: the two sides
+      // diverged past repair (e.g. long background stay). Rebuild the stream.
+      Log.w(TAG, "Recovery target left the audio buffer; escalating");
+      this.onResyncFailed?.();
+    }
+    // Empty buffer: stream data simply hasn't arrived yet — pump will anchor
+    // on the first fed chunk; not a failure.
+  }
+
+  private onRecoveryTimeout(): void {
+    const video = this.videoElement;
+    // Only escalate when playback is genuinely expected to progress: a paused
+    // or seeking video legitimately produces no timeupdate — keep waiting for
+    // its play/seeked to anchor instead.
+    if (!video || video.paused || video.seeking || this.isSeeking || document.visibilityState === "hidden") {
+      return;
+    }
+    Log.w(TAG, `No video progress within ${RECOVERY_TIMEOUT_MS}ms of recovery; escalating`);
+    this.onResyncFailed?.();
   }
 
   // ==================== Media readiness ====================
@@ -492,6 +652,12 @@ export class PCMAudioPlayer {
     }
 
     this.isBuffering = false;
+    if (this.syncState !== "active") {
+      // Video clock not trusted yet; the state machine anchors on its own
+      // events (recovery timeupdate / background free-run via pump).
+      this.pump();
+      return;
+    }
     Log.v(TAG, "Video playback resumed; resyncing PCM audio");
     this.resyncFromBuffer(video.currentTime);
   }
@@ -533,7 +699,10 @@ export class PCMAudioPlayer {
     if (this.nextStartTime < ctxNow + 0.005) {
       // Chain (re)start: if the audio about to play is ahead of the video
       // clock, delay the chain start so it lines up instead of drifting.
-      const lead = this.videoElement ? this.outputStreamCursor - this.videoElement.currentTime : 0;
+      // Outside ACTIVE the video clock is not a reference — start immediately
+      // and let the recovery anchor fix alignment.
+      const lead =
+        this.syncState === "active" && this.videoElement ? this.outputStreamCursor - this.videoElement.currentTime : 0;
       this.nextStartTime = ctxNow + Math.max(CHAIN_RESTART_DELAY, Math.min(lead, 2));
       chainRestart = true;
     }
@@ -638,7 +807,13 @@ export class PCMAudioPlayer {
   private controlTick(): void {
     const ctx = this.context;
     const video = this.videoElement;
-    if (!ctx || !video || ctx.state !== "running" || !this.canScheduleAudio() || !this.stretcher) {
+    if (!ctx || !video || ctx.state !== "running" || !this.stretcher) {
+      return;
+    }
+    // Drift control and hard resync are meaningful only when the video clock
+    // is trusted. BACKGROUND/RECOVERING free-run: correcting against a frozen
+    // or rebuilding video clock replays audio (the "broken record" loop).
+    if (this.syncState !== "active" || !this.canScheduleAudio()) {
       return;
     }
 
@@ -791,11 +966,16 @@ export class PCMAudioPlayer {
   }
 
   /** Remove buffered audio that is too far behind the current playback position.
-   *  Same strategy as MSE SourceBuffer cleanup: relative to currentTime. */
+   *  Same strategy as MSE SourceBuffer cleanup: relative to currentTime.
+   *  Outside ACTIVE the video clock may be frozen (background free-run), so the
+   *  audio playhead is the reference — otherwise the buffer grows unbounded. */
   private cleanupBuffer(): void {
     if (this.audioBuffer.length === 0 || !this.videoElement) return;
 
-    const videoTime = this.videoElement.currentTime;
+    const videoTime =
+      this.syncState === "active"
+        ? this.videoElement.currentTime
+        : (this.audioStreamTimeNow() ?? this.videoElement.currentTime);
 
     if (videoTime - this.audioBuffer[0].time < this.config.bufferCleanupMaxBackward) return;
 
@@ -839,8 +1019,9 @@ export class PCMAudioPlayer {
   /**
    * Rebuild the scheduling chain from the seek buffer at a target position
    * (used for seeks, resume after pause/suspend, and hard resyncs).
+   * Returns false when the target is not covered by the buffer.
    */
-  private resyncFromBuffer(targetTime: number): void {
+  private resyncFromBuffer(targetTime: number): boolean {
     this.cancelChain(true);
     this.pendingChunks = [];
     this.inputCursor = null;
@@ -849,12 +1030,13 @@ export class PCMAudioPlayer {
     const startIndex = this.findChunkIndexByTime(targetTime);
     if (startIndex < 0) {
       Log.v(TAG, "Resync target not in buffer, waiting for new data");
-      return;
+      return false;
     }
 
     this.refillPendingFromBuffer(targetTime);
     Log.v(TAG, `Resync at ${targetTime.toFixed(3)}s, refilled ${this.pendingChunks.length} chunks`);
     this.pump();
+    return true;
   }
 
   private onVideoSeeking(): void {
@@ -870,23 +1052,27 @@ export class PCMAudioPlayer {
 
     Log.v(TAG, `Video seeked to ${targetTime.toFixed(3)}, resyncing audio`);
     this.isSeeking = false;
+    // A completed seek makes video.currentTime authoritative in any state.
+    if (this.syncState === "recovering") {
+      this.setSyncState(document.visibilityState === "hidden" ? "background" : "active");
+    }
     this.resyncFromBuffer(targetTime);
   }
 
   // ==================== Playback Control ====================
 
   async play(): Promise<void> {
-    if (this.context?.state === "suspended") {
+    if (this.context && this.context.state !== "running") {
       try {
         await this.context.resume();
         playbackUnlocked = true;
-        // onstatechange → resyncFromBuffer
+        // onstatechange drives the rest (background free-run or recovery anchor)
       } catch (_e) {
         Log.w(TAG, "Failed to resume AudioContext on play()");
       }
     } else {
       const video = this.videoElement;
-      if (video && this.canScheduleAudio()) {
+      if (video && this.syncState === "active" && this.canScheduleAudio()) {
         this.resyncFromBuffer(video.currentTime);
       }
     }
@@ -928,6 +1114,7 @@ export class PCMAudioPlayer {
     this.stretcherFailed = false;
     this.softSyncUntil = 0;
     this.resetDriftState();
+    this.setSyncState(document.visibilityState === "hidden" ? "background" : "active");
   }
 
   setVolume(volume: number): void {

--- a/web-ui/src/mpegts/player/mpegts-player.ts
+++ b/web-ui/src/mpegts/player/mpegts-player.ts
@@ -56,6 +56,17 @@ export function createMpegtsPlayer(
     if (!pcmPlayer) {
       pcmPlayer = new PCMAudioPlayer(config);
       pcmPlayer.onSuspended = () => impl.onAudioSuspended?.();
+      pcmPlayer.onResyncFailed = () => {
+        // Post-background audio recovery failed (video clock never came back,
+        // or drifted past the audio buffer) — the session must be rebuilt.
+        // Route through the normal error path so the app's retry/reload logic
+        // (live edge for live, current position for catchup) takes over.
+        impl.onError?.({
+          category: "media",
+          detail: "AudioResyncFailed",
+          info: "Audio could not re-anchor to the video clock after an interruption",
+        });
+      };
       pcmPlayerInitPromise = pcmPlayer.init();
       pcmPlayer.attachVideo(video);
     }


### PR DESCRIPTION
## Summary

Fixes a bug where returning to the foreground after a background interruption (e.g. iOS Safari Control Center resume, tab backgrounding) could cause audio/video desync, or a short audio "broken record" replay loop.

## Root cause

The PCM audio player's drift control loop (`pcm-audio-player.ts`) unconditionally trusted `video.currentTime`, including while it was frozen (iOS suspends video decode in background) or stale (media pipeline still rebuilding right after returning to foreground). The 1.5s hard-resync threshold would then repeatedly snap audio back to the same frozen position — producing the looping replay — and residual drift after resume was left to the slow steady-state correction (±10% stretch ratio, tens of seconds to converge), producing the audible A/V desync.

## Fix

Replace the implicit "always trust `video.currentTime`" assumption with an explicit, lifecycle-event-driven sync state machine in `PCMAudioPlayer`:

- **ACTIVE** — foreground, video clock trusted. Existing drift control and hard-resync behavior, unchanged.
- **BACKGROUND** — page hidden (`visibilitychange`). Audio free-runs; drift correction and hard resync are disabled since the video clock is untrustworthy. Schedule-ahead window widens 0.6s → 4s to survive background timer throttling.
- **RECOVERING** — entered on `visibilitychange → visible` or the `AudioContext` transitioning back to `"running"` (now explicitly covering WebKit's iOS-only `"interrupted"` state, previously only `"suspended"` was handled). Drift control stays disabled until the video pipeline proves it's live again — first `timeupdate` while visible, or a completed seek. On anchor: if the existing chain is already close to the video clock, it's kept and soft-synced (no audible rebuild); otherwise the chain is rebuilt once, deterministically, instead of via repeated reactive hard-resyncs.

A one-shot recovery timeout (bound to `RECOVERING`, cleared on any transition) escalates via a new `onResyncFailed` callback when the video clock never resumes progress or has drifted out of the audio seek buffer — this routes through the existing media-error retry path (live-edge reload / catchup reload) instead of leaving playback silently muted.

Also tightened the app-level stale-live-session threshold in `video-player.tsx` (fixed 10s → tied to `liveSyncMaxLatency + 5s`) so a long backgrounded live session reloads at the live edge rather than chasing at 2x for a long time.

## Files changed

- `web-ui/src/mpegts/audio/pcm-audio-player.ts` — core state machine, state-aware drift control/pump/resync
- `web-ui/src/mpegts/player/mpegts-player.ts` — wires `onResyncFailed` into the existing media-error path
- `web-ui/src/components/player/video-player.tsx` — tightens stale-live-session threshold

## Testing

- `pnpm run type-check:tsc` ✓
- `biome check` on changed files ✓
- `vite build web-ui` ✓
- Manual verification on real iOS Safari / Android Chrome (background → Control Center resume → foreground) still recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)