### PR TITLE
feat(web-ui): default heavy player features off on constrained devices

### DIFF
--- a/web-ui/player.html
+++ b/web-ui/player.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="overflow-hidden overscroll-none">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
@@ -36,7 +36,7 @@
     </script>
     <link href="/src/index.css" rel="stylesheet" />
   </head>
-  <body class="overflow-hidden overscroll-none bg-background text-foreground antialiased">
+  <body class="bg-background text-foreground antialiased">
     <div id="root"></div>
     <script type="module" src="/src/pages/player.tsx"></script>
   </body>

--- a/web-ui/src/lib/platform.ts
+++ b/web-ui/src/lib/platform.ts
@@ -44,3 +44,62 @@ export function isIOS(): boolean {
 
   return false;
 }
+
+/**
+ * Devices where GPU/CPU-heavy player features should default off
+ * (heat, power, or weak SoC): phones, tablets, and constrained TVs.
+ *
+ * Prefer Client Hints when available; fall back to UA / platform checks.
+ * Layout breakpoints (e.g. width < 768) are intentionally not used.
+ */
+export function isPerformanceConstrainedDevice(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  // LG webOS smart TVs (official UA token is `Web0S`, digit zero).
+  const ua = navigator.userAgent;
+  if (/Web0S/i.test(ua)) {
+    return true;
+  }
+
+  if (navigator.userAgentData?.mobile === true) {
+    return true;
+  }
+
+  if (isIOS()) {
+    return true;
+  }
+
+  // Android / HarmonyOS phones and tablets (including some that omit "Mobile").
+  if (/Android|HarmonyOS|OpenHarmony/i.test(ua)) {
+    return true;
+  }
+
+  // Other common phone / tablet tokens outside Android / Apple.
+  if (/Mobile|Tablet|Silk|Kindle|PlayBook/i.test(ua)) {
+    return true;
+  }
+
+  // Chinese in-app / OEM browsers and custom kernels that may rewrite the UA
+  // enough to miss the checks above. Skip desktop ports of the same brands.
+  if (/Windows NT|Win64|WOW64/i.test(ua)) {
+    return false;
+  }
+  if (/Macintosh|Mac OS X/i.test(ua)) {
+    return false;
+  }
+  if (/\bX11\b|\bLinux\b/i.test(ua)) {
+    return false;
+  }
+
+  if (
+    /MicroMessenger|MiniProgramEnv|miniProgram|MQQBrowser|QBWebView|QQTheme|\sQQ\/|UCBrowser|UCWEB|baiduboxapp|baidubrowser|SogouMobileBrowser|QihooBrowser|QHBrowser|360Browser|HuaweiBrowser|MiuiBrowser|HeyTapBrowser|VivoBrowser|AlipayClient|DingTalk|Weibo|TBS\/|XWEB/i.test(
+      ua,
+    )
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/web-ui/src/lib/player-storage.ts
+++ b/web-ui/src/lib/player-storage.ts
@@ -3,7 +3,10 @@
  *
  * createStore<T>(key, defaultValue) returns a [get, save] tuple that handles
  * JSON serialization, error handling, and backward-compatible reads.
+ * defaultValue may be a value or a lazy getter (e.g. platform-dependent defaults).
  */
+
+import { isPerformanceConstrainedDevice } from "./platform";
 
 function cloneDefaultValue<T>(value: T): T {
   if (value === null || typeof value !== "object") {
@@ -12,22 +15,26 @@ function cloneDefaultValue<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
-function createStore<T>(key: string, defaultValue: T): [get: () => T, save: (value: T) => void] {
-  const defaultSnapshot = JSON.stringify(defaultValue);
+function createStore<T>(
+  key: string,
+  defaultValue: T | (() => T),
+): [get: () => T, save: (value: T) => void] {
+  const resolveDefault = (): T =>
+    typeof defaultValue === "function" ? (defaultValue as () => T)() : defaultValue;
 
   return [
     (): T => {
       try {
         const raw = localStorage.getItem(key);
-        if (raw === null) return cloneDefaultValue(defaultValue);
+        if (raw === null) return cloneDefaultValue(resolveDefault());
         return JSON.parse(raw) as T;
       } catch {
-        return cloneDefaultValue(defaultValue);
+        return cloneDefaultValue(resolveDefault());
       }
     },
     (value: T): void => {
       try {
-        if (JSON.stringify(value) === defaultSnapshot) {
+        if (JSON.stringify(value) === JSON.stringify(resolveDefault())) {
           localStorage.removeItem(key);
         } else {
           localStorage.setItem(key, JSON.stringify(value));
@@ -42,11 +49,17 @@ export const [getLastChannelId, saveLastChannelId] = createStore<string | null>(
   null,
 );
 export const [getSidebarVisible, saveSidebarVisible] = createStore("rtp2httpd-player-sidebar-visible", true);
-export const [getSeamlessSwitch, saveSeamlessSwitch] = createStore("rtp2httpd-player-seamless-switch", true);
-export const [getAutoDeinterlace, saveAutoDeinterlace] = createStore("rtp2httpd-player-auto-deinterlace", true);
+export const [getSeamlessSwitch, saveSeamlessSwitch] = createStore(
+  "rtp2httpd-player-seamless-switch",
+  () => !isPerformanceConstrainedDevice(),
+);
+export const [getAutoDeinterlace, saveAutoDeinterlace] = createStore(
+  "rtp2httpd-player-auto-deinterlace",
+  () => !isPerformanceConstrainedDevice(),
+);
 export const [getPictureEnhancement, savePictureEnhancement] = createStore(
   "rtp2httpd-player-picture-enhancement",
-  true,
+  () => !isPerformanceConstrainedDevice(),
 );
 export const [getVolume, saveVolume] = createStore("rtp2httpd-player-volume", 1);
 export const [getMuted, saveMuted] = createStore("rtp2httpd-player-muted", false);

--- a/web-ui/src/lib/player-storage.ts
+++ b/web-ui/src/lib/player-storage.ts
@@ -15,12 +15,8 @@ function cloneDefaultValue<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
-function createStore<T>(
-  key: string,
-  defaultValue: T | (() => T),
-): [get: () => T, save: (value: T) => void] {
-  const resolveDefault = (): T =>
-    typeof defaultValue === "function" ? (defaultValue as () => T)() : defaultValue;
+function createStore<T>(key: string, defaultValue: T | (() => T)): [get: () => T, save: (value: T) => void] {
+  const resolveDefault = (): T => (typeof defaultValue === "function" ? (defaultValue as () => T)() : defaultValue);
 
   return [
     (): T => {

--- a/web-ui/src/vite-env.d.ts
+++ b/web-ui/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 /** User-Agent Client Hints (Chromium); not yet in all DOM lib versions. */
 interface NavigatorUAData {
   readonly platform: string;
+  readonly mobile: boolean;
 }
 
 interface Navigator {


### PR DESCRIPTION
## Summary
- Remove `overflow-hidden` / `overscroll-none` scroll lock from the player page `html`/`body`.
- Add `isPerformanceConstrainedDevice()` (phones, tablets, LG webOS `Web0S`, HarmonyOS, and common Chinese in-app/OEM browsers/kernels) while keeping desktop browsers default-on.
- Make seamless switch, auto deinterlace, and picture enhancement defaults lazy: on for desktop, off for constrained devices; existing localStorage values are preserved.

## Test plan
- [x] Desktop Chrome/Firefox/Safari: first visit (no related localStorage keys) has all three toggles on
- [x] Mobile / iPad / Android tablet (or UA spoof): first visit has all three toggles off
- [x] LG webOS UA (`Web0S`): first visit has all three toggles off
- [x] WeChat / QQ in-app browser on phone: defaults off; PC WeChat/QQ Browser still defaults on
- [x] After manually changing a toggle, reload keeps the saved value
- [x] Player page can scroll (no body scroll lock)