### PR TITLE
feat(web-ui): refresh player and status visuals

### DIFF
--- a/web-ui/player.html
+++ b/web-ui/player.html
@@ -10,8 +10,8 @@
     <meta name="format-detection" content="telephone=no" />
     <title>rtp2httpd Player</title>
     <link rel="icon" type="image/png" href="./assets/icon.png" />
-    <meta name="theme-color" content="#2463ea" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#101729" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#0891b2" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#050b18" media="(prefers-color-scheme: dark)" />
     <link rel="apple-touch-icon" href="./assets/icon.png" />
     <script>
       (() => {

--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -28,31 +28,33 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         key={channel.id}
         ref={ref}
         className={clsx(
-          "rounded-xl border bg-card text-card-foreground shadow group cursor-pointer overflow-hidden transition-[color,background-color,border-color,box-shadow] duration-200 flex items-center gap-2 p-2 w-full text-left",
+          "group flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-2xl border p-2 text-left text-card-foreground transition-[color,background-color,border-color,box-shadow,transform] duration-200",
           isCurrentChannel
-            ? "border-primary bg-primary/5 shadow-md"
-            : "border-border hover:border-primary/50 hover:bg-muted/50 hover:shadow-sm",
+            ? "border-cyan-400/45 bg-[linear-gradient(135deg,rgba(34,211,238,0.14),rgba(99,102,241,0.12))] shadow-[0_12px_28px_rgba(8,145,178,0.13),inset_0_1px_0_rgba(255,255,255,0.55)] dark:border-cyan-300/35 dark:shadow-[0_12px_30px_rgba(2,8,23,0.36),0_0_20px_rgba(34,211,238,0.06)]"
+            : "border-slate-200/70 bg-white/52 shadow-[0_8px_22px_rgba(30,64,175,0.055),inset_0_1px_0_rgba(255,255,255,0.5)] motion-safe:hover:-translate-y-px hover:border-cyan-400/35 hover:bg-cyan-50/55 hover:shadow-[0_12px_28px_rgba(8,145,178,0.1)] dark:border-white/8 dark:bg-slate-950/36 dark:shadow-[0_8px_22px_rgba(0,0,0,0.18)] dark:hover:border-cyan-300/25 dark:hover:bg-cyan-300/7",
         )}
         onClick={handleClick}
       >
         {/* Left: Channel Number and Info */}
-        <span className="flex h-5 md:h-6 min-w-7 md:min-w-8 items-center justify-center rounded-lg bg-primary/10 px-1.5 md:px-2 text-[10px] md:text-xs font-semibold text-primary shrink-0">
+        <span className="flex h-5 min-w-7 shrink-0 items-center justify-center rounded-lg bg-[linear-gradient(135deg,rgba(34,211,238,0.18),rgba(99,102,241,0.16))] px-1.5 font-semibold text-[10px] text-cyan-700 ring-1 ring-cyan-500/10 dark:text-cyan-200 md:h-6 md:min-w-8 md:px-2 md:text-xs">
           {channel.id}
         </span>
-        <div className="flex-1 overflow-hidden min-w-0">
+        <div className="min-w-0 flex-1 overflow-hidden">
           <div className="flex items-center gap-1 md:gap-1.5">
-            <div className="truncate text-sm md:text-base font-semibold leading-tight">{channel.name}</div>
+            <div className="min-w-0 flex-1 truncate font-semibold text-sm leading-tight tracking-[0.005em] md:text-base">
+              {channel.name}
+            </div>
             {channel.sources.some((s) => s.catchup && s.catchupSource) && (
               <span title={t("catchupSupported")}>
-                <History className="h-3 w-3 md:h-3.5 md:w-3.5 shrink-0 text-primary" />
+                <History className="h-3 w-3 shrink-0 text-cyan-600 dark:text-cyan-300 md:h-3.5 md:w-3.5" />
               </span>
             )}
           </div>
-          <div className="mt-0.5 truncate text-[10px] md:text-xs text-muted-foreground">
+          <div className="mt-0.5 truncate text-[10px] text-slate-500 leading-4 dark:text-slate-400 md:text-xs">
             {groupLabel}
             {currentProgram && (
               <>
-                <span className="mx-1">·</span>
+                {groupLabel && <span className="mx-1">·</span>}
                 <span>{currentProgram}</span>
               </>
             )}
@@ -60,12 +62,12 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         </div>
         {/* Right: Logo */}
         {channel.logo && (
-          <div className="flex h-8 w-14 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[#404d6a] px-1.5 py-0.5 dark:bg-transparent md:h-10 md:w-20 md:px-2 md:py-1">
+          <div className="flex h-8 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-cyan-900/8 bg-[linear-gradient(145deg,rgba(15,42,72,0.88),rgba(49,46,129,0.76))] px-1.5 py-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] dark:border-cyan-100/10 md:h-10 md:w-20 md:px-2 md:py-1">
             <img
               src={channel.logo}
               alt={channel.name}
               referrerPolicy="no-referrer"
-              className="h-full w-full object-contain transition-transform duration-200 group-hover:scale-105"
+              className="h-full w-full object-contain drop-shadow-[0_0_8px_rgba(207,250,254,0.16)] transition-transform duration-200 group-hover:scale-105"
               onError={(e) => {
                 (e.target as HTMLImageElement).style.display = "none";
               }}

--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -28,25 +28,39 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         key={channel.id}
         ref={ref}
         className={clsx(
-          "group relative isolate flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-2xl border p-2 text-left text-card-foreground transition-[color,background-color,border-color,box-shadow] duration-200",
+          "group relative isolate flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-2xl border p-2 text-left text-card-foreground transition-[color,background-color,border-color,box-shadow,backdrop-filter] duration-300 ease-out motion-reduce:transition-none",
           isCurrentChannel
-            ? "border-blue-400/50 bg-[linear-gradient(135deg,rgba(59,130,246,0.18),rgba(99,102,241,0.13))] shadow-[0_14px_30px_-18px_rgba(37,99,235,0.42),inset_0_1px_0_rgba(255,255,255,0.72),inset_0_-1px_0_rgba(37,99,235,0.1)] ring-1 ring-blue-400/10 backdrop-blur-md backdrop-saturate-150 before:pointer-events-none before:absolute before:inset-x-3 before:top-0 before:h-px before:bg-[linear-gradient(90deg,transparent,rgba(191,219,254,0.76),transparent)] before:content-[''] dark:border-blue-300/40 dark:shadow-[0_16px_34px_-18px_rgba(0,0,0,0.78),0_0_24px_-12px_rgba(59,130,246,0.54),inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(59,130,246,0.12)] dark:ring-blue-300/10 dark:before:bg-[linear-gradient(90deg,transparent,rgba(191,219,254,0.34),transparent)]"
-            : "border-slate-200/70 bg-white/48 shadow-[inset_0_1px_0_rgba(255,255,255,0.44)] hover:border-blue-400/35 hover:bg-blue-50/52 dark:border-white/8 dark:bg-slate-950/34 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045)] dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
+            ? "border-blue-300/65 bg-white/38 shadow-[0_16px_32px_-18px_rgba(37,99,235,0.46),0_0_20px_-12px_rgba(59,130,246,0.42),inset_0_1px_0_rgba(255,255,255,0.78),inset_0_-1px_0_rgba(37,99,235,0.12)] backdrop-blur-md backdrop-saturate-150 dark:border-blue-200/55 dark:bg-slate-900/30 dark:shadow-[0_18px_36px_-18px_rgba(0,0,0,0.82),0_0_28px_-12px_rgba(59,130,246,0.62),inset_0_1px_0_rgba(255,255,255,0.17),inset_0_-1px_0_rgba(59,130,246,0.14)]"
+            : "border-slate-200/70 bg-white/48 shadow-[inset_0_1px_0_rgba(255,255,255,0.44)] backdrop-blur-none backdrop-saturate-100 hover:border-blue-400/35 hover:bg-blue-50/52 dark:border-white/8 dark:bg-slate-950/34 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045)] dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
         )}
         onClick={handleClick}
       >
+        <span
+          aria-hidden
+          className={clsx(
+            "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none",
+            isCurrentChannel && "opacity-100",
+          )}
+        />
+        <span
+          aria-hidden
+          className={clsx(
+            "pointer-events-none absolute inset-x-3 top-px z-20 h-px rounded-full bg-[linear-gradient(90deg,transparent_0%,rgba(147,197,253,0.42)_14%,rgba(219,234,254,0.96)_48%,rgba(165,180,252,0.68)_78%,transparent_100%)] opacity-0 shadow-[0_0_12px_rgba(147,197,253,0.5)] transition-opacity duration-300 ease-out motion-reduce:transition-none",
+            isCurrentChannel && "opacity-100",
+          )}
+        />
         {/* Left: Channel Number and Info */}
         <span
           className={clsx(
-            "flex h-5 min-w-7 shrink-0 items-center justify-center rounded-lg px-1.5 font-semibold text-[10px] md:h-6 md:min-w-8 md:px-2 md:text-xs",
+            "relative z-10 flex h-5 min-w-7 shrink-0 items-center justify-center rounded-lg px-1.5 font-semibold text-[10px] transition-[color,background-color,box-shadow] duration-300 ease-out motion-reduce:transition-none md:h-6 md:min-w-8 md:px-2 md:text-xs",
             isCurrentChannel
-              ? "bg-[linear-gradient(135deg,rgba(59,130,246,0.26),rgba(99,102,241,0.2))] text-blue-700 shadow-[0_6px_16px_-10px_rgba(37,99,235,0.7),inset_0_1px_0_rgba(255,255,255,0.42)] ring-1 ring-blue-400/25 dark:text-blue-100"
-              : "bg-[linear-gradient(135deg,rgba(59,130,246,0.15),rgba(99,102,241,0.13))] text-blue-700 ring-1 ring-blue-500/10 dark:text-blue-200",
+              ? "bg-blue-400/24 text-blue-700 shadow-[0_6px_16px_-10px_rgba(37,99,235,0.7),inset_0_1px_0_rgba(255,255,255,0.46),0_0_0_1px_rgba(96,165,250,0.28)] dark:text-blue-100"
+              : "bg-blue-500/13 text-blue-700 shadow-[0_0_0_1px_rgba(59,130,246,0.1)] dark:text-blue-200",
           )}
         >
           {channel.id}
         </span>
-        <div className="min-w-0 flex-1 overflow-hidden">
+        <div className="relative z-10 min-w-0 flex-1 overflow-hidden">
           <div className="flex items-center gap-1 md:gap-1.5">
             <div className="min-w-0 flex-1 truncate font-semibold text-sm leading-tight tracking-[0.005em] md:text-base">
               {channel.name}
@@ -69,7 +83,7 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         </div>
         {/* Right: Logo */}
         {channel.logo && (
-          <div className="flex h-8 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-blue-900/8 bg-[linear-gradient(145deg,rgba(15,42,72,0.88),rgba(49,46,129,0.76))] px-1.5 py-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] dark:border-blue-100/10 md:h-10 md:w-20 md:px-2 md:py-1">
+          <div className="relative z-10 flex h-8 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-blue-900/8 bg-[linear-gradient(145deg,rgba(15,42,72,0.88),rgba(49,46,129,0.76))] px-1.5 py-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] dark:border-blue-100/10 md:h-10 md:w-20 md:px-2 md:py-1">
             <img
               src={channel.logo}
               alt={channel.name}

--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -9,9 +9,8 @@ import {
   PLAYER_LIST_SURFACE_DEFAULT_CLASS,
   PLAYER_LIST_SURFACE_HOVER_CLASS,
   PLAYER_LIST_SURFACE_SELECTED_CLASS,
-  PLAYER_SELECTED_GLASS_LAYER_CLASS,
-  PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
 } from "./classnames";
+import { PlayerSelectedGlassLayers } from "./player-selected-glass-layers";
 
 interface ChannelListItemProps {
   channel: Channel;
@@ -43,20 +42,7 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         )}
         onClick={handleClick}
       >
-        <span
-          aria-hidden
-          className={clsx(
-            PLAYER_SELECTED_GLASS_LAYER_CLASS,
-            isCurrentChannel && "opacity-100",
-          )}
-        />
-        <span
-          aria-hidden
-          className={clsx(
-            PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
-            isCurrentChannel && "opacity-100",
-          )}
-        />
+        <PlayerSelectedGlassLayers visible={isCurrentChannel} />
         {/* Left: Channel Number and Info */}
         <span
           className={clsx(

--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -28,15 +28,15 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         key={channel.id}
         ref={ref}
         className={clsx(
-          "group flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-2xl border p-2 text-left text-card-foreground transition-[color,background-color,border-color,box-shadow,transform] duration-200",
+          "group flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-2xl border p-2 text-left text-card-foreground transition-[color,background-color,border-color,box-shadow] duration-200",
           isCurrentChannel
-            ? "border-cyan-400/45 bg-[linear-gradient(135deg,rgba(34,211,238,0.14),rgba(99,102,241,0.12))] shadow-[0_12px_28px_rgba(8,145,178,0.13),inset_0_1px_0_rgba(255,255,255,0.55)] dark:border-cyan-300/35 dark:shadow-[0_12px_30px_rgba(2,8,23,0.36),0_0_20px_rgba(34,211,238,0.06)]"
-            : "border-slate-200/70 bg-white/52 shadow-[0_8px_22px_rgba(30,64,175,0.055),inset_0_1px_0_rgba(255,255,255,0.5)] motion-safe:hover:-translate-y-px hover:border-cyan-400/35 hover:bg-cyan-50/55 hover:shadow-[0_12px_28px_rgba(8,145,178,0.1)] dark:border-white/8 dark:bg-slate-950/36 dark:shadow-[0_8px_22px_rgba(0,0,0,0.18)] dark:hover:border-cyan-300/25 dark:hover:bg-cyan-300/7",
+            ? "border-blue-400/45 bg-[linear-gradient(135deg,rgba(59,130,246,0.14),rgba(99,102,241,0.12))] shadow-[0_12px_28px_rgba(37,99,235,0.13),inset_0_1px_0_rgba(255,255,255,0.55)] dark:border-blue-300/35 dark:shadow-[0_12px_30px_rgba(2,8,23,0.36),0_0_20px_rgba(59,130,246,0.06)]"
+            : "border-slate-200/70 bg-white/52 shadow-[0_8px_22px_rgba(30,64,175,0.055),inset_0_1px_0_rgba(255,255,255,0.5)] hover:border-blue-400/35 hover:bg-blue-50/55 hover:shadow-[0_12px_28px_rgba(37,99,235,0.1)] dark:border-white/8 dark:bg-slate-950/36 dark:shadow-[0_8px_22px_rgba(0,0,0,0.18)] dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
         )}
         onClick={handleClick}
       >
         {/* Left: Channel Number and Info */}
-        <span className="flex h-5 min-w-7 shrink-0 items-center justify-center rounded-lg bg-[linear-gradient(135deg,rgba(34,211,238,0.18),rgba(99,102,241,0.16))] px-1.5 font-semibold text-[10px] text-cyan-700 ring-1 ring-cyan-500/10 dark:text-cyan-200 md:h-6 md:min-w-8 md:px-2 md:text-xs">
+        <span className="flex h-5 min-w-7 shrink-0 items-center justify-center rounded-lg bg-[linear-gradient(135deg,rgba(59,130,246,0.18),rgba(99,102,241,0.16))] px-1.5 font-semibold text-[10px] text-blue-700 ring-1 ring-blue-500/10 dark:text-blue-200 md:h-6 md:min-w-8 md:px-2 md:text-xs">
           {channel.id}
         </span>
         <div className="min-w-0 flex-1 overflow-hidden">
@@ -46,7 +46,7 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
             </div>
             {channel.sources.some((s) => s.catchup && s.catchupSource) && (
               <span title={t("catchupSupported")}>
-                <History className="h-3 w-3 shrink-0 text-cyan-600 dark:text-cyan-300 md:h-3.5 md:w-3.5" />
+                <History className="h-3 w-3 shrink-0 text-blue-600 dark:text-blue-300 md:h-3.5 md:w-3.5" />
               </span>
             )}
           </div>
@@ -62,12 +62,12 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         </div>
         {/* Right: Logo */}
         {channel.logo && (
-          <div className="flex h-8 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-cyan-900/8 bg-[linear-gradient(145deg,rgba(15,42,72,0.88),rgba(49,46,129,0.76))] px-1.5 py-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] dark:border-cyan-100/10 md:h-10 md:w-20 md:px-2 md:py-1">
+          <div className="flex h-8 w-14 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-blue-900/8 bg-[linear-gradient(145deg,rgba(15,42,72,0.88),rgba(49,46,129,0.76))] px-1.5 py-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] dark:border-blue-100/10 md:h-10 md:w-20 md:px-2 md:py-1">
             <img
               src={channel.logo}
               alt={channel.name}
               referrerPolicy="no-referrer"
-              className="h-full w-full object-contain drop-shadow-[0_0_8px_rgba(207,250,254,0.16)] transition-transform duration-200 group-hover:scale-105"
+              className="h-full w-full object-contain drop-shadow-[0_0_8px_rgba(219,234,254,0.16)]"
               onError={(e) => {
                 (e.target as HTMLImageElement).style.display = "none";
               }}

--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -28,15 +28,22 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         key={channel.id}
         ref={ref}
         className={clsx(
-          "group flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-2xl border p-2 text-left text-card-foreground transition-[color,background-color,border-color,box-shadow] duration-200",
+          "group relative isolate flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-2xl border p-2 text-left text-card-foreground transition-[color,background-color,border-color,box-shadow] duration-200",
           isCurrentChannel
-            ? "border-blue-400/45 bg-[linear-gradient(135deg,rgba(59,130,246,0.14),rgba(99,102,241,0.12))] shadow-[0_12px_28px_rgba(37,99,235,0.13),inset_0_1px_0_rgba(255,255,255,0.55)] dark:border-blue-300/35 dark:shadow-[0_12px_30px_rgba(2,8,23,0.36),0_0_20px_rgba(59,130,246,0.06)]"
-            : "border-slate-200/70 bg-white/52 shadow-[0_8px_22px_rgba(30,64,175,0.055),inset_0_1px_0_rgba(255,255,255,0.5)] hover:border-blue-400/35 hover:bg-blue-50/55 hover:shadow-[0_12px_28px_rgba(37,99,235,0.1)] dark:border-white/8 dark:bg-slate-950/36 dark:shadow-[0_8px_22px_rgba(0,0,0,0.18)] dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
+            ? "border-blue-400/50 bg-[linear-gradient(135deg,rgba(59,130,246,0.18),rgba(99,102,241,0.13))] shadow-[0_14px_30px_-18px_rgba(37,99,235,0.42),inset_0_1px_0_rgba(255,255,255,0.72),inset_0_-1px_0_rgba(37,99,235,0.1)] ring-1 ring-blue-400/10 backdrop-blur-md backdrop-saturate-150 before:pointer-events-none before:absolute before:inset-x-3 before:top-0 before:h-px before:bg-[linear-gradient(90deg,transparent,rgba(191,219,254,0.76),transparent)] before:content-[''] dark:border-blue-300/40 dark:shadow-[0_16px_34px_-18px_rgba(0,0,0,0.78),0_0_24px_-12px_rgba(59,130,246,0.54),inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(59,130,246,0.12)] dark:ring-blue-300/10 dark:before:bg-[linear-gradient(90deg,transparent,rgba(191,219,254,0.34),transparent)]"
+            : "border-slate-200/70 bg-white/48 shadow-[inset_0_1px_0_rgba(255,255,255,0.44)] hover:border-blue-400/35 hover:bg-blue-50/52 dark:border-white/8 dark:bg-slate-950/34 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045)] dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
         )}
         onClick={handleClick}
       >
         {/* Left: Channel Number and Info */}
-        <span className="flex h-5 min-w-7 shrink-0 items-center justify-center rounded-lg bg-[linear-gradient(135deg,rgba(59,130,246,0.18),rgba(99,102,241,0.16))] px-1.5 font-semibold text-[10px] text-blue-700 ring-1 ring-blue-500/10 dark:text-blue-200 md:h-6 md:min-w-8 md:px-2 md:text-xs">
+        <span
+          className={clsx(
+            "flex h-5 min-w-7 shrink-0 items-center justify-center rounded-lg px-1.5 font-semibold text-[10px] md:h-6 md:min-w-8 md:px-2 md:text-xs",
+            isCurrentChannel
+              ? "bg-[linear-gradient(135deg,rgba(59,130,246,0.26),rgba(99,102,241,0.2))] text-blue-700 shadow-[0_6px_16px_-10px_rgba(37,99,235,0.7),inset_0_1px_0_rgba(255,255,255,0.42)] ring-1 ring-blue-400/25 dark:text-blue-100"
+              : "bg-[linear-gradient(135deg,rgba(59,130,246,0.15),rgba(99,102,241,0.13))] text-blue-700 ring-1 ring-blue-500/10 dark:text-blue-200",
+          )}
+        >
           {channel.id}
         </span>
         <div className="min-w-0 flex-1 overflow-hidden">

--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -10,6 +10,7 @@ import {
   PLAYER_LIST_SURFACE_HOVER_CLASS,
   PLAYER_LIST_SURFACE_SELECTED_CLASS,
   PLAYER_SELECTED_GLASS_LAYER_CLASS,
+  PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
 } from "./classnames";
 
 interface ChannelListItemProps {
@@ -46,6 +47,13 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
           aria-hidden
           className={clsx(
             PLAYER_SELECTED_GLASS_LAYER_CLASS,
+            isCurrentChannel && "opacity-100",
+          )}
+        />
+        <span
+          aria-hidden
+          className={clsx(
+            PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
             isCurrentChannel && "opacity-100",
           )}
         />

--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -10,7 +10,6 @@ import {
   PLAYER_LIST_SURFACE_HOVER_CLASS,
   PLAYER_LIST_SURFACE_SELECTED_CLASS,
   PLAYER_SELECTED_GLASS_LAYER_CLASS,
-  PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
 } from "./classnames";
 
 interface ChannelListItemProps {
@@ -47,13 +46,6 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
           aria-hidden
           className={clsx(
             PLAYER_SELECTED_GLASS_LAYER_CLASS,
-            isCurrentChannel && "opacity-100",
-          )}
-        />
-        <span
-          aria-hidden
-          className={clsx(
-            PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
             isCurrentChannel && "opacity-100",
           )}
         />

--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -4,6 +4,14 @@ import { forwardRef, memo, useCallback } from "react";
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import type { Locale } from "../../lib/locale";
 import type { Channel } from "../../types/player";
+import {
+  PLAYER_LIST_SURFACE_BASE_CLASS,
+  PLAYER_LIST_SURFACE_DEFAULT_CLASS,
+  PLAYER_LIST_SURFACE_HOVER_CLASS,
+  PLAYER_LIST_SURFACE_SELECTED_CLASS,
+  PLAYER_SELECTED_GLASS_LAYER_CLASS,
+  PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
+} from "./classnames";
 
 interface ChannelListItemProps {
   channel: Channel;
@@ -28,24 +36,24 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         key={channel.id}
         ref={ref}
         className={clsx(
-          "group relative isolate flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-2xl border p-2 text-left text-card-foreground transition-[color,background-color,border-color,box-shadow,backdrop-filter] duration-300 ease-out motion-reduce:transition-none",
-          isCurrentChannel
-            ? "border-blue-300/65 bg-white/38 shadow-[0_16px_32px_-18px_rgba(37,99,235,0.46),0_0_20px_-12px_rgba(59,130,246,0.42),inset_0_1px_0_rgba(255,255,255,0.78),inset_0_-1px_0_rgba(37,99,235,0.12)] backdrop-blur-md backdrop-saturate-150 dark:border-blue-200/55 dark:bg-slate-900/30 dark:shadow-[0_18px_36px_-18px_rgba(0,0,0,0.82),0_0_28px_-12px_rgba(59,130,246,0.62),inset_0_1px_0_rgba(255,255,255,0.17),inset_0_-1px_0_rgba(59,130,246,0.14)]"
-            : "border-slate-200/70 bg-white/48 shadow-[inset_0_1px_0_rgba(255,255,255,0.44)] backdrop-blur-none backdrop-saturate-100 hover:border-blue-400/35 hover:bg-blue-50/52 dark:border-white/8 dark:bg-slate-950/34 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045)] dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
+          PLAYER_LIST_SURFACE_BASE_CLASS,
+          "group flex w-full cursor-pointer items-center gap-2 p-2 text-left",
+          isCurrentChannel ? PLAYER_LIST_SURFACE_SELECTED_CLASS : PLAYER_LIST_SURFACE_DEFAULT_CLASS,
+          !isCurrentChannel && PLAYER_LIST_SURFACE_HOVER_CLASS,
         )}
         onClick={handleClick}
       >
         <span
           aria-hidden
           className={clsx(
-            "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none",
+            PLAYER_SELECTED_GLASS_LAYER_CLASS,
             isCurrentChannel && "opacity-100",
           )}
         />
         <span
           aria-hidden
           className={clsx(
-            "pointer-events-none absolute inset-x-3 top-px z-20 h-px rounded-full bg-[linear-gradient(90deg,transparent_0%,rgba(147,197,253,0.42)_14%,rgba(219,234,254,0.96)_48%,rgba(165,180,252,0.68)_78%,transparent_100%)] opacity-0 shadow-[0_0_12px_rgba(147,197,253,0.5)] transition-opacity duration-300 ease-out motion-reduce:transition-none",
+            PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
             isCurrentChannel && "opacity-100",
           )}
         />

--- a/web-ui/src/components/player/channel-list.tsx
+++ b/web-ui/src/components/player/channel-list.tsx
@@ -210,7 +210,7 @@ function ChannelListComponent({
               className={clsx(
                 "min-h-7 max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-full border px-2.5 py-1 font-medium text-xs leading-none transition-[color,background-color,border-color,box-shadow]",
                 selectedGroup === null
-                  ? "border-blue-400/25 bg-[linear-gradient(135deg,#2563eb,#4f46e5)] text-white shadow-[0_5px_14px_rgba(37,99,235,0.25)]"
+                  ? "border-blue-400/30 bg-blue-500/10 text-blue-700 shadow-[0_4px_12px_rgba(37,99,235,0.1)] dark:border-blue-300/20 dark:bg-blue-400/14 dark:text-blue-200 dark:shadow-[0_4px_12px_rgba(37,99,235,0.08)]"
                   : "cursor-pointer border border-blue-900/8 bg-white/55 text-slate-500 hover:border-blue-400/30 hover:bg-blue-50/80 hover:text-blue-800 dark:border-blue-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-blue-300/10 dark:hover:text-blue-100",
               )}
             >
@@ -224,7 +224,7 @@ function ChannelListComponent({
                 className={clsx(
                   "min-h-7 max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-full border px-2.5 py-1 font-medium text-xs leading-none transition-[color,background-color,border-color,box-shadow]",
                   selectedGroup === group
-                    ? "border-blue-400/25 bg-[linear-gradient(135deg,#2563eb,#4f46e5)] text-white shadow-[0_5px_14px_rgba(37,99,235,0.25)]"
+                    ? "border-blue-400/30 bg-blue-500/10 text-blue-700 shadow-[0_4px_12px_rgba(37,99,235,0.1)] dark:border-blue-300/20 dark:bg-blue-400/14 dark:text-blue-200 dark:shadow-[0_4px_12px_rgba(37,99,235,0.08)]"
                     : "cursor-pointer border border-blue-900/8 bg-white/55 text-slate-500 hover:border-blue-400/30 hover:bg-blue-50/80 hover:text-blue-800 dark:border-blue-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-blue-300/10 dark:hover:text-blue-100",
                 )}
               >

--- a/web-ui/src/components/player/channel-list.tsx
+++ b/web-ui/src/components/player/channel-list.tsx
@@ -192,7 +192,7 @@ function ChannelListComponent({
               value={searchQuery}
               onChange={handleSearchInputChange}
               onKeyDown={handleSearchKeyDown}
-              className="h-8 w-full rounded-xl border border-blue-900/10 bg-white/60 px-3 py-0 pl-8 text-slate-800 text-xs shadow-[0_8px_24px_rgba(30,64,175,0.06),inset_0_1px_0_rgba(255,255,255,0.7)] backdrop-blur-xl transition placeholder:text-slate-400 focus:border-blue-400/60 focus:outline-none focus:ring-2 focus:ring-blue-400/20 dark:border-blue-100/10 dark:bg-slate-950/45 dark:text-blue-50 dark:placeholder:text-slate-500 md:h-9 md:pl-9 md:text-sm"
+              className="h-8 w-full rounded-xl border border-blue-900/10 bg-white/78 px-3 py-0 pl-8 text-slate-800 text-xs shadow-none transition placeholder:text-slate-400 focus:border-blue-400/60 focus:outline-none focus:ring-2 focus:ring-blue-400/20 dark:border-blue-100/10 dark:bg-slate-900/85 dark:text-blue-50 dark:placeholder:text-slate-500 md:h-9 md:pl-9 md:text-sm"
             />
             <Search className="absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-blue-600/65 dark:text-blue-300/55 md:h-4 md:w-4" />
           </div>

--- a/web-ui/src/components/player/channel-list.tsx
+++ b/web-ui/src/components/player/channel-list.tsx
@@ -129,10 +129,15 @@ function ChannelListComponent({
     }, 0);
 
     if (!currentChannel) return;
-    if (nextScrollBehaviorRef.current === "skip") return;
+    const requestedBehavior = nextScrollBehaviorRef.current;
+    if (requestedBehavior === "skip") return;
+    const behavior =
+      requestedBehavior === "smooth" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        ? "instant"
+        : requestedBehavior;
 
     currentChannelRef.current?.scrollIntoView({
-      behavior: nextScrollBehaviorRef.current,
+      behavior,
       block: "center",
     });
   }, [currentChannel]);
@@ -176,37 +181,37 @@ function ChannelListComponent({
   }, []);
 
   return (
-    <div className="flex h-full flex-col bg-card">
+    <div className="flex h-full flex-col bg-transparent">
       {/* Search */}
       <div className="px-2 pt-2 pb-0">
-        <div className="flex items-center">
-          <div className="relative flex-1">
+        <div className="flex items-center gap-2">
+          <div className="relative min-w-0 flex-1">
             <input
               type="text"
               placeholder={t("searchChannels")}
               value={searchQuery}
               onChange={handleSearchInputChange}
               onKeyDown={handleSearchKeyDown}
-              className="w-full rounded-lg border border-border bg-background px-3 py-1 md:py-1.5 pl-8 md:pl-9 text-xs md:text-sm shadow-sm transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              className="h-8 w-full rounded-xl border border-cyan-900/10 bg-white/60 px-3 py-0 pl-8 text-slate-800 text-xs shadow-[0_8px_24px_rgba(30,64,175,0.06),inset_0_1px_0_rgba(255,255,255,0.7)] backdrop-blur-xl transition placeholder:text-slate-400 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/20 dark:border-cyan-100/10 dark:bg-slate-950/45 dark:text-cyan-50 dark:placeholder:text-slate-500 md:h-9 md:pl-9 md:text-sm"
             />
-            <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 md:h-4 md:w-4 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-cyan-600/65 dark:text-cyan-300/55 md:h-4 md:w-4" />
           </div>
-          {settingsSlot && <div>{settingsSlot}</div>}
+          {settingsSlot && <div className="shrink-0">{settingsSlot}</div>}
         </div>
       </div>
 
       {/* Groups */}
       {groups && groups.length > 0 && (
-        <div className="border-y border-border bg-muted/30 px-2 py-2 mt-2">
-          <div className="flex flex-wrap gap-1.5">
+        <div className="mt-2 border-cyan-950/10 border-y bg-[linear-gradient(90deg,rgba(224,242,254,0.55),rgba(238,242,255,0.68))] px-2 py-2 backdrop-blur-xl dark:border-cyan-100/10 dark:bg-[linear-gradient(90deg,rgba(8,47,73,0.3),rgba(30,27,75,0.36))]">
+          <div className="flex flex-wrap items-center gap-1.5">
             <button
               type="button"
               onClick={() => setSelectedGroup(null)}
               className={clsx(
-                "rounded-lg px-2.5 md:px-2 py-0.5 md:py-1 text-xs font-medium transition-[color,background-color,box-shadow]",
+                "min-h-7 max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-full border px-2.5 py-1 font-medium text-xs leading-none transition-[color,background-color,border-color,box-shadow]",
                 selectedGroup === null
-                  ? "bg-primary text-primary-foreground shadow-sm"
-                  : "bg-background text-muted-foreground cursor-pointer hover:bg-background/80 hover:text-foreground",
+                  ? "border-cyan-400/25 bg-[linear-gradient(135deg,#0891b2,#4f46e5)] text-white shadow-[0_5px_14px_rgba(8,145,178,0.25)]"
+                  : "cursor-pointer border border-cyan-900/8 bg-white/55 text-slate-500 hover:border-cyan-400/30 hover:bg-cyan-50/80 hover:text-cyan-800 dark:border-cyan-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-cyan-300/10 dark:hover:text-cyan-100",
               )}
             >
               {t("allChannels")}
@@ -217,10 +222,10 @@ function ChannelListComponent({
                 key={group}
                 onClick={() => setSelectedGroup(group)}
                 className={clsx(
-                  "rounded-lg px-2.5 md:px-2 py-0.5 md:py-1 text-xs font-medium transition-[color,background-color,box-shadow]",
+                  "min-h-7 max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-full border px-2.5 py-1 font-medium text-xs leading-none transition-[color,background-color,border-color,box-shadow]",
                   selectedGroup === group
-                    ? "bg-primary text-primary-foreground shadow-sm"
-                    : "cursor-pointer bg-background text-muted-foreground hover:bg-background/80 hover:text-foreground",
+                    ? "border-cyan-400/25 bg-[linear-gradient(135deg,#0891b2,#4f46e5)] text-white shadow-[0_5px_14px_rgba(8,145,178,0.25)]"
+                    : "cursor-pointer border border-cyan-900/8 bg-white/55 text-slate-500 hover:border-cyan-400/30 hover:bg-cyan-50/80 hover:text-cyan-800 dark:border-cyan-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-cyan-300/10 dark:hover:text-cyan-100",
                 )}
               >
                 {group}

--- a/web-ui/src/components/player/channel-list.tsx
+++ b/web-ui/src/components/player/channel-list.tsx
@@ -192,9 +192,9 @@ function ChannelListComponent({
               value={searchQuery}
               onChange={handleSearchInputChange}
               onKeyDown={handleSearchKeyDown}
-              className="h-8 w-full rounded-xl border border-cyan-900/10 bg-white/60 px-3 py-0 pl-8 text-slate-800 text-xs shadow-[0_8px_24px_rgba(30,64,175,0.06),inset_0_1px_0_rgba(255,255,255,0.7)] backdrop-blur-xl transition placeholder:text-slate-400 focus:border-cyan-400/60 focus:outline-none focus:ring-2 focus:ring-cyan-400/20 dark:border-cyan-100/10 dark:bg-slate-950/45 dark:text-cyan-50 dark:placeholder:text-slate-500 md:h-9 md:pl-9 md:text-sm"
+              className="h-8 w-full rounded-xl border border-blue-900/10 bg-white/60 px-3 py-0 pl-8 text-slate-800 text-xs shadow-[0_8px_24px_rgba(30,64,175,0.06),inset_0_1px_0_rgba(255,255,255,0.7)] backdrop-blur-xl transition placeholder:text-slate-400 focus:border-blue-400/60 focus:outline-none focus:ring-2 focus:ring-blue-400/20 dark:border-blue-100/10 dark:bg-slate-950/45 dark:text-blue-50 dark:placeholder:text-slate-500 md:h-9 md:pl-9 md:text-sm"
             />
-            <Search className="absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-cyan-600/65 dark:text-cyan-300/55 md:h-4 md:w-4" />
+            <Search className="absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-blue-600/65 dark:text-blue-300/55 md:h-4 md:w-4" />
           </div>
           {settingsSlot && <div className="shrink-0">{settingsSlot}</div>}
         </div>
@@ -202,7 +202,7 @@ function ChannelListComponent({
 
       {/* Groups */}
       {groups && groups.length > 0 && (
-        <div className="mt-2 border-cyan-950/10 border-y bg-[linear-gradient(90deg,rgba(224,242,254,0.55),rgba(238,242,255,0.68))] px-2 py-2 backdrop-blur-xl dark:border-cyan-100/10 dark:bg-[linear-gradient(90deg,rgba(8,47,73,0.3),rgba(30,27,75,0.36))]">
+        <div className="mt-2 border-blue-950/10 border-y bg-[linear-gradient(90deg,rgba(224,242,254,0.55),rgba(238,242,255,0.68))] px-2 py-2 backdrop-blur-xl dark:border-blue-100/10 dark:bg-[linear-gradient(90deg,rgba(8,47,73,0.3),rgba(30,27,75,0.36))]">
           <div className="flex flex-wrap items-center gap-1.5">
             <button
               type="button"
@@ -210,8 +210,8 @@ function ChannelListComponent({
               className={clsx(
                 "min-h-7 max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-full border px-2.5 py-1 font-medium text-xs leading-none transition-[color,background-color,border-color,box-shadow]",
                 selectedGroup === null
-                  ? "border-cyan-400/25 bg-[linear-gradient(135deg,#0891b2,#4f46e5)] text-white shadow-[0_5px_14px_rgba(8,145,178,0.25)]"
-                  : "cursor-pointer border border-cyan-900/8 bg-white/55 text-slate-500 hover:border-cyan-400/30 hover:bg-cyan-50/80 hover:text-cyan-800 dark:border-cyan-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-cyan-300/10 dark:hover:text-cyan-100",
+                  ? "border-blue-400/25 bg-[linear-gradient(135deg,#2563eb,#4f46e5)] text-white shadow-[0_5px_14px_rgba(37,99,235,0.25)]"
+                  : "cursor-pointer border border-blue-900/8 bg-white/55 text-slate-500 hover:border-blue-400/30 hover:bg-blue-50/80 hover:text-blue-800 dark:border-blue-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-blue-300/10 dark:hover:text-blue-100",
               )}
             >
               {t("allChannels")}
@@ -224,8 +224,8 @@ function ChannelListComponent({
                 className={clsx(
                   "min-h-7 max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-full border px-2.5 py-1 font-medium text-xs leading-none transition-[color,background-color,border-color,box-shadow]",
                   selectedGroup === group
-                    ? "border-cyan-400/25 bg-[linear-gradient(135deg,#0891b2,#4f46e5)] text-white shadow-[0_5px_14px_rgba(8,145,178,0.25)]"
-                    : "cursor-pointer border border-cyan-900/8 bg-white/55 text-slate-500 hover:border-cyan-400/30 hover:bg-cyan-50/80 hover:text-cyan-800 dark:border-cyan-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-cyan-300/10 dark:hover:text-cyan-100",
+                    ? "border-blue-400/25 bg-[linear-gradient(135deg,#2563eb,#4f46e5)] text-white shadow-[0_5px_14px_rgba(37,99,235,0.25)]"
+                    : "cursor-pointer border border-blue-900/8 bg-white/55 text-slate-500 hover:border-blue-400/30 hover:bg-blue-50/80 hover:text-blue-800 dark:border-blue-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-blue-300/10 dark:hover:text-blue-100",
                 )}
               >
                 {group}

--- a/web-ui/src/components/player/channel-list.tsx
+++ b/web-ui/src/components/player/channel-list.tsx
@@ -204,22 +204,10 @@ function ChannelListComponent({
       {groups && groups.length > 0 && (
         <div className="mt-2 border-blue-950/10 border-y bg-[linear-gradient(90deg,rgba(224,242,254,0.55),rgba(238,242,255,0.68))] px-2 py-2 backdrop-blur-xl dark:border-blue-100/10 dark:bg-[linear-gradient(90deg,rgba(8,47,73,0.3),rgba(30,27,75,0.36))]">
           <div className="flex flex-wrap items-center gap-1.5">
-            <button
-              type="button"
-              onClick={() => setSelectedGroup(null)}
-              className={clsx(
-                "min-h-7 max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-full border px-2.5 py-1 font-medium text-xs leading-none transition-[color,background-color,border-color,box-shadow]",
-                selectedGroup === null
-                  ? "border-blue-400/30 bg-blue-500/10 text-blue-700 shadow-[0_4px_12px_rgba(37,99,235,0.1)] dark:border-blue-300/20 dark:bg-blue-400/14 dark:text-blue-200 dark:shadow-[0_4px_12px_rgba(37,99,235,0.08)]"
-                  : "cursor-pointer border border-blue-900/8 bg-white/55 text-slate-500 hover:border-blue-400/30 hover:bg-blue-50/80 hover:text-blue-800 dark:border-blue-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-blue-300/10 dark:hover:text-blue-100",
-              )}
-            >
-              {t("allChannels")}
-            </button>
-            {groups?.map((group) => (
+            {[null, ...groups].map((group) => (
               <button
                 type="button"
-                key={group}
+                key={group ?? "all"}
                 onClick={() => setSelectedGroup(group)}
                 className={clsx(
                   "min-h-7 max-w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-full border px-2.5 py-1 font-medium text-xs leading-none transition-[color,background-color,border-color,box-shadow]",
@@ -228,7 +216,7 @@ function ChannelListComponent({
                     : "cursor-pointer border border-blue-900/8 bg-white/55 text-slate-500 hover:border-blue-400/30 hover:bg-blue-50/80 hover:text-blue-800 dark:border-blue-100/10 dark:bg-slate-950/35 dark:text-slate-400 dark:hover:bg-blue-300/10 dark:hover:text-blue-100",
                 )}
               >
-                {group}
+                {group ?? t("allChannels")}
               </button>
             ))}
           </div>

--- a/web-ui/src/components/player/classnames.ts
+++ b/web-ui/src/components/player/classnames.ts
@@ -21,3 +21,6 @@ export const PLAYER_SELECTED_GLASS_LAYER_CLASS =
 
 export const PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS =
   "pointer-events-none absolute inset-x-3 top-0 z-20 h-px rounded-full bg-[linear-gradient(90deg,transparent_0%,rgba(147,197,253,0.42)_14%,rgba(219,234,254,0.96)_48%,rgba(165,180,252,0.68)_78%,transparent_100%)] opacity-0 shadow-[0_0_8px_rgba(147,197,253,0.46)] transition-opacity duration-300 ease-out motion-reduce:transition-none";
+
+export const PLAYER_SELECTED_COMPACT_TOP_HIGHLIGHT_CLASS =
+  "pointer-events-none absolute inset-x-1 top-px z-20 h-5 rounded-t-xl bg-[radial-gradient(ellipse_at_top,rgba(219,234,254,0.3)_0%,rgba(147,197,253,0.11)_42%,transparent_76%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none";

--- a/web-ui/src/components/player/classnames.ts
+++ b/web-ui/src/components/player/classnames.ts
@@ -8,7 +8,7 @@ export const PLAYER_LIST_SURFACE_BASE_CLASS =
   "relative isolate overflow-hidden rounded-2xl border text-card-foreground transition-[color,background-color,border-color,box-shadow,backdrop-filter] duration-300 ease-out motion-reduce:transition-none";
 
 export const PLAYER_LIST_SURFACE_SELECTED_CLASS =
-  "border-blue-300/65 bg-white/38 shadow-[0_16px_32px_-18px_rgba(37,99,235,0.46),0_0_20px_-12px_rgba(59,130,246,0.42),inset_0_1px_0_rgba(255,255,255,0.78),inset_0_-1px_0_rgba(37,99,235,0.12)] backdrop-blur-md backdrop-saturate-150 dark:border-blue-200/55 dark:bg-slate-900/30 dark:shadow-[0_18px_36px_-18px_rgba(0,0,0,0.82),0_0_28px_-12px_rgba(59,130,246,0.62),inset_0_1px_0_rgba(255,255,255,0.17),inset_0_-1px_0_rgba(59,130,246,0.14)]";
+  "border-blue-300/65 bg-white/38 shadow-[0_16px_32px_-18px_rgba(37,99,235,0.46),0_0_20px_-12px_rgba(59,130,246,0.42),inset_0_-1px_0_rgba(37,99,235,0.12)] backdrop-blur-md backdrop-saturate-150 dark:border-blue-200/55 dark:bg-slate-900/30 dark:shadow-[0_18px_36px_-18px_rgba(0,0,0,0.82),0_0_28px_-12px_rgba(59,130,246,0.62),inset_0_-1px_0_rgba(59,130,246,0.14)]";
 
 export const PLAYER_LIST_SURFACE_DEFAULT_CLASS =
   "border-slate-200/70 bg-white/48 shadow-[inset_0_1px_0_rgba(255,255,255,0.44)] backdrop-blur-none backdrop-saturate-100 dark:border-white/8 dark:bg-slate-950/34 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045)]";
@@ -17,7 +17,4 @@ export const PLAYER_LIST_SURFACE_HOVER_CLASS =
   "hover:border-blue-400/35 hover:bg-blue-50/52 dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7";
 
 export const PLAYER_SELECTED_GLASS_LAYER_CLASS =
-  "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none";
-
-export const PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS =
-  "pointer-events-none absolute inset-x-3 top-px z-20 h-px rounded-full bg-[linear-gradient(90deg,transparent_0%,rgba(147,197,253,0.42)_14%,rgba(219,234,254,0.96)_48%,rgba(165,180,252,0.68)_78%,transparent_100%)] opacity-0 shadow-[0_0_12px_rgba(147,197,253,0.5)] transition-opacity duration-300 ease-out motion-reduce:transition-none";
+  "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(180deg,rgba(219,234,254,0.16)_0%,rgba(191,219,254,0.07)_18%,transparent_42%),linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none";

--- a/web-ui/src/components/player/classnames.ts
+++ b/web-ui/src/components/player/classnames.ts
@@ -1,5 +1,5 @@
 export const PLAYER_OVERLAY_SURFACE_CLASS =
-  "border border-cyan-100/20 bg-[linear-gradient(145deg,rgba(7,20,43,0.82),rgba(26,24,72,0.68))] shadow-[0_18px_48px_rgba(1,7,24,0.58),inset_0_1px_0_rgba(255,255,255,0.1)] backdrop-blur-[16px] backdrop-saturate-[1.3]";
+  "border border-blue-100/20 bg-[linear-gradient(145deg,rgba(7,20,43,0.82),rgba(26,24,72,0.68))] shadow-[0_18px_48px_rgba(1,7,24,0.58),inset_0_1px_0_rgba(255,255,255,0.1)] backdrop-blur-[16px] backdrop-saturate-[1.3]";
 
 export const PLAYER_CONTROL_BUTTON_CLASS =
-  "rounded-full border border-transparent text-white transition-[color,background-color,border-color,box-shadow,transform] duration-200 motion-reduce:transition-none hover:border-cyan-100/20 hover:bg-cyan-300/15 hover:text-cyan-50 hover:shadow-[0_0_24px_rgba(34,211,238,0.16)] motion-safe:active:scale-95";
+  "rounded-full border border-transparent text-white transition-[color,background-color,border-color,box-shadow,transform] duration-200 motion-reduce:transition-none hover:border-blue-100/20 hover:bg-blue-300/15 hover:text-blue-50 hover:shadow-[0_0_24px_rgba(59,130,246,0.16)] motion-safe:active:scale-95";

--- a/web-ui/src/components/player/classnames.ts
+++ b/web-ui/src/components/player/classnames.ts
@@ -1,5 +1,5 @@
 export const PLAYER_OVERLAY_SURFACE_CLASS =
-  "border border-blue-200/32 bg-[linear-gradient(180deg,rgba(219,234,254,0.12)_0%,rgba(191,219,254,0.045)_16%,transparent_34%),linear-gradient(145deg,rgba(7,20,43,0.84),rgba(26,24,72,0.76))] shadow-[0_18px_48px_-18px_rgba(1,7,24,0.72),0_0_24px_-16px_rgba(59,130,246,0.48),inset_0_-1px_0_rgba(59,130,246,0.12)] backdrop-blur-[16px] backdrop-saturate-[1.3]";
+  "isolate overflow-hidden border border-blue-200/55 bg-slate-900/30 shadow-[0_18px_36px_-18px_rgba(0,0,0,0.82),0_0_28px_-12px_rgba(59,130,246,0.62),inset_0_1px_0_rgba(255,255,255,0.17),inset_0_-1px_0_rgba(59,130,246,0.14)] backdrop-blur-md backdrop-saturate-150";
 
 export const PLAYER_CONTROL_BUTTON_CLASS =
   "rounded-full border border-transparent text-white transition-[color,background-color,border-color,box-shadow,transform] duration-200 motion-reduce:transition-none hover:border-blue-100/20 hover:bg-blue-300/15 hover:text-blue-50 hover:shadow-[0_0_24px_rgba(59,130,246,0.16)] motion-safe:active:scale-95";
@@ -20,4 +20,4 @@ export const PLAYER_SELECTED_GLASS_LAYER_CLASS =
   "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none";
 
 export const PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS =
-  "pointer-events-none absolute inset-x-3 top-px z-20 h-px rounded-full bg-[linear-gradient(90deg,transparent_0%,rgba(147,197,253,0.42)_14%,rgba(219,234,254,0.96)_48%,rgba(165,180,252,0.68)_78%,transparent_100%)] opacity-0 shadow-[0_0_12px_rgba(147,197,253,0.5)] transition-opacity duration-300 ease-out motion-reduce:transition-none";
+  "pointer-events-none absolute inset-x-3 top-0 z-20 h-px rounded-full bg-[linear-gradient(90deg,transparent_0%,rgba(147,197,253,0.42)_14%,rgba(219,234,254,0.96)_48%,rgba(165,180,252,0.68)_78%,transparent_100%)] opacity-0 shadow-[0_0_8px_rgba(147,197,253,0.46)] transition-opacity duration-300 ease-out motion-reduce:transition-none";

--- a/web-ui/src/components/player/classnames.ts
+++ b/web-ui/src/components/player/classnames.ts
@@ -8,7 +8,7 @@ export const PLAYER_LIST_SURFACE_BASE_CLASS =
   "relative isolate overflow-hidden rounded-2xl border text-card-foreground transition-[color,background-color,border-color,box-shadow,backdrop-filter] duration-300 ease-out motion-reduce:transition-none";
 
 export const PLAYER_LIST_SURFACE_SELECTED_CLASS =
-  "border-blue-300/65 bg-white/38 shadow-[0_16px_32px_-18px_rgba(37,99,235,0.46),0_0_20px_-12px_rgba(59,130,246,0.42),inset_0_-1px_0_rgba(37,99,235,0.12)] backdrop-blur-md backdrop-saturate-150 dark:border-blue-200/55 dark:bg-slate-900/30 dark:shadow-[0_18px_36px_-18px_rgba(0,0,0,0.82),0_0_28px_-12px_rgba(59,130,246,0.62),inset_0_-1px_0_rgba(59,130,246,0.14)]";
+  "border-blue-300/65 bg-white/38 shadow-[0_16px_32px_-18px_rgba(37,99,235,0.46),0_0_20px_-12px_rgba(59,130,246,0.42),inset_0_1px_0_rgba(255,255,255,0.78),inset_0_-1px_0_rgba(37,99,235,0.12)] backdrop-blur-md backdrop-saturate-150 dark:border-blue-200/55 dark:bg-slate-900/30 dark:shadow-[0_18px_36px_-18px_rgba(0,0,0,0.82),0_0_28px_-12px_rgba(59,130,246,0.62),inset_0_1px_0_rgba(255,255,255,0.17),inset_0_-1px_0_rgba(59,130,246,0.14)]";
 
 export const PLAYER_LIST_SURFACE_DEFAULT_CLASS =
   "border-slate-200/70 bg-white/48 shadow-[inset_0_1px_0_rgba(255,255,255,0.44)] backdrop-blur-none backdrop-saturate-100 dark:border-white/8 dark:bg-slate-950/34 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045)]";
@@ -17,4 +17,7 @@ export const PLAYER_LIST_SURFACE_HOVER_CLASS =
   "hover:border-blue-400/35 hover:bg-blue-50/52 dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7";
 
 export const PLAYER_SELECTED_GLASS_LAYER_CLASS =
-  "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(180deg,rgba(219,234,254,0.12)_0%,rgba(191,219,254,0.045)_10%,transparent_26%),linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none";
+  "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none";
+
+export const PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS =
+  "pointer-events-none absolute inset-x-3 top-px z-20 h-px rounded-full bg-[linear-gradient(90deg,transparent_0%,rgba(147,197,253,0.42)_14%,rgba(219,234,254,0.96)_48%,rgba(165,180,252,0.68)_78%,transparent_100%)] opacity-0 shadow-[0_0_12px_rgba(147,197,253,0.5)] transition-opacity duration-300 ease-out motion-reduce:transition-none";

--- a/web-ui/src/components/player/classnames.ts
+++ b/web-ui/src/components/player/classnames.ts
@@ -3,3 +3,21 @@ export const PLAYER_OVERLAY_SURFACE_CLASS =
 
 export const PLAYER_CONTROL_BUTTON_CLASS =
   "rounded-full border border-transparent text-white transition-[color,background-color,border-color,box-shadow,transform] duration-200 motion-reduce:transition-none hover:border-blue-100/20 hover:bg-blue-300/15 hover:text-blue-50 hover:shadow-[0_0_24px_rgba(59,130,246,0.16)] motion-safe:active:scale-95";
+
+export const PLAYER_LIST_SURFACE_BASE_CLASS =
+  "relative isolate overflow-hidden rounded-2xl border text-card-foreground transition-[color,background-color,border-color,box-shadow,backdrop-filter] duration-300 ease-out motion-reduce:transition-none";
+
+export const PLAYER_LIST_SURFACE_SELECTED_CLASS =
+  "border-blue-300/65 bg-white/38 shadow-[0_16px_32px_-18px_rgba(37,99,235,0.46),0_0_20px_-12px_rgba(59,130,246,0.42),inset_0_1px_0_rgba(255,255,255,0.78),inset_0_-1px_0_rgba(37,99,235,0.12)] backdrop-blur-md backdrop-saturate-150 dark:border-blue-200/55 dark:bg-slate-900/30 dark:shadow-[0_18px_36px_-18px_rgba(0,0,0,0.82),0_0_28px_-12px_rgba(59,130,246,0.62),inset_0_1px_0_rgba(255,255,255,0.17),inset_0_-1px_0_rgba(59,130,246,0.14)]";
+
+export const PLAYER_LIST_SURFACE_DEFAULT_CLASS =
+  "border-slate-200/70 bg-white/48 shadow-[inset_0_1px_0_rgba(255,255,255,0.44)] backdrop-blur-none backdrop-saturate-100 dark:border-white/8 dark:bg-slate-950/34 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045)]";
+
+export const PLAYER_LIST_SURFACE_HOVER_CLASS =
+  "hover:border-blue-400/35 hover:bg-blue-50/52 dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7";
+
+export const PLAYER_SELECTED_GLASS_LAYER_CLASS =
+  "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none";
+
+export const PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS =
+  "pointer-events-none absolute inset-x-3 top-px z-20 h-px rounded-full bg-[linear-gradient(90deg,transparent_0%,rgba(147,197,253,0.42)_14%,rgba(219,234,254,0.96)_48%,rgba(165,180,252,0.68)_78%,transparent_100%)] opacity-0 shadow-[0_0_12px_rgba(147,197,253,0.5)] transition-opacity duration-300 ease-out motion-reduce:transition-none";

--- a/web-ui/src/components/player/classnames.ts
+++ b/web-ui/src/components/player/classnames.ts
@@ -1,5 +1,5 @@
 export const PLAYER_OVERLAY_SURFACE_CLASS =
-  "border border-blue-100/20 bg-[linear-gradient(145deg,rgba(7,20,43,0.82),rgba(26,24,72,0.68))] shadow-[0_18px_48px_rgba(1,7,24,0.58),inset_0_1px_0_rgba(255,255,255,0.1)] backdrop-blur-[16px] backdrop-saturate-[1.3]";
+  "border border-blue-200/32 bg-[linear-gradient(180deg,rgba(219,234,254,0.12)_0%,rgba(191,219,254,0.045)_16%,transparent_34%),linear-gradient(145deg,rgba(7,20,43,0.84),rgba(26,24,72,0.76))] shadow-[0_18px_48px_-18px_rgba(1,7,24,0.72),0_0_24px_-16px_rgba(59,130,246,0.48),inset_0_-1px_0_rgba(59,130,246,0.12)] backdrop-blur-[16px] backdrop-saturate-[1.3]";
 
 export const PLAYER_CONTROL_BUTTON_CLASS =
   "rounded-full border border-transparent text-white transition-[color,background-color,border-color,box-shadow,transform] duration-200 motion-reduce:transition-none hover:border-blue-100/20 hover:bg-blue-300/15 hover:text-blue-50 hover:shadow-[0_0_24px_rgba(59,130,246,0.16)] motion-safe:active:scale-95";
@@ -17,4 +17,4 @@ export const PLAYER_LIST_SURFACE_HOVER_CLASS =
   "hover:border-blue-400/35 hover:bg-blue-50/52 dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7";
 
 export const PLAYER_SELECTED_GLASS_LAYER_CLASS =
-  "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(180deg,rgba(219,234,254,0.16)_0%,rgba(191,219,254,0.07)_18%,transparent_42%),linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none";
+  "pointer-events-none absolute inset-0 z-0 bg-[linear-gradient(180deg,rgba(219,234,254,0.12)_0%,rgba(191,219,254,0.045)_10%,transparent_26%),linear-gradient(135deg,rgba(147,197,253,0.18)_0%,rgba(59,130,246,0.13)_42%,rgba(99,102,241,0.2)_100%)] opacity-0 transition-opacity duration-300 ease-out motion-reduce:transition-none";

--- a/web-ui/src/components/player/classnames.ts
+++ b/web-ui/src/components/player/classnames.ts
@@ -1,2 +1,5 @@
 export const PLAYER_OVERLAY_SURFACE_CLASS =
-  "bg-[rgba(9,9,11,0.58)] border border-[rgba(255,255,255,0.16)] shadow-[0_12px_32px_rgba(0,0,0,0.45)] backdrop-blur-[12px] backdrop-saturate-[1.15]";
+  "border border-cyan-100/20 bg-[linear-gradient(145deg,rgba(7,20,43,0.82),rgba(26,24,72,0.68))] shadow-[0_18px_48px_rgba(1,7,24,0.58),inset_0_1px_0_rgba(255,255,255,0.1)] backdrop-blur-[16px] backdrop-saturate-[1.3]";
+
+export const PLAYER_CONTROL_BUTTON_CLASS =
+  "rounded-full border border-transparent text-white transition-[color,background-color,border-color,box-shadow,transform] duration-200 motion-reduce:transition-none hover:border-cyan-100/20 hover:bg-cyan-300/15 hover:text-cyan-50 hover:shadow-[0_0_24px_rgba(34,211,238,0.16)] motion-safe:active:scale-95";

--- a/web-ui/src/components/player/epg-view.tsx
+++ b/web-ui/src/components/player/epg-view.tsx
@@ -178,14 +178,14 @@ function EPGViewComponent({
                         key={program.id}
                         ref={playing ? currentProgramRef : null}
                         className={clsx(
-                          "w-full overflow-hidden rounded-2xl border text-left text-card-foreground transition-[color,background-color,border-color,box-shadow,opacity,transform] duration-200",
+                          "relative isolate w-full overflow-hidden rounded-2xl border text-left text-card-foreground transition-[color,background-color,border-color,box-shadow,opacity] duration-200",
                           playing
-                            ? "border-blue-400/45 bg-[linear-gradient(135deg,rgba(59,130,246,0.14),rgba(99,102,241,0.12))] shadow-[0_12px_28px_rgba(37,99,235,0.13),inset_0_1px_0_rgba(255,255,255,0.55)] dark:border-blue-300/35 dark:shadow-[0_12px_30px_rgba(2,8,23,0.34),0_0_20px_rgba(59,130,246,0.06)]"
+                            ? "border-blue-400/50 bg-[linear-gradient(135deg,rgba(59,130,246,0.18),rgba(99,102,241,0.13))] shadow-[0_14px_30px_-18px_rgba(37,99,235,0.42),inset_0_1px_0_rgba(255,255,255,0.72),inset_0_-1px_0_rgba(37,99,235,0.1)] ring-1 ring-blue-400/10 backdrop-blur-md backdrop-saturate-150 before:pointer-events-none before:absolute before:inset-x-3 before:top-0 before:h-px before:bg-[linear-gradient(90deg,transparent,rgba(191,219,254,0.76),transparent)] before:content-[''] dark:border-blue-300/40 dark:shadow-[0_16px_34px_-18px_rgba(0,0,0,0.78),0_0_24px_-12px_rgba(59,130,246,0.54),inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(59,130,246,0.12)] dark:ring-blue-300/10 dark:before:bg-[linear-gradient(90deg,transparent,rgba(191,219,254,0.34),transparent)]"
                             : isPast
                               ? "border-slate-200/65 bg-white/38 opacity-65 dark:border-white/8 dark:bg-slate-950/28"
-                              : "border-slate-200/70 bg-white/52 shadow-[0_8px_22px_rgba(30,64,175,0.05),inset_0_1px_0_rgba(255,255,255,0.5)] dark:border-white/8 dark:bg-slate-950/36 dark:shadow-[0_8px_22px_rgba(0,0,0,0.16)]",
+                              : "border-slate-200/70 bg-white/48 shadow-[inset_0_1px_0_rgba(255,255,255,0.44)] dark:border-white/8 dark:bg-slate-950/34 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045)]",
                           ((isPast && supportsCatchup) || onAir) &&
-                            "cursor-pointer motion-safe:hover:-translate-y-px hover:border-blue-400/35 hover:bg-blue-50/55 hover:opacity-100 hover:shadow-[0_12px_28px_rgba(37,99,235,0.1)] dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
+                            "cursor-pointer hover:border-blue-400/35 hover:bg-blue-50/52 hover:opacity-100 dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
                         )}
                         onClick={() => {
                           if (isPast && supportsCatchup) {

--- a/web-ui/src/components/player/epg-view.tsx
+++ b/web-ui/src/components/player/epg-view.tsx
@@ -158,8 +158,8 @@ function EPGViewComponent({
           return (
             <div key={dateKey} className="relative">
               {/* Date Header */}
-              <div className="sticky top-0 z-10 border-cyan-950/10 border-b bg-white/66 px-3 py-1.5 shadow-[0_8px_20px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-cyan-100/10 dark:bg-slate-950/62 dark:shadow-[0_8px_20px_rgba(0,0,0,0.18)] md:px-4 md:py-2">
-                <h3 className="font-semibold text-cyan-800 text-xs tracking-wide dark:text-cyan-100 md:text-sm">
+              <div className="sticky top-0 z-10 border-blue-950/10 border-b bg-white/66 px-3 py-1.5 shadow-[0_8px_20px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-blue-100/10 dark:bg-slate-950/62 dark:shadow-[0_8px_20px_rgba(0,0,0,0.18)] md:px-4 md:py-2">
+                <h3 className="font-semibold text-blue-800 text-xs tracking-wide dark:text-blue-100 md:text-sm">
                   {formatRelativeDate(date)}
                 </h3>
               </div>
@@ -180,12 +180,12 @@ function EPGViewComponent({
                         className={clsx(
                           "w-full overflow-hidden rounded-2xl border text-left text-card-foreground transition-[color,background-color,border-color,box-shadow,opacity,transform] duration-200",
                           playing
-                            ? "border-cyan-400/45 bg-[linear-gradient(135deg,rgba(34,211,238,0.14),rgba(99,102,241,0.12))] shadow-[0_12px_28px_rgba(8,145,178,0.13),inset_0_1px_0_rgba(255,255,255,0.55)] dark:border-cyan-300/35 dark:shadow-[0_12px_30px_rgba(2,8,23,0.34),0_0_20px_rgba(34,211,238,0.06)]"
+                            ? "border-blue-400/45 bg-[linear-gradient(135deg,rgba(59,130,246,0.14),rgba(99,102,241,0.12))] shadow-[0_12px_28px_rgba(37,99,235,0.13),inset_0_1px_0_rgba(255,255,255,0.55)] dark:border-blue-300/35 dark:shadow-[0_12px_30px_rgba(2,8,23,0.34),0_0_20px_rgba(59,130,246,0.06)]"
                             : isPast
                               ? "border-slate-200/65 bg-white/38 opacity-65 dark:border-white/8 dark:bg-slate-950/28"
                               : "border-slate-200/70 bg-white/52 shadow-[0_8px_22px_rgba(30,64,175,0.05),inset_0_1px_0_rgba(255,255,255,0.5)] dark:border-white/8 dark:bg-slate-950/36 dark:shadow-[0_8px_22px_rgba(0,0,0,0.16)]",
                           ((isPast && supportsCatchup) || onAir) &&
-                            "cursor-pointer motion-safe:hover:-translate-y-px hover:border-cyan-400/35 hover:bg-cyan-50/55 hover:opacity-100 hover:shadow-[0_12px_28px_rgba(8,145,178,0.1)] dark:hover:border-cyan-300/25 dark:hover:bg-cyan-300/7",
+                            "cursor-pointer motion-safe:hover:-translate-y-px hover:border-blue-400/35 hover:bg-blue-50/55 hover:opacity-100 hover:shadow-[0_12px_28px_rgba(37,99,235,0.1)] dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
                         )}
                         onClick={() => {
                           if (isPast && supportsCatchup) {
@@ -202,12 +202,12 @@ function EPGViewComponent({
                           <div className="flex shrink-0">
                             {playing ? (
                               <div
-                                className="h-8 w-1 rounded-full bg-[linear-gradient(to_bottom,#22d3ee,#6366f1)] shadow-[0_0_12px_rgba(34,211,238,0.48)] md:h-10"
+                                className="h-8 w-1 rounded-full bg-[linear-gradient(to_bottom,#3b82f6,#6366f1)] shadow-[0_0_12px_rgba(59,130,246,0.48)] md:h-10"
                                 title={t("nowPlaying")}
                               />
                             ) : isPast && supportsCatchup ? (
                               <div
-                                className="h-8 w-1 rounded-full bg-slate-400/25 dark:bg-cyan-100/18 md:h-10"
+                                className="h-8 w-1 rounded-full bg-slate-400/25 dark:bg-blue-100/18 md:h-10"
                                 title={t("replay")}
                               />
                             ) : (
@@ -220,7 +220,7 @@ function EPGViewComponent({
                             <span
                               className={clsx(
                                 "font-semibold text-xs tabular-nums leading-tight md:text-sm",
-                                playing && "text-cyan-700 dark:text-cyan-200",
+                                playing && "text-blue-700 dark:text-blue-200",
                               )}
                             >
                               {formatTime(program.start)}
@@ -241,12 +241,12 @@ function EPGViewComponent({
                           <div className="flex h-8 md:h-10 w-3 md:w-4 shrink-0 items-center justify-center">
                             {onAir && (
                               <span title={t("onAir")}>
-                                <Circle className="h-2.5 w-2.5 fill-current text-cyan-500 drop-shadow-[0_0_5px_rgba(34,211,238,0.65)] md:h-3 md:w-3" />
+                                <Circle className="h-2.5 w-2.5 fill-current text-blue-500 drop-shadow-[0_0_5px_rgba(59,130,246,0.65)] md:h-3 md:w-3" />
                               </span>
                             )}
                             {isPast && supportsCatchup && (
                               <span title={t("replay")}>
-                                <History className="h-3 w-3 text-slate-400 dark:text-cyan-100/45 md:h-3.5 md:w-3.5" />
+                                <History className="h-3 w-3 text-slate-400 dark:text-blue-100/45 md:h-3.5 md:w-3.5" />
                               </span>
                             )}
                           </div>

--- a/web-ui/src/components/player/epg-view.tsx
+++ b/web-ui/src/components/player/epg-view.tsx
@@ -11,7 +11,6 @@ import {
   PLAYER_LIST_SURFACE_HOVER_CLASS,
   PLAYER_LIST_SURFACE_SELECTED_CLASS,
   PLAYER_SELECTED_GLASS_LAYER_CLASS,
-  PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
 } from "./classnames";
 
 interface EPGViewProps {
@@ -209,10 +208,6 @@ function EPGViewComponent({
                         <span
                           aria-hidden
                           className={clsx(PLAYER_SELECTED_GLASS_LAYER_CLASS, playing && "opacity-100")}
-                        />
-                        <span
-                          aria-hidden
-                          className={clsx(PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS, playing && "opacity-100")}
                         />
                         <div className="relative z-10 flex items-center gap-2 p-2 md:gap-2.5 md:p-2.5">
                           {/* Left: Status Indicator Bar */}

--- a/web-ui/src/components/player/epg-view.tsx
+++ b/web-ui/src/components/player/epg-view.tsx
@@ -11,6 +11,7 @@ import {
   PLAYER_LIST_SURFACE_HOVER_CLASS,
   PLAYER_LIST_SURFACE_SELECTED_CLASS,
   PLAYER_SELECTED_GLASS_LAYER_CLASS,
+  PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
 } from "./classnames";
 
 interface EPGViewProps {
@@ -208,6 +209,10 @@ function EPGViewComponent({
                         <span
                           aria-hidden
                           className={clsx(PLAYER_SELECTED_GLASS_LAYER_CLASS, playing && "opacity-100")}
+                        />
+                        <span
+                          aria-hidden
+                          className={clsx(PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS, playing && "opacity-100")}
                         />
                         <div className="relative z-10 flex items-center gap-2 p-2 md:gap-2.5 md:p-2.5">
                           {/* Left: Status Indicator Bar */}

--- a/web-ui/src/components/player/epg-view.tsx
+++ b/web-ui/src/components/player/epg-view.tsx
@@ -10,9 +10,8 @@ import {
   PLAYER_LIST_SURFACE_DEFAULT_CLASS,
   PLAYER_LIST_SURFACE_HOVER_CLASS,
   PLAYER_LIST_SURFACE_SELECTED_CLASS,
-  PLAYER_SELECTED_GLASS_LAYER_CLASS,
-  PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
 } from "./classnames";
+import { PlayerSelectedGlassLayers } from "./player-selected-glass-layers";
 
 interface EPGViewProps {
   channelId: string | null;
@@ -191,10 +190,11 @@ function EPGViewComponent({
                           playing ? PLAYER_LIST_SURFACE_SELECTED_CLASS : PLAYER_LIST_SURFACE_DEFAULT_CLASS,
                           !playing && isPast && "opacity-65",
                           ((isPast && supportsCatchup) || onAir) && "cursor-pointer",
-                          !playing && ((isPast && supportsCatchup) || onAir) && [
-                            "hover:opacity-100",
-                            PLAYER_LIST_SURFACE_HOVER_CLASS,
-                          ],
+                          !playing &&
+                            ((isPast && supportsCatchup) || onAir) && [
+                              "hover:opacity-100",
+                              PLAYER_LIST_SURFACE_HOVER_CLASS,
+                            ],
                         )}
                         onClick={() => {
                           if (isPast && supportsCatchup) {
@@ -206,14 +206,7 @@ function EPGViewComponent({
                           }
                         }}
                       >
-                        <span
-                          aria-hidden
-                          className={clsx(PLAYER_SELECTED_GLASS_LAYER_CLASS, playing && "opacity-100")}
-                        />
-                        <span
-                          aria-hidden
-                          className={clsx(PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS, playing && "opacity-100")}
-                        />
+                        <PlayerSelectedGlassLayers visible={playing} />
                         <div className="relative z-10 flex items-center gap-2 p-2 md:gap-2.5 md:p-2.5">
                           {/* Left: Status Indicator Bar */}
                           <div className="flex shrink-0">

--- a/web-ui/src/components/player/epg-view.tsx
+++ b/web-ui/src/components/player/epg-view.tsx
@@ -5,6 +5,14 @@ import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import type { EPGData } from "../../lib/epg-parser";
 import type { Locale } from "../../lib/locale";
 import type { EPGProgram } from "../../types/player";
+import {
+  PLAYER_LIST_SURFACE_BASE_CLASS,
+  PLAYER_LIST_SURFACE_DEFAULT_CLASS,
+  PLAYER_LIST_SURFACE_HOVER_CLASS,
+  PLAYER_LIST_SURFACE_SELECTED_CLASS,
+  PLAYER_SELECTED_GLASS_LAYER_CLASS,
+  PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
+} from "./classnames";
 
 interface EPGViewProps {
   channelId: string | null;
@@ -178,14 +186,15 @@ function EPGViewComponent({
                         key={program.id}
                         ref={playing ? currentProgramRef : null}
                         className={clsx(
-                          "relative isolate w-full overflow-hidden rounded-2xl border text-left text-card-foreground transition-[color,background-color,border-color,box-shadow,opacity] duration-200",
-                          playing
-                            ? "border-blue-400/50 bg-[linear-gradient(135deg,rgba(59,130,246,0.18),rgba(99,102,241,0.13))] shadow-[0_14px_30px_-18px_rgba(37,99,235,0.42),inset_0_1px_0_rgba(255,255,255,0.72),inset_0_-1px_0_rgba(37,99,235,0.1)] ring-1 ring-blue-400/10 backdrop-blur-md backdrop-saturate-150 before:pointer-events-none before:absolute before:inset-x-3 before:top-0 before:h-px before:bg-[linear-gradient(90deg,transparent,rgba(191,219,254,0.76),transparent)] before:content-[''] dark:border-blue-300/40 dark:shadow-[0_16px_34px_-18px_rgba(0,0,0,0.78),0_0_24px_-12px_rgba(59,130,246,0.54),inset_0_1px_0_rgba(255,255,255,0.14),inset_0_-1px_0_rgba(59,130,246,0.12)] dark:ring-blue-300/10 dark:before:bg-[linear-gradient(90deg,transparent,rgba(191,219,254,0.34),transparent)]"
-                            : isPast
-                              ? "border-slate-200/65 bg-white/38 opacity-65 dark:border-white/8 dark:bg-slate-950/28"
-                              : "border-slate-200/70 bg-white/48 shadow-[inset_0_1px_0_rgba(255,255,255,0.44)] dark:border-white/8 dark:bg-slate-950/34 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045)]",
-                          ((isPast && supportsCatchup) || onAir) &&
-                            "cursor-pointer hover:border-blue-400/35 hover:bg-blue-50/52 hover:opacity-100 dark:hover:border-blue-300/25 dark:hover:bg-blue-300/7",
+                          PLAYER_LIST_SURFACE_BASE_CLASS,
+                          "w-full text-left",
+                          playing ? PLAYER_LIST_SURFACE_SELECTED_CLASS : PLAYER_LIST_SURFACE_DEFAULT_CLASS,
+                          !playing && isPast && "opacity-65",
+                          ((isPast && supportsCatchup) || onAir) && "cursor-pointer",
+                          !playing && ((isPast && supportsCatchup) || onAir) && [
+                            "hover:opacity-100",
+                            PLAYER_LIST_SURFACE_HOVER_CLASS,
+                          ],
                         )}
                         onClick={() => {
                           if (isPast && supportsCatchup) {
@@ -197,7 +206,15 @@ function EPGViewComponent({
                           }
                         }}
                       >
-                        <div className="flex items-center gap-2 md:gap-2.5 p-2 md:p-2.5">
+                        <span
+                          aria-hidden
+                          className={clsx(PLAYER_SELECTED_GLASS_LAYER_CLASS, playing && "opacity-100")}
+                        />
+                        <span
+                          aria-hidden
+                          className={clsx(PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS, playing && "opacity-100")}
+                        />
+                        <div className="relative z-10 flex items-center gap-2 p-2 md:gap-2.5 md:p-2.5">
                           {/* Left: Status Indicator Bar */}
                           <div className="flex shrink-0">
                             {playing ? (
@@ -216,16 +233,16 @@ function EPGViewComponent({
                           </div>
 
                           {/* Middle-Left: Time */}
-                          <div className="flex w-14 shrink-0 flex-col items-end md:w-16">
+                          <div className="flex w-[4.75rem] shrink-0 flex-col items-end md:w-[5.25rem]">
                             <span
                               className={clsx(
-                                "font-semibold text-xs tabular-nums leading-tight md:text-sm",
+                                "whitespace-nowrap font-semibold text-xs tabular-nums leading-tight md:text-sm",
                                 playing && "text-blue-700 dark:text-blue-200",
                               )}
                             >
                               {formatTime(program.start)}
                             </span>
-                            <span className="text-[10px] text-slate-500 tabular-nums leading-4 dark:text-slate-400 md:text-xs">
+                            <span className="whitespace-nowrap text-[10px] text-slate-500 tabular-nums leading-4 dark:text-slate-400 md:text-xs">
                               {formatDuration(program.start, program.end)}
                             </span>
                           </div>

--- a/web-ui/src/components/player/epg-view.tsx
+++ b/web-ui/src/components/player/epg-view.tsx
@@ -74,10 +74,15 @@ function EPGViewComponent({
     }, 0);
 
     if (!currentPlayingProgram || !channelId || !channelPrograms.length) return;
-    if (nextScrollBehaviorRef.current === "skip") return;
+    const requestedBehavior = nextScrollBehaviorRef.current;
+    if (requestedBehavior === "skip") return;
+    const behavior =
+      requestedBehavior === "smooth" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        ? "instant"
+        : requestedBehavior;
 
     currentProgramRef.current?.scrollIntoView({
-      behavior: nextScrollBehaviorRef.current,
+      behavior,
       block: "center",
     });
   }, [currentPlayingProgram, channelId, channelPrograms]);
@@ -138,7 +143,11 @@ function EPGViewComponent({
   };
 
   if (!channelId || channelPrograms.length === 0) {
-    return <div className="flex h-full items-center justify-center text-muted-foreground">{t("noEpgAvailable")}</div>;
+    return (
+      <div className="flex h-full items-center justify-center bg-transparent px-6 text-center text-slate-500 text-sm leading-6 dark:text-slate-400">
+        {t("noEpgAvailable")}
+      </div>
+    );
   }
 
   return (
@@ -149,8 +158,10 @@ function EPGViewComponent({
           return (
             <div key={dateKey} className="relative">
               {/* Date Header */}
-              <div className="sticky top-0 z-10 border-b border-border bg-card px-3 md:px-4 py-1.5 md:py-2 shadow-sm">
-                <h3 className="text-xs md:text-sm font-semibold text-foreground">{formatRelativeDate(date)}</h3>
+              <div className="sticky top-0 z-10 border-cyan-950/10 border-b bg-white/66 px-3 py-1.5 shadow-[0_8px_20px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-cyan-100/10 dark:bg-slate-950/62 dark:shadow-[0_8px_20px_rgba(0,0,0,0.18)] md:px-4 md:py-2">
+                <h3 className="font-semibold text-cyan-800 text-xs tracking-wide dark:text-cyan-100 md:text-sm">
+                  {formatRelativeDate(date)}
+                </h3>
               </div>
 
               {/* Programs for this date */}
@@ -167,14 +178,14 @@ function EPGViewComponent({
                         key={program.id}
                         ref={playing ? currentProgramRef : null}
                         className={clsx(
-                          "rounded-xl border bg-card text-card-foreground shadow overflow-hidden transition-[color,background-color,border-color,box-shadow,opacity] duration-200 w-full text-left",
+                          "w-full overflow-hidden rounded-2xl border text-left text-card-foreground transition-[color,background-color,border-color,box-shadow,opacity,transform] duration-200",
                           playing
-                            ? "border-primary bg-primary/5 shadow-md"
+                            ? "border-cyan-400/45 bg-[linear-gradient(135deg,rgba(34,211,238,0.14),rgba(99,102,241,0.12))] shadow-[0_12px_28px_rgba(8,145,178,0.13),inset_0_1px_0_rgba(255,255,255,0.55)] dark:border-cyan-300/35 dark:shadow-[0_12px_30px_rgba(2,8,23,0.34),0_0_20px_rgba(34,211,238,0.06)]"
                             : isPast
-                              ? "border-border opacity-70"
-                              : "border-border",
+                              ? "border-slate-200/65 bg-white/38 opacity-65 dark:border-white/8 dark:bg-slate-950/28"
+                              : "border-slate-200/70 bg-white/52 shadow-[0_8px_22px_rgba(30,64,175,0.05),inset_0_1px_0_rgba(255,255,255,0.5)] dark:border-white/8 dark:bg-slate-950/36 dark:shadow-[0_8px_22px_rgba(0,0,0,0.16)]",
                           ((isPast && supportsCatchup) || onAir) &&
-                            "cursor-pointer hover:border-primary/50 hover:bg-muted/50 hover:opacity-100 hover:shadow-sm",
+                            "cursor-pointer motion-safe:hover:-translate-y-px hover:border-cyan-400/35 hover:bg-cyan-50/55 hover:opacity-100 hover:shadow-[0_12px_28px_rgba(8,145,178,0.1)] dark:hover:border-cyan-300/25 dark:hover:bg-cyan-300/7",
                         )}
                         onClick={() => {
                           if (isPast && supportsCatchup) {
@@ -190,10 +201,13 @@ function EPGViewComponent({
                           {/* Left: Status Indicator Bar */}
                           <div className="flex shrink-0">
                             {playing ? (
-                              <div className="h-8 md:h-10 w-1 rounded-full bg-primary" title={t("nowPlaying")} />
+                              <div
+                                className="h-8 w-1 rounded-full bg-[linear-gradient(to_bottom,#22d3ee,#6366f1)] shadow-[0_0_12px_rgba(34,211,238,0.48)] md:h-10"
+                                title={t("nowPlaying")}
+                              />
                             ) : isPast && supportsCatchup ? (
                               <div
-                                className="h-8 md:h-10 w-1 rounded-full bg-muted-foreground/30"
+                                className="h-8 w-1 rounded-full bg-slate-400/25 dark:bg-cyan-100/18 md:h-10"
                                 title={t("replay")}
                               />
                             ) : (
@@ -202,23 +216,23 @@ function EPGViewComponent({
                           </div>
 
                           {/* Middle-Left: Time */}
-                          <div className="flex shrink-0 flex-col items-end">
+                          <div className="flex w-14 shrink-0 flex-col items-end md:w-16">
                             <span
                               className={clsx(
-                                "text-xs md:text-sm font-semibold tabular-nums leading-tight",
-                                playing && "text-primary",
+                                "font-semibold text-xs tabular-nums leading-tight md:text-sm",
+                                playing && "text-cyan-700 dark:text-cyan-200",
                               )}
                             >
                               {formatTime(program.start)}
                             </span>
-                            <span className="text-[10px] md:text-xs text-muted-foreground tabular-nums">
+                            <span className="text-[10px] text-slate-500 tabular-nums leading-4 dark:text-slate-400 md:text-xs">
                               {formatDuration(program.start, program.end)}
                             </span>
                           </div>
 
                           {/* Middle-Right: Title and Description */}
-                          <div className="flex-1 overflow-hidden min-w-0">
-                            <div className="text-sm md:text-base font-semibold leading-tight">
+                          <div className="min-w-0 flex-1 overflow-hidden">
+                            <div className="line-clamp-2 break-words font-semibold text-sm leading-tight tracking-[0.005em] md:text-base">
                               {program.title || t("excellentProgram")}
                             </div>
                           </div>
@@ -227,12 +241,12 @@ function EPGViewComponent({
                           <div className="flex h-8 md:h-10 w-3 md:w-4 shrink-0 items-center justify-center">
                             {onAir && (
                               <span title={t("onAir")}>
-                                <Circle className="h-2.5 w-2.5 md:h-3 md:w-3 text-primary fill-current" />
+                                <Circle className="h-2.5 w-2.5 fill-current text-cyan-500 drop-shadow-[0_0_5px_rgba(34,211,238,0.65)] md:h-3 md:w-3" />
                               </span>
                             )}
                             {isPast && supportsCatchup && (
                               <span title={t("replay")}>
-                                <History className="h-3 w-3 md:h-3.5 md:w-3.5 text-muted-foreground" />
+                                <History className="h-3 w-3 text-slate-400 dark:text-cyan-100/45 md:h-3.5 md:w-3.5" />
                               </span>
                             )}
                           </div>

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -310,10 +310,10 @@ export function PlayerControls({
             <div
               className={clsx(
                 PLAYER_OVERLAY_SURFACE_CLASS,
-                "invisible absolute bottom-full left-1/2 -translate-x-1/2 cursor-pointer rounded-xl px-2 py-2 opacity-0 transition-[opacity,visibility] duration-150 group-hover/volume:visible group-hover/volume:opacity-100 group-focus-within/volume:visible group-focus-within/volume:opacity-100 md:px-3",
+                "invisible absolute bottom-full left-1/2 flex -translate-x-1/2 cursor-pointer items-center justify-center rounded-xl px-2 py-2 opacity-0 transition-[opacity,visibility] duration-150 group-hover/volume:visible group-hover/volume:opacity-100 group-focus-within/volume:visible group-focus-within/volume:opacity-100 md:px-3",
               )}
             >
-              <PlayerSelectedGlassLayers />
+              <PlayerSelectedGlassLayers compact />
               <input
                 type="range"
                 min="0"
@@ -321,7 +321,7 @@ export function PlayerControls({
                 step="0.01"
                 value={isMuted ? 0 : volume}
                 onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
-                className="relative z-10 h-16 w-1 cursor-pointer appearance-none bg-transparent [writing-mode:vertical-lr] [direction:rtl] md:h-20"
+                className="relative z-10 m-0 block h-16 w-1 cursor-pointer appearance-none bg-transparent [writing-mode:vertical-lr] [direction:rtl] md:h-20"
                 style={{
                   background: `linear-gradient(to top, #3b82f6 0%, #6366f1 ${(isMuted ? 0 : volume) * 100}%, rgba(219,234,254,0.18) ${(isMuted ? 0 : volume) * 100}%, rgba(219,234,254,0.18) 100%)`,
                 }}

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -17,7 +17,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import type { Locale } from "../../lib/locale";
 import type { Channel, EPGProgram } from "../../types/player";
-import { PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
+import { PLAYER_CONTROL_BUTTON_CLASS, PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
 
 interface PlayerControlsProps {
   // Channel information
@@ -205,16 +205,16 @@ export function PlayerControls({
   }, []);
 
   return (
-    <div className="w-full bg-linear-to-t from-black/95 via-black/70 to-transparent px-3 md:px-4 pb-3 md:pb-4 pt-8 md:pt-12 flex flex-col gap-2 md:gap-3">
+    <div className="flex w-full flex-col gap-2 bg-[linear-gradient(to_top,rgba(2,8,23,0.98)_0%,rgba(8,22,51,0.9)_46%,rgba(21,27,69,0.48)_72%,transparent_100%)] px-3 pt-8 pb-3 md:gap-3 md:px-4 md:pt-12 md:pb-4">
       {/* Program Info */}
       {currentProgram && (
-        <div className="flex items-center justify-between text-xs md:text-sm text-white/80">
-          <div className="flex-1 truncate">
-            <span className="font-medium">{formatTime(startTime)}</span>
-            <span className="mx-1 md:mx-2 text-white/40">|</span>
+        <div className="flex min-w-0 items-center justify-between gap-2 text-xs tracking-[0.01em] text-cyan-50/80 md:text-sm">
+          <div className="min-w-0 flex-1 truncate">
+            <span className="font-medium text-cyan-100">{formatTime(startTime)}</span>
+            <span className="mx-1 text-cyan-100/30 md:mx-2">|</span>
             <span className="text-white/90">{currentProgram.title || t("excellentProgram")}</span>
           </div>
-          <span className="font-medium ml-2">{formatTime(endTime)}</span>
+          <span className="shrink-0 font-medium tabular-nums">{formatTime(endTime)}</span>
         </div>
       )}
 
@@ -229,24 +229,32 @@ export function PlayerControls({
           aria-valuenow={Math.round(progress)}
           aria-label={t("seekTo")}
           className={clsx(
-            "group relative h-2 rounded-full bg-white/20 transition-[height,box-shadow] duration-150",
-            isCatchupSupported ? "cursor-pointer hover:h-3" : "cursor-default",
+            "group relative h-2 rounded-full bg-cyan-50/15 shadow-[inset_0_1px_3px_rgba(0,0,0,0.45)] ring-1 ring-white/10 transition-[height,box-shadow] duration-150",
+            isCatchupSupported
+              ? "cursor-pointer hover:h-3 hover:shadow-[0_0_20px_rgba(34,211,238,0.16),inset_0_1px_3px_rgba(0,0,0,0.45)]"
+              : "cursor-default",
           )}
           onMouseDown={isCatchupSupported ? handleMouseDown : undefined}
           onMouseMove={isCatchupSupported ? handleMouseMove : undefined}
           onMouseLeave={isCatchupSupported ? handleMouseLeave : undefined}
         >
           <div
-            className="absolute left-0 top-0 h-full rounded-full bg-blue-500 transition-[width] duration-150"
+            className="absolute top-0 left-0 h-full rounded-full bg-[linear-gradient(90deg,#22d3ee_0%,#38bdf8_52%,#6366f1_100%)] shadow-[0_0_18px_rgba(34,211,238,0.4)] transition-[width] duration-150"
             style={{ width: `${progress}%` }}
           />
 
           {isCatchupSupported && hoverPosition !== null && (
             <>
-              <div className="absolute top-0 h-full w-0.5 bg-white/60" style={{ left: `${hoverPosition}%` }} />
+              <div
+                className="absolute top-0 h-full w-0.5 bg-cyan-50/80 shadow-[0_0_8px_rgba(103,232,249,0.7)]"
+                style={{ left: `${hoverPosition}%` }}
+              />
               {hoverTime && (
                 <div
-                  className="absolute bottom-full mb-2 -translate-x-1/2 whitespace-nowrap rounded bg-black/90 px-2 py-1 text-xs text-white shadow-lg"
+                  className={clsx(
+                    PLAYER_OVERLAY_SURFACE_CLASS,
+                    "absolute bottom-full mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg px-2.5 py-1 text-xs font-medium text-cyan-50",
+                  )}
                   style={{ left: `${hoverPosition}%` }}
                 >
                   {formatTime(hoverTime, true)}
@@ -257,7 +265,7 @@ export function PlayerControls({
 
           <div
             className={clsx(
-              "absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow-lg transition-[left] duration-150",
+              "absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-cyan-300 shadow-[0_0_16px_rgba(103,232,249,0.75)] transition-[left,width,height] duration-150",
               isCatchupSupported && "group-hover:h-4 group-hover:w-4",
             )}
             style={{ left: `${progress}%` }}
@@ -266,14 +274,14 @@ export function PlayerControls({
       )}
 
       {/* Control Bar */}
-      <div className="flex items-center justify-between">
+      <div className="flex min-w-0 items-center justify-between gap-1">
         {/* Left Controls */}
-        <div className="flex items-center gap-1.5 md:gap-3">
+        <div className="flex min-w-0 items-center gap-0.5 sm:gap-1.5 md:gap-3">
           {/* Play/Pause */}
           <button
             type="button"
             onClick={onPlayPause}
-            className="rounded-full p-1.5 md:p-2 text-white transition cursor-pointer hover:bg-white/20 active:scale-95"
+            className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1.5 md:p-2")}
             title={isPlaying ? t("pause") : t("play")}
           >
             {isPlaying ? <Pause className="h-5 w-5 md:h-7 md:w-7" /> : <Play className="h-5 w-5 md:h-7 md:w-7" />}
@@ -284,7 +292,7 @@ export function PlayerControls({
             <button
               type="button"
               onClick={onMuteToggle}
-              className="rounded-full p-1.5 md:p-2 text-white transition cursor-pointer hover:bg-white/20 active:scale-95"
+              className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1.5 md:p-2")}
               title={isMuted ? t("unmute") : t("mute")}
             >
               {isMuted || volume === 0 ? (
@@ -300,7 +308,7 @@ export function PlayerControls({
             <div
               className={clsx(
                 PLAYER_OVERLAY_SURFACE_CLASS,
-                "invisible absolute bottom-full left-1/2 -translate-x-1/2 cursor-pointer rounded-lg px-2 py-2 opacity-0 transition-[opacity,visibility] duration-150 group-hover/volume:visible group-hover/volume:opacity-100 md:px-3",
+                "invisible absolute bottom-full left-1/2 -translate-x-1/2 cursor-pointer rounded-xl px-2 py-2 opacity-0 transition-[opacity,visibility] duration-150 group-hover/volume:visible group-hover/volume:opacity-100 group-focus-within/volume:visible group-focus-within/volume:opacity-100 md:px-3",
               )}
             >
               <input
@@ -312,14 +320,14 @@ export function PlayerControls({
                 onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
                 className="h-16 md:h-20 w-1 cursor-pointer appearance-none bg-transparent [writing-mode:vertical-lr] [direction:rtl]"
                 style={{
-                  background: `linear-gradient(to top, #3b82f6 0%, #3b82f6 ${(isMuted ? 0 : volume) * 100}%, rgba(255,255,255,0.2) ${(isMuted ? 0 : volume) * 100}%, rgba(255,255,255,0.2) 100%)`,
+                  background: `linear-gradient(to top, #22d3ee 0%, #6366f1 ${(isMuted ? 0 : volume) * 100}%, rgba(207,250,254,0.18) ${(isMuted ? 0 : volume) * 100}%, rgba(207,250,254,0.18) 100%)`,
                 }}
               />
             </div>
           </div>
 
           {/* Time Display */}
-          <div className="text-xs md:text-sm text-white/80">
+          <div className="hidden whitespace-nowrap text-xs text-cyan-50/75 tabular-nums min-[360px]:block md:text-sm">
             {currentProgram ? (
               <span>
                 {formatDuration(elapsedTime)} / {formatDuration(duration)}
@@ -333,18 +341,21 @@ export function PlayerControls({
         </div>
 
         {/* Right Controls */}
-        <div className="flex items-center gap-1 md:gap-2">
+        <div className="flex shrink-0 items-center gap-0.5 sm:gap-1 md:gap-2">
           {/* Live/Catchup Indicator & Go Live Button */}
           {isLive ? (
-            <span className="flex items-center gap-1 md:gap-1.5 p-1.5 md:p-2 text-xs md:text-sm font-medium text-white">
-              <span className="h-1.5 w-1.5 md:h-2 md:w-2 animate-pulse rounded-full bg-red-600" />
+            <span className="flex items-center gap-1 whitespace-nowrap p-1.5 text-xs font-semibold tracking-wide text-white md:gap-1.5 md:p-2 md:text-sm">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-rose-400 shadow-[0_0_12px_rgba(251,113,133,0.85)] md:h-2 md:w-2" />
               {t("live")}
             </span>
           ) : (
             <button
               type="button"
               onClick={() => onSeek(new Date())}
-              className="rounded-full px-2 py-1 md:px-2.5 md:py-1.5 text-white transition hover:bg-white/20 active:scale-95 cursor-pointer text-xs md:text-sm font-medium"
+              className={clsx(
+                PLAYER_CONTROL_BUTTON_CLASS,
+                "cursor-pointer whitespace-nowrap bg-cyan-300/10 px-2 py-1 text-xs font-medium text-cyan-50 md:px-2.5 md:py-1.5 md:text-sm",
+              )}
             >
               {t("goLive")}
             </button>
@@ -355,14 +366,17 @@ export function PlayerControls({
             <div className="group/source relative flex items-center focus-within:z-10" tabIndex={-1}>
               <button
                 type="button"
-                className="rounded-full px-2 py-1 md:px-2.5 md:py-1.5 text-xs md:text-sm font-medium text-white transition hover:bg-white/20 active:scale-95 cursor-pointer"
+                className={clsx(
+                  PLAYER_CONTROL_BUTTON_CLASS,
+                  "max-w-16 cursor-pointer truncate px-2 py-1 text-xs font-medium min-[360px]:max-w-24 md:max-w-40 md:px-2.5 md:py-1.5 md:text-sm",
+                )}
               >
                 {channel.sources[activeSourceIndex]?.label || `${t("source")} ${activeSourceIndex + 1}`}
               </button>
               <div
                 className={clsx(
                   PLAYER_OVERLAY_SURFACE_CLASS,
-                  "invisible absolute bottom-full left-1/2 -translate-x-1/2 rounded-lg py-1 opacity-0 transition-[opacity,visibility] duration-150 group-hover/source:visible group-hover/source:opacity-100 group-focus-within/source:visible group-focus-within/source:opacity-100",
+                  "invisible absolute bottom-full left-1/2 -translate-x-1/2 overflow-hidden rounded-xl py-1 opacity-0 transition-[opacity,visibility] duration-150 group-hover/source:visible group-hover/source:opacity-100 group-focus-within/source:visible group-focus-within/source:opacity-100",
                 )}
               >
                 {channel.sources
@@ -377,8 +391,10 @@ export function PlayerControls({
                         e.currentTarget.blur();
                       }}
                       className={clsx(
-                        "block w-full whitespace-nowrap px-3 py-1.5 text-xs md:text-sm text-left transition-colors cursor-pointer",
-                        index === activeSourceIndex ? "text-primary font-medium" : "text-white/80 hover:bg-white/10",
+                        "block w-full cursor-pointer whitespace-nowrap px-3 py-1.5 text-left text-xs transition-colors md:text-sm",
+                        index === activeSourceIndex
+                          ? "bg-cyan-300/10 font-medium text-cyan-200"
+                          : "text-white/75 hover:bg-cyan-200/10 hover:text-cyan-50",
                       )}
                     >
                       <span className="flex items-center gap-2">
@@ -395,7 +411,7 @@ export function PlayerControls({
           <button
             type="button"
             onClick={onFullscreen}
-            className="rounded-full p-1.5 md:p-2 text-white transition hover:bg-white/20 active:scale-95 cursor-pointer"
+            className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1.5 md:p-2")}
             title={isFullscreen ? t("exitFullscreen") : t("fullscreen")}
           >
             {isFullscreen ? (
@@ -410,7 +426,7 @@ export function PlayerControls({
             <button
               type="button"
               onClick={onPiPToggle}
-              className="rounded-full p-1.5 md:p-2 text-white transition hover:bg-white/20 active:scale-95 cursor-pointer"
+              className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1.5 md:p-2")}
               title={t("pictureInPicture")}
             >
               <PictureInPicture className="h-5 w-5 md:h-6 md:w-6" />
@@ -422,7 +438,7 @@ export function PlayerControls({
             <button
               type="button"
               onClick={onToggleSidebar}
-              className="hidden md:flex rounded-full p-1.5 md:p-2 text-white transition hover:bg-white/20 active:scale-95 cursor-pointer"
+              className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "hidden cursor-pointer p-1.5 md:flex md:p-2")}
               title={showSidebar ? t("hideSidebar") : t("showSidebar")}
             >
               {showSidebar ? (

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -18,6 +18,7 @@ import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import type { Locale } from "../../lib/locale";
 import type { Channel, EPGProgram } from "../../types/player";
 import { PLAYER_CONTROL_BUTTON_CLASS, PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
+import { PlayerSelectedGlassLayers } from "./player-selected-glass-layers";
 
 interface PlayerControlsProps {
   // Channel information
@@ -257,7 +258,8 @@ export function PlayerControls({
                   )}
                   style={{ left: `${hoverPosition}%` }}
                 >
-                  {formatTime(hoverTime, true)}
+                  <PlayerSelectedGlassLayers />
+                  <span className="relative z-10">{formatTime(hoverTime, true)}</span>
                 </div>
               )}
             </>
@@ -311,6 +313,7 @@ export function PlayerControls({
                 "invisible absolute bottom-full left-1/2 -translate-x-1/2 cursor-pointer rounded-xl px-2 py-2 opacity-0 transition-[opacity,visibility] duration-150 group-hover/volume:visible group-hover/volume:opacity-100 group-focus-within/volume:visible group-focus-within/volume:opacity-100 md:px-3",
               )}
             >
+              <PlayerSelectedGlassLayers />
               <input
                 type="range"
                 min="0"
@@ -318,7 +321,7 @@ export function PlayerControls({
                 step="0.01"
                 value={isMuted ? 0 : volume}
                 onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
-                className="h-16 md:h-20 w-1 cursor-pointer appearance-none bg-transparent [writing-mode:vertical-lr] [direction:rtl]"
+                className="relative z-10 h-16 w-1 cursor-pointer appearance-none bg-transparent [writing-mode:vertical-lr] [direction:rtl] md:h-20"
                 style={{
                   background: `linear-gradient(to top, #3b82f6 0%, #6366f1 ${(isMuted ? 0 : volume) * 100}%, rgba(219,234,254,0.18) ${(isMuted ? 0 : volume) * 100}%, rgba(219,234,254,0.18) 100%)`,
                 }}
@@ -379,6 +382,7 @@ export function PlayerControls({
                   "invisible absolute bottom-full left-1/2 -translate-x-1/2 overflow-hidden rounded-xl py-1 opacity-0 transition-[opacity,visibility] duration-150 group-hover/source:visible group-hover/source:opacity-100 group-focus-within/source:visible group-focus-within/source:opacity-100",
                 )}
               >
+                <PlayerSelectedGlassLayers />
                 {channel.sources
                   .map((source, index) => ({ source, index }))
                   .filter(({ source }) => isLive || (source.catchup && source.catchupSource))
@@ -391,7 +395,7 @@ export function PlayerControls({
                         e.currentTarget.blur();
                       }}
                       className={clsx(
-                        "block w-full cursor-pointer whitespace-nowrap px-3 py-1.5 text-left text-xs transition-colors md:text-sm",
+                        "relative z-10 block w-full cursor-pointer whitespace-nowrap px-3 py-1.5 text-left text-xs transition-colors md:text-sm",
                         index === activeSourceIndex
                           ? "bg-blue-300/10 font-medium text-blue-200"
                           : "text-white/75 hover:bg-blue-200/10 hover:text-blue-50",

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -208,10 +208,10 @@ export function PlayerControls({
     <div className="flex w-full flex-col gap-2 bg-[linear-gradient(to_top,rgba(2,8,23,0.98)_0%,rgba(8,22,51,0.9)_46%,rgba(21,27,69,0.48)_72%,transparent_100%)] px-3 pt-8 pb-3 md:gap-3 md:px-4 md:pt-12 md:pb-4">
       {/* Program Info */}
       {currentProgram && (
-        <div className="flex min-w-0 items-center justify-between gap-2 text-xs tracking-[0.01em] text-cyan-50/80 md:text-sm">
+        <div className="flex min-w-0 items-center justify-between gap-2 text-xs tracking-[0.01em] text-blue-50/80 md:text-sm">
           <div className="min-w-0 flex-1 truncate">
-            <span className="font-medium text-cyan-100">{formatTime(startTime)}</span>
-            <span className="mx-1 text-cyan-100/30 md:mx-2">|</span>
+            <span className="font-medium text-blue-100">{formatTime(startTime)}</span>
+            <span className="mx-1 text-blue-100/30 md:mx-2">|</span>
             <span className="text-white/90">{currentProgram.title || t("excellentProgram")}</span>
           </div>
           <span className="shrink-0 font-medium tabular-nums">{formatTime(endTime)}</span>
@@ -229,9 +229,9 @@ export function PlayerControls({
           aria-valuenow={Math.round(progress)}
           aria-label={t("seekTo")}
           className={clsx(
-            "group relative h-2 rounded-full bg-cyan-50/15 shadow-[inset_0_1px_3px_rgba(0,0,0,0.45)] ring-1 ring-white/10 transition-[height,box-shadow] duration-150",
+            "group relative h-2 rounded-full bg-blue-50/15 shadow-[inset_0_1px_3px_rgba(0,0,0,0.45)] ring-1 ring-white/10 transition-[height,box-shadow] duration-150",
             isCatchupSupported
-              ? "cursor-pointer hover:h-3 hover:shadow-[0_0_20px_rgba(34,211,238,0.16),inset_0_1px_3px_rgba(0,0,0,0.45)]"
+              ? "cursor-pointer hover:h-3 hover:shadow-[0_0_20px_rgba(59,130,246,0.16),inset_0_1px_3px_rgba(0,0,0,0.45)]"
               : "cursor-default",
           )}
           onMouseDown={isCatchupSupported ? handleMouseDown : undefined}
@@ -239,21 +239,21 @@ export function PlayerControls({
           onMouseLeave={isCatchupSupported ? handleMouseLeave : undefined}
         >
           <div
-            className="absolute top-0 left-0 h-full rounded-full bg-[linear-gradient(90deg,#22d3ee_0%,#38bdf8_52%,#6366f1_100%)] shadow-[0_0_18px_rgba(34,211,238,0.4)] transition-[width] duration-150"
+            className="absolute top-0 left-0 h-full rounded-full bg-[linear-gradient(90deg,#3b82f6_0%,#38bdf8_52%,#6366f1_100%)] shadow-[0_0_18px_rgba(59,130,246,0.4)] transition-[width] duration-150"
             style={{ width: `${progress}%` }}
           />
 
           {isCatchupSupported && hoverPosition !== null && (
             <>
               <div
-                className="absolute top-0 h-full w-0.5 bg-cyan-50/80 shadow-[0_0_8px_rgba(103,232,249,0.7)]"
+                className="absolute top-0 h-full w-0.5 bg-blue-50/80 shadow-[0_0_8px_rgba(147,197,253,0.7)]"
                 style={{ left: `${hoverPosition}%` }}
               />
               {hoverTime && (
                 <div
                   className={clsx(
                     PLAYER_OVERLAY_SURFACE_CLASS,
-                    "absolute bottom-full mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg px-2.5 py-1 text-xs font-medium text-cyan-50",
+                    "absolute bottom-full mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg px-2.5 py-1 text-xs font-medium text-blue-50",
                   )}
                   style={{ left: `${hoverPosition}%` }}
                 >
@@ -265,7 +265,7 @@ export function PlayerControls({
 
           <div
             className={clsx(
-              "absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-cyan-300 shadow-[0_0_16px_rgba(103,232,249,0.75)] transition-[left,width,height] duration-150",
+              "absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-blue-300 shadow-[0_0_16px_rgba(147,197,253,0.75)] transition-[left,width,height] duration-150",
               isCatchupSupported && "group-hover:h-4 group-hover:w-4",
             )}
             style={{ left: `${progress}%` }}
@@ -320,14 +320,14 @@ export function PlayerControls({
                 onChange={(e) => onVolumeChange(parseFloat(e.target.value))}
                 className="h-16 md:h-20 w-1 cursor-pointer appearance-none bg-transparent [writing-mode:vertical-lr] [direction:rtl]"
                 style={{
-                  background: `linear-gradient(to top, #22d3ee 0%, #6366f1 ${(isMuted ? 0 : volume) * 100}%, rgba(207,250,254,0.18) ${(isMuted ? 0 : volume) * 100}%, rgba(207,250,254,0.18) 100%)`,
+                  background: `linear-gradient(to top, #3b82f6 0%, #6366f1 ${(isMuted ? 0 : volume) * 100}%, rgba(219,234,254,0.18) ${(isMuted ? 0 : volume) * 100}%, rgba(219,234,254,0.18) 100%)`,
                 }}
               />
             </div>
           </div>
 
           {/* Time Display */}
-          <div className="hidden whitespace-nowrap text-xs text-cyan-50/75 tabular-nums min-[360px]:block md:text-sm">
+          <div className="hidden whitespace-nowrap text-xs text-blue-50/75 tabular-nums min-[360px]:block md:text-sm">
             {currentProgram ? (
               <span>
                 {formatDuration(elapsedTime)} / {formatDuration(duration)}
@@ -354,7 +354,7 @@ export function PlayerControls({
               onClick={() => onSeek(new Date())}
               className={clsx(
                 PLAYER_CONTROL_BUTTON_CLASS,
-                "cursor-pointer whitespace-nowrap bg-cyan-300/10 px-2 py-1 text-xs font-medium text-cyan-50 md:px-2.5 md:py-1.5 md:text-sm",
+                "cursor-pointer whitespace-nowrap bg-blue-300/10 px-2 py-1 text-xs font-medium text-blue-50 md:px-2.5 md:py-1.5 md:text-sm",
               )}
             >
               {t("goLive")}
@@ -393,8 +393,8 @@ export function PlayerControls({
                       className={clsx(
                         "block w-full cursor-pointer whitespace-nowrap px-3 py-1.5 text-left text-xs transition-colors md:text-sm",
                         index === activeSourceIndex
-                          ? "bg-cyan-300/10 font-medium text-cyan-200"
-                          : "text-white/75 hover:bg-cyan-200/10 hover:text-cyan-50",
+                          ? "bg-blue-300/10 font-medium text-blue-200"
+                          : "text-white/75 hover:bg-blue-200/10 hover:text-blue-50",
                       )}
                     >
                       <span className="flex items-center gap-2">

--- a/web-ui/src/components/player/player-selected-glass-layers.tsx
+++ b/web-ui/src/components/player/player-selected-glass-layers.tsx
@@ -1,15 +1,26 @@
 import { clsx } from "clsx";
-import { PLAYER_SELECTED_GLASS_LAYER_CLASS, PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS } from "./classnames";
+import {
+  PLAYER_SELECTED_COMPACT_TOP_HIGHLIGHT_CLASS,
+  PLAYER_SELECTED_GLASS_LAYER_CLASS,
+  PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
+} from "./classnames";
 
 interface PlayerSelectedGlassLayersProps {
+  compact?: boolean;
   visible?: boolean;
 }
 
-export function PlayerSelectedGlassLayers({ visible = true }: PlayerSelectedGlassLayersProps) {
+export function PlayerSelectedGlassLayers({ compact = false, visible = true }: PlayerSelectedGlassLayersProps) {
   return (
     <>
       <span aria-hidden className={clsx(PLAYER_SELECTED_GLASS_LAYER_CLASS, visible && "opacity-100")} />
-      <span aria-hidden className={clsx(PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS, visible && "opacity-100")} />
+      <span
+        aria-hidden
+        className={clsx(
+          compact ? PLAYER_SELECTED_COMPACT_TOP_HIGHLIGHT_CLASS : PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
+          visible && "opacity-100",
+        )}
+      />
     </>
   );
 }

--- a/web-ui/src/components/player/player-selected-glass-layers.tsx
+++ b/web-ui/src/components/player/player-selected-glass-layers.tsx
@@ -1,0 +1,15 @@
+import { clsx } from "clsx";
+import { PLAYER_SELECTED_GLASS_LAYER_CLASS, PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS } from "./classnames";
+
+interface PlayerSelectedGlassLayersProps {
+  visible?: boolean;
+}
+
+export function PlayerSelectedGlassLayers({ visible = true }: PlayerSelectedGlassLayersProps) {
+  return (
+    <>
+      <span aria-hidden className={clsx(PLAYER_SELECTED_GLASS_LAYER_CLASS, visible && "opacity-100")} />
+      <span aria-hidden className={clsx(PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS, visible && "opacity-100")} />
+    </>
+  );
+}

--- a/web-ui/src/components/player/player-selected-glass-layers.tsx
+++ b/web-ui/src/components/player/player-selected-glass-layers.tsx
@@ -5,22 +5,14 @@ import {
   PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
 } from "./classnames";
 
-interface PlayerSelectedGlassLayersProps {
-  compact?: boolean;
-  visible?: boolean;
-}
+type PlayerSelectedGlassLayersProps = { compact?: boolean; visible?: boolean };
 
 export function PlayerSelectedGlassLayers({ compact = false, visible = true }: PlayerSelectedGlassLayersProps) {
+  const highlightClass = compact ? PLAYER_SELECTED_COMPACT_TOP_HIGHLIGHT_CLASS : PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS;
   return (
     <>
       <span aria-hidden className={clsx(PLAYER_SELECTED_GLASS_LAYER_CLASS, visible && "opacity-100")} />
-      <span
-        aria-hidden
-        className={clsx(
-          compact ? PLAYER_SELECTED_COMPACT_TOP_HIGHLIGHT_CLASS : PLAYER_SELECTED_TOP_HIGHLIGHT_CLASS,
-          visible && "opacity-100",
-        )}
-      />
+      <span aria-hidden className={clsx(highlightClass, visible && "opacity-100")} />
     </>
   );
 }

--- a/web-ui/src/components/player/settings-dropdown.tsx
+++ b/web-ui/src/components/player/settings-dropdown.tsx
@@ -67,24 +67,24 @@ function SettingsDropdownComponent({
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex size-8 cursor-pointer items-center justify-center rounded-xl border border-transparent p-0 text-slate-500 transition-[color,background-color,border-color,box-shadow,transform] motion-reduce:transition-none hover:border-cyan-400/20 hover:bg-cyan-400/10 hover:text-cyan-700 hover:shadow-[0_0_18px_rgba(34,211,238,0.1)] motion-safe:active:scale-95 dark:text-slate-400 dark:hover:text-cyan-200 md:size-9"
+        className="flex size-8 cursor-pointer items-center justify-center rounded-xl border border-transparent p-0 text-slate-500 transition-[color,background-color,border-color,box-shadow,transform] motion-reduce:transition-none hover:border-blue-400/20 hover:bg-blue-400/10 hover:text-blue-700 hover:shadow-[0_0_18px_rgba(59,130,246,0.1)] motion-safe:active:scale-95 dark:text-slate-400 dark:hover:text-blue-200 md:size-9"
         title={t("settings")}
       >
         <Settings className="h-5 w-5" />
       </button>
 
       {isOpen && (
-        <div className="absolute top-full right-0 z-50 mt-1 w-52 max-w-[calc(100vw-1rem)] rounded-2xl border border-cyan-900/12 bg-[linear-gradient(145deg,rgba(255,255,255,0.9),rgba(238,242,255,0.82))] shadow-[0_20px_55px_rgba(30,64,175,0.18),inset_0_1px_0_rgba(255,255,255,0.82)] backdrop-blur-2xl dark:border-cyan-100/15 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.94),rgba(26,24,72,0.9))] dark:shadow-[0_22px_60px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
+        <div className="absolute top-full right-0 z-50 mt-1 w-52 max-w-[calc(100vw-1rem)] rounded-2xl border border-blue-900/12 bg-[linear-gradient(145deg,rgba(255,255,255,0.9),rgba(238,242,255,0.82))] shadow-[0_20px_55px_rgba(30,64,175,0.18),inset_0_1px_0_rgba(255,255,255,0.82)] backdrop-blur-2xl dark:border-blue-100/15 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.94),rgba(26,24,72,0.9))] dark:shadow-[0_22px_60px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
           <div className="space-y-3.5 p-3">
             {/* Language Select */}
             <label className="block">
-              <span className="mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-cyan-50/55">
+              <span className="mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-blue-50/55">
                 {t("language")}
               </span>
               <select
                 value={locale}
                 onChange={(e) => onLocaleChange(e.target.value as Locale)}
-                className="h-9 w-full cursor-pointer rounded-xl border border-cyan-900/10 bg-white/60 px-3 py-0 pr-8 text-foreground text-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition-[color,background-color,border-color,box-shadow] hover:border-cyan-400/25 hover:bg-cyan-50/75 focus:outline-none focus:ring-2 focus:ring-cyan-400/35 dark:border-cyan-100/10 dark:bg-slate-950/45 dark:shadow-none dark:hover:bg-cyan-300/8"
+                className="h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/60 px-3 py-0 pr-8 text-foreground text-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition-[color,background-color,border-color,box-shadow] hover:border-blue-400/25 hover:bg-blue-50/75 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-950/45 dark:shadow-none dark:hover:bg-blue-300/8"
               >
                 {localeOptions.map((option) => (
                   <option key={option.value} value={option.value}>
@@ -96,13 +96,13 @@ function SettingsDropdownComponent({
 
             {/* Theme Select */}
             <label className="block">
-              <span className="mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-cyan-50/55">
+              <span className="mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-blue-50/55">
                 {t("theme")}
               </span>
               <select
                 value={theme}
                 onChange={(e) => onThemeChange(e.target.value as ThemeMode)}
-                className="h-9 w-full cursor-pointer rounded-xl border border-cyan-900/10 bg-white/60 px-3 py-0 pr-8 text-foreground text-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition-[color,background-color,border-color,box-shadow] hover:border-cyan-400/25 hover:bg-cyan-50/75 focus:outline-none focus:ring-2 focus:ring-cyan-400/35 dark:border-cyan-100/10 dark:bg-slate-950/45 dark:shadow-none dark:hover:bg-cyan-300/8"
+                className="h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/60 px-3 py-0 pr-8 text-foreground text-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition-[color,background-color,border-color,box-shadow] hover:border-blue-400/25 hover:bg-blue-50/75 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-950/45 dark:shadow-none dark:hover:bg-blue-300/8"
               >
                 {themeOptions.map((option) => (
                   <option key={option} value={option}>
@@ -114,53 +114,53 @@ function SettingsDropdownComponent({
 
             {/* Seamless channel/source switch (dual-slot preload) */}
             <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
-              <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-cyan-50/65">
+              <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">
                 {t("seamlessSwitch")}
               </span>
               <Switch
                 checked={seamlessSwitch}
                 onCheckedChange={onSeamlessSwitchChange}
                 aria-label={t("seamlessSwitch")}
-                className="border-cyan-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-cyan-300/35 data-[state=checked]:bg-cyan-500 data-[state=checked]:shadow-[0_0_16px_rgba(34,211,238,0.24)] dark:border-cyan-100/10 dark:bg-slate-800/80"
+                className="border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80"
               />
             </div>
 
             {/* Video processing group: deinterlace + picture enhancement.
                 Both only take effect for 1080p-and-below content, so the
                 resolution caveat is stated once as a shared group note. */}
-            <div className="space-y-3 border-cyan-900/10 border-t pt-3.5 dark:border-cyan-100/10">
+            <div className="space-y-3 border-blue-900/10 border-t pt-3.5 dark:border-blue-100/10">
               <div className="px-0.5">
-                <span className="block font-medium text-slate-600 text-xs leading-4 dark:text-cyan-50/65">
+                <span className="block font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">
                   {t("videoProcessing")}
                 </span>
-                <span className="mt-0.5 block text-[11px] text-slate-400 leading-4 dark:text-cyan-50/35">
+                <span className="mt-0.5 block text-[11px] text-slate-400 leading-4 dark:text-blue-50/35">
                   {t("resolutionLimitHint")}
                 </span>
               </div>
 
               {/* Automatic deinterlacing (heuristic detection, ≤1080 content only) */}
               <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
-                <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-cyan-50/65">
+                <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">
                   {t("deinterlace")}
                 </span>
                 <Switch
                   checked={autoDeinterlace}
                   onCheckedChange={onAutoDeinterlaceChange}
                   aria-label={t("deinterlace")}
-                  className="border-cyan-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-cyan-300/35 data-[state=checked]:bg-cyan-500 data-[state=checked]:shadow-[0_0_16px_rgba(34,211,238,0.24)] dark:border-cyan-100/10 dark:bg-slate-800/80"
+                  className="border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80"
                 />
               </div>
 
               {/* Picture enhancement (WebGL post-processing inside the render gate) */}
               <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
-                <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-cyan-50/65">
+                <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">
                   {t("pictureEnhancement")}
                 </span>
                 <Switch
                   checked={pictureEnhancement}
                   onCheckedChange={onPictureEnhancementChange}
                   aria-label={t("pictureEnhancement")}
-                  className="border-cyan-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-cyan-300/35 data-[state=checked]:bg-cyan-500 data-[state=checked]:shadow-[0_0_16px_rgba(34,211,238,0.24)] dark:border-cyan-100/10 dark:bg-slate-800/80"
+                  className="border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80"
                 />
               </div>
             </div>

--- a/web-ui/src/components/player/settings-dropdown.tsx
+++ b/web-ui/src/components/player/settings-dropdown.tsx
@@ -33,6 +33,30 @@ const themeLabels: Record<ThemeMode, TranslationKey> = {
   dark: "themeDark",
 };
 
+const SETTING_LABEL_CLASS = "mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-blue-50/55";
+const SETTING_SELECT_CLASS =
+  "h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/78 px-3 py-0 pr-8 text-foreground text-sm shadow-none transition-[color,background-color,border-color] hover:border-blue-400/25 hover:bg-blue-50/70 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-900/85 dark:hover:bg-slate-800/90";
+
+interface SettingSwitchProps {
+  label: string;
+  value: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function SettingSwitch({ label, value, onChange }: SettingSwitchProps) {
+  return (
+    <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
+      <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">{label}</span>
+      <Switch
+        checked={value}
+        onCheckedChange={onChange}
+        aria-label={label}
+        className="border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80"
+      />
+    </div>
+  );
+}
+
 function SettingsDropdownComponent({
   locale,
   onLocaleChange,
@@ -78,13 +102,11 @@ function SettingsDropdownComponent({
           <div className="space-y-3.5 p-3">
             {/* Language Select */}
             <label className="block">
-              <span className="mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-blue-50/55">
-                {t("language")}
-              </span>
+              <span className={SETTING_LABEL_CLASS}>{t("language")}</span>
               <select
                 value={locale}
                 onChange={(e) => onLocaleChange(e.target.value as Locale)}
-                className="h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/78 px-3 py-0 pr-8 text-foreground text-sm shadow-none transition-[color,background-color,border-color] hover:border-blue-400/25 hover:bg-blue-50/70 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-900/85 dark:hover:bg-slate-800/90"
+                className={SETTING_SELECT_CLASS}
               >
                 {localeOptions.map((option) => (
                   <option key={option.value} value={option.value}>
@@ -96,13 +118,11 @@ function SettingsDropdownComponent({
 
             {/* Theme Select */}
             <label className="block">
-              <span className="mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-blue-50/55">
-                {t("theme")}
-              </span>
+              <span className={SETTING_LABEL_CLASS}>{t("theme")}</span>
               <select
                 value={theme}
                 onChange={(e) => onThemeChange(e.target.value as ThemeMode)}
-                className="h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/78 px-3 py-0 pr-8 text-foreground text-sm shadow-none transition-[color,background-color,border-color] hover:border-blue-400/25 hover:bg-blue-50/70 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-900/85 dark:hover:bg-slate-800/90"
+                className={SETTING_SELECT_CLASS}
               >
                 {themeOptions.map((option) => (
                   <option key={option} value={option}>
@@ -113,17 +133,7 @@ function SettingsDropdownComponent({
             </label>
 
             {/* Seamless channel/source switch (dual-slot preload) */}
-            <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
-              <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">
-                {t("seamlessSwitch")}
-              </span>
-              <Switch
-                checked={seamlessSwitch}
-                onCheckedChange={onSeamlessSwitchChange}
-                aria-label={t("seamlessSwitch")}
-                className="border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80"
-              />
-            </div>
+            <SettingSwitch label={t("seamlessSwitch")} value={seamlessSwitch} onChange={onSeamlessSwitchChange} />
 
             {/* Video processing group: deinterlace + picture enhancement.
                 Both only take effect for 1080p-and-below content, so the
@@ -139,30 +149,14 @@ function SettingsDropdownComponent({
               </div>
 
               {/* Automatic deinterlacing (heuristic detection, ≤1080 content only) */}
-              <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
-                <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">
-                  {t("deinterlace")}
-                </span>
-                <Switch
-                  checked={autoDeinterlace}
-                  onCheckedChange={onAutoDeinterlaceChange}
-                  aria-label={t("deinterlace")}
-                  className="border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80"
-                />
-              </div>
+              <SettingSwitch label={t("deinterlace")} value={autoDeinterlace} onChange={onAutoDeinterlaceChange} />
 
               {/* Picture enhancement (WebGL post-processing inside the render gate) */}
-              <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
-                <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">
-                  {t("pictureEnhancement")}
-                </span>
-                <Switch
-                  checked={pictureEnhancement}
-                  onCheckedChange={onPictureEnhancementChange}
-                  aria-label={t("pictureEnhancement")}
-                  className="border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80"
-                />
-              </div>
+              <SettingSwitch
+                label={t("pictureEnhancement")}
+                value={pictureEnhancement}
+                onChange={onPictureEnhancementChange}
+              />
             </div>
           </div>
         </div>

--- a/web-ui/src/components/player/settings-dropdown.tsx
+++ b/web-ui/src/components/player/settings-dropdown.tsx
@@ -67,22 +67,24 @@ function SettingsDropdownComponent({
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-center p-1 md:p-2 rounded hover:bg-muted transition-colors cursor-pointer"
+        className="flex size-8 cursor-pointer items-center justify-center rounded-xl border border-transparent p-0 text-slate-500 transition-[color,background-color,border-color,box-shadow,transform] motion-reduce:transition-none hover:border-cyan-400/20 hover:bg-cyan-400/10 hover:text-cyan-700 hover:shadow-[0_0_18px_rgba(34,211,238,0.1)] motion-safe:active:scale-95 dark:text-slate-400 dark:hover:text-cyan-200 md:size-9"
         title={t("settings")}
       >
-        <Settings className="h-5 w-5 text-muted-foreground" />
+        <Settings className="h-5 w-5" />
       </button>
 
       {isOpen && (
-        <div className="absolute top-full right-0 mt-1 w-46 rounded-md border border-border bg-card shadow-lg z-50">
-          <div className="p-2 space-y-3">
+        <div className="absolute top-full right-0 z-50 mt-1 w-52 max-w-[calc(100vw-1rem)] rounded-2xl border border-cyan-900/12 bg-[linear-gradient(145deg,rgba(255,255,255,0.9),rgba(238,242,255,0.82))] shadow-[0_20px_55px_rgba(30,64,175,0.18),inset_0_1px_0_rgba(255,255,255,0.82)] backdrop-blur-2xl dark:border-cyan-100/15 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.94),rgba(26,24,72,0.9))] dark:shadow-[0_22px_60px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
+          <div className="space-y-3.5 p-3">
             {/* Language Select */}
             <label className="block">
-              <span className="block text-xs font-medium text-muted-foreground mb-1.5 px-1">{t("language")}</span>
+              <span className="mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-cyan-50/55">
+                {t("language")}
+              </span>
               <select
                 value={locale}
                 onChange={(e) => onLocaleChange(e.target.value as Locale)}
-                className="w-full px-2 py-1.5 text-sm rounded border border-border bg-background text-foreground cursor-pointer transition-[color,background-color,border-color,box-shadow] hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary"
+                className="h-9 w-full cursor-pointer rounded-xl border border-cyan-900/10 bg-white/60 px-3 py-0 pr-8 text-foreground text-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition-[color,background-color,border-color,box-shadow] hover:border-cyan-400/25 hover:bg-cyan-50/75 focus:outline-none focus:ring-2 focus:ring-cyan-400/35 dark:border-cyan-100/10 dark:bg-slate-950/45 dark:shadow-none dark:hover:bg-cyan-300/8"
               >
                 {localeOptions.map((option) => (
                   <option key={option.value} value={option.value}>
@@ -94,11 +96,13 @@ function SettingsDropdownComponent({
 
             {/* Theme Select */}
             <label className="block">
-              <span className="block text-xs font-medium text-muted-foreground mb-1.5 px-1">{t("theme")}</span>
+              <span className="mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-cyan-50/55">
+                {t("theme")}
+              </span>
               <select
                 value={theme}
                 onChange={(e) => onThemeChange(e.target.value as ThemeMode)}
-                className="w-full px-2 py-1.5 text-sm rounded border border-border bg-background text-foreground cursor-pointer transition-[color,background-color,border-color,box-shadow] hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary"
+                className="h-9 w-full cursor-pointer rounded-xl border border-cyan-900/10 bg-white/60 px-3 py-0 pr-8 text-foreground text-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition-[color,background-color,border-color,box-shadow] hover:border-cyan-400/25 hover:bg-cyan-50/75 focus:outline-none focus:ring-2 focus:ring-cyan-400/35 dark:border-cyan-100/10 dark:bg-slate-950/45 dark:shadow-none dark:hover:bg-cyan-300/8"
               >
                 {themeOptions.map((option) => (
                   <option key={option} value={option}>
@@ -109,41 +113,54 @@ function SettingsDropdownComponent({
             </label>
 
             {/* Seamless channel/source switch (dual-slot preload) */}
-            <div className="flex items-center justify-between px-1">
-              <span className="text-xs font-medium text-muted-foreground">{t("seamlessSwitch")}</span>
+            <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
+              <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-cyan-50/65">
+                {t("seamlessSwitch")}
+              </span>
               <Switch
                 checked={seamlessSwitch}
                 onCheckedChange={onSeamlessSwitchChange}
                 aria-label={t("seamlessSwitch")}
+                className="border-cyan-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-cyan-300/35 data-[state=checked]:bg-cyan-500 data-[state=checked]:shadow-[0_0_16px_rgba(34,211,238,0.24)] dark:border-cyan-100/10 dark:bg-slate-800/80"
               />
             </div>
 
             {/* Video processing group: deinterlace + picture enhancement.
                 Both only take effect for 1080p-and-below content, so the
                 resolution caveat is stated once as a shared group note. */}
-            <div className="space-y-3 border-t border-border pt-3">
-              <div className="px-1">
-                <span className="block text-xs font-medium text-muted-foreground">{t("videoProcessing")}</span>
-                <span className="block text-[11px] text-muted-foreground/70 mt-0.5">{t("resolutionLimitHint")}</span>
+            <div className="space-y-3 border-cyan-900/10 border-t pt-3.5 dark:border-cyan-100/10">
+              <div className="px-0.5">
+                <span className="block font-medium text-slate-600 text-xs leading-4 dark:text-cyan-50/65">
+                  {t("videoProcessing")}
+                </span>
+                <span className="mt-0.5 block text-[11px] text-slate-400 leading-4 dark:text-cyan-50/35">
+                  {t("resolutionLimitHint")}
+                </span>
               </div>
 
               {/* Automatic deinterlacing (heuristic detection, ≤1080 content only) */}
-              <div className="flex items-center justify-between px-1">
-                <span className="text-xs font-medium text-muted-foreground">{t("deinterlace")}</span>
+              <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
+                <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-cyan-50/65">
+                  {t("deinterlace")}
+                </span>
                 <Switch
                   checked={autoDeinterlace}
                   onCheckedChange={onAutoDeinterlaceChange}
                   aria-label={t("deinterlace")}
+                  className="border-cyan-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-cyan-300/35 data-[state=checked]:bg-cyan-500 data-[state=checked]:shadow-[0_0_16px_rgba(34,211,238,0.24)] dark:border-cyan-100/10 dark:bg-slate-800/80"
                 />
               </div>
 
               {/* Picture enhancement (WebGL post-processing inside the render gate) */}
-              <div className="flex items-center justify-between px-1">
-                <span className="text-xs font-medium text-muted-foreground">{t("pictureEnhancement")}</span>
+              <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
+                <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-cyan-50/65">
+                  {t("pictureEnhancement")}
+                </span>
                 <Switch
                   checked={pictureEnhancement}
                   onCheckedChange={onPictureEnhancementChange}
                   aria-label={t("pictureEnhancement")}
+                  className="border-cyan-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-cyan-300/35 data-[state=checked]:bg-cyan-500 data-[state=checked]:shadow-[0_0_16px_rgba(34,211,238,0.24)] dark:border-cyan-100/10 dark:bg-slate-800/80"
                 />
               </div>
             </div>

--- a/web-ui/src/components/player/settings-dropdown.tsx
+++ b/web-ui/src/components/player/settings-dropdown.tsx
@@ -84,7 +84,7 @@ function SettingsDropdownComponent({
               <select
                 value={locale}
                 onChange={(e) => onLocaleChange(e.target.value as Locale)}
-                className="h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/60 px-3 py-0 pr-8 text-foreground text-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition-[color,background-color,border-color,box-shadow] hover:border-blue-400/25 hover:bg-blue-50/75 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-950/45 dark:shadow-none dark:hover:bg-blue-300/8"
+                className="h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/78 px-3 py-0 pr-8 text-foreground text-sm shadow-none transition-[color,background-color,border-color] hover:border-blue-400/25 hover:bg-blue-50/70 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-900/85 dark:hover:bg-slate-800/90"
               >
                 {localeOptions.map((option) => (
                   <option key={option.value} value={option.value}>
@@ -102,7 +102,7 @@ function SettingsDropdownComponent({
               <select
                 value={theme}
                 onChange={(e) => onThemeChange(e.target.value as ThemeMode)}
-                className="h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/60 px-3 py-0 pr-8 text-foreground text-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition-[color,background-color,border-color,box-shadow] hover:border-blue-400/25 hover:bg-blue-50/75 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-950/45 dark:shadow-none dark:hover:bg-blue-300/8"
+                className="h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/78 px-3 py-0 pr-8 text-foreground text-sm shadow-none transition-[color,background-color,border-color] hover:border-blue-400/25 hover:bg-blue-50/70 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-900/85 dark:hover:bg-slate-800/90"
               >
                 {themeOptions.map((option) => (
                   <option key={option} value={option}>

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -41,8 +41,8 @@ import {
 import mp2WasmUrl from "../../mpegts/wasm/minimp3/mp2_decoder.wasm?url";
 import type { Channel, EPGProgram } from "../../types/player";
 import { PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
-import { PlayerSelectedGlassLayers } from "./player-selected-glass-layers";
 import { PlayerControls } from "./player-controls";
+import { PlayerSelectedGlassLayers } from "./player-selected-glass-layers";
 
 interface VideoPlayerProps {
   channel: Channel | null;

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -41,6 +41,7 @@ import {
 import mp2WasmUrl from "../../mpegts/wasm/minimp3/mp2_decoder.wasm?url";
 import type { Channel, EPGProgram } from "../../types/player";
 import { PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
+import { PlayerSelectedGlassLayers } from "./player-selected-glass-layers";
 import { PlayerControls } from "./player-controls";
 
 interface VideoPlayerProps {
@@ -168,21 +169,24 @@ function PlayerTopLeftOverlay({
         visible ? "opacity-100" : "opacity-0 pointer-events-none",
       )}
     >
-      <span className="shrink-0 font-medium text-xs text-blue-50 tabular-nums drop-shadow-sm md:text-base">
-        {time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-      </span>
-      {loading && (
-        <>
-          <span className="shrink-0 text-blue-100/35 text-xs md:text-sm" aria-hidden="true">
-            ·
-          </span>
-          <div className="relative h-3 w-3 md:h-3.5 md:w-3.5 shrink-0">
-            <div className="absolute inset-0 rounded-full border border-blue-100/25" />
-            <div className="absolute inset-0 animate-spin rounded-full border border-blue-200 border-t-transparent shadow-[0_0_8px_rgba(147,197,253,0.5)]" />
-          </div>
-          <span className="min-w-0 truncate text-blue-50/70 text-xs md:text-sm">{loadingText}</span>
-        </>
-      )}
+      <PlayerSelectedGlassLayers />
+      <div className="relative z-10 flex min-w-0 items-center gap-1.5 md:gap-2">
+        <span className="shrink-0 font-medium text-xs text-blue-50 tabular-nums drop-shadow-sm md:text-base">
+          {time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+        </span>
+        {loading && (
+          <>
+            <span className="shrink-0 text-blue-100/35 text-xs md:text-sm" aria-hidden="true">
+              ·
+            </span>
+            <div className="relative h-3 w-3 shrink-0 md:h-3.5 md:w-3.5">
+              <div className="absolute inset-0 rounded-full border border-blue-100/25" />
+              <div className="absolute inset-0 animate-spin rounded-full border border-blue-200 border-t-transparent shadow-[0_0_8px_rgba(147,197,253,0.5)]" />
+            </div>
+            <span className="min-w-0 truncate text-blue-50/70 text-xs md:text-sm">{loadingText}</span>
+          </>
+        )}
+      </div>
     </div>
   );
 }
@@ -1509,21 +1513,22 @@ export function VideoPlayer({
           <div
             className={clsx(
               PLAYER_OVERLAY_SURFACE_CLASS,
-              "flex max-w-[calc(100vw-2rem)] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-xl px-2 py-1.5 md:max-w-none md:gap-2 md:px-3 md:py-2",
+              "relative flex max-w-[calc(100vw-2rem)] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-xl px-2 py-1.5 md:max-w-none md:gap-2 md:px-3 md:py-2",
             )}
           >
+            <PlayerSelectedGlassLayers />
             {channel.logo && (
               <img
                 src={channel.logo}
                 alt={channel.name}
                 referrerPolicy="no-referrer"
-                className="h-8 w-20 object-contain drop-shadow-[0_0_14px_rgba(147,197,253,0.2)] md:h-14 md:w-36"
+                className="relative z-10 h-8 w-20 object-contain drop-shadow-[0_0_14px_rgba(147,197,253,0.2)] md:h-14 md:w-36"
                 onError={(e) => {
                   (e.target as HTMLImageElement).style.display = "none";
                 }}
               />
             )}
-            <div className="flex w-full min-w-0 items-center justify-center">
+            <div className="relative z-10 flex w-full min-w-0 items-center justify-center">
               <div className="flex min-w-0 items-center gap-1.5 md:gap-2">
                 <span
                   className={clsx(

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -168,19 +168,19 @@ function PlayerTopLeftOverlay({
         visible ? "opacity-100" : "opacity-0 pointer-events-none",
       )}
     >
-      <span className="shrink-0 font-medium text-xs text-cyan-50 tabular-nums drop-shadow-sm md:text-base">
+      <span className="shrink-0 font-medium text-xs text-blue-50 tabular-nums drop-shadow-sm md:text-base">
         {time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
       </span>
       {loading && (
         <>
-          <span className="shrink-0 text-cyan-100/35 text-xs md:text-sm" aria-hidden="true">
+          <span className="shrink-0 text-blue-100/35 text-xs md:text-sm" aria-hidden="true">
             ·
           </span>
           <div className="relative h-3 w-3 md:h-3.5 md:w-3.5 shrink-0">
-            <div className="absolute inset-0 rounded-full border border-cyan-100/25" />
-            <div className="absolute inset-0 animate-spin rounded-full border border-cyan-200 border-t-transparent shadow-[0_0_8px_rgba(103,232,249,0.5)]" />
+            <div className="absolute inset-0 rounded-full border border-blue-100/25" />
+            <div className="absolute inset-0 animate-spin rounded-full border border-blue-200 border-t-transparent shadow-[0_0_8px_rgba(147,197,253,0.5)]" />
           </div>
-          <span className="min-w-0 truncate text-cyan-50/70 text-xs md:text-sm">{loadingText}</span>
+          <span className="min-w-0 truncate text-blue-50/70 text-xs md:text-sm">{loadingText}</span>
         </>
       )}
     </div>
@@ -1517,7 +1517,7 @@ export function VideoPlayer({
                 src={channel.logo}
                 alt={channel.name}
                 referrerPolicy="no-referrer"
-                className="h-8 w-20 object-contain drop-shadow-[0_0_14px_rgba(103,232,249,0.2)] md:h-14 md:w-36"
+                className="h-8 w-20 object-contain drop-shadow-[0_0_14px_rgba(147,197,253,0.2)] md:h-14 md:w-36"
                 onError={(e) => {
                   (e.target as HTMLImageElement).style.display = "none";
                 }}
@@ -1529,8 +1529,8 @@ export function VideoPlayer({
                   className={clsx(
                     "shrink-0 rounded-md px-1 py-0.5 font-semibold text-[10px] transition-[color,background-color,box-shadow,scale] duration-300 md:px-1.5 md:text-xs",
                     digitBuffer
-                      ? "scale-110 bg-[linear-gradient(135deg,#22d3ee,#6366f1)] text-white shadow-[0_0_20px_rgba(34,211,238,0.45)] ring-2 ring-cyan-200/40"
-                      : "bg-cyan-100/10 text-cyan-50/65 ring-1 ring-cyan-100/10",
+                      ? "scale-110 bg-[linear-gradient(135deg,#3b82f6,#6366f1)] text-white shadow-[0_0_20px_rgba(59,130,246,0.45)] ring-2 ring-blue-200/40"
+                      : "bg-blue-100/10 text-blue-50/65 ring-1 ring-blue-100/10",
                   )}
                 >
                   {digitBuffer || channel.id}
@@ -1538,8 +1538,8 @@ export function VideoPlayer({
                 <h2 className="truncate font-bold text-white text-xs tracking-[0.01em] md:text-base">{channel.name}</h2>
                 {channel.groups.length > 0 && (
                   <>
-                    <span className="hidden text-cyan-100/35 text-xs sm:inline md:text-sm">·</span>
-                    <div className="hidden truncate text-cyan-50/65 text-xs sm:block md:text-sm">
+                    <span className="hidden text-blue-100/35 text-xs sm:inline md:text-sm">·</span>
+                    <div className="hidden truncate text-blue-50/65 text-xs sm:block md:text-sm">
                       {channel.groups.join(" / ")}
                     </div>
                   </>
@@ -1557,10 +1557,10 @@ export function VideoPlayer({
           onClick={handleUserInteraction}
         >
           <div className="flex flex-col items-center gap-4 text-white">
-            <Play className="h-20 w-20 fill-cyan-100/20 text-cyan-100 opacity-95 drop-shadow-[0_0_24px_rgba(34,211,238,0.55)]" />
+            <Play className="h-20 w-20 fill-blue-100/20 text-blue-100 opacity-95 drop-shadow-[0_0_24px_rgba(59,130,246,0.55)]" />
             <div className="max-w-lg px-2 text-center">
-              <div className="mb-2 font-semibold text-2xl tracking-tight text-cyan-50">{t("clickToPlay")}</div>
-              <div className="text-pretty text-cyan-50/65 text-sm leading-5">{t("autoplayBlocked")}</div>
+              <div className="mb-2 font-semibold text-2xl tracking-tight text-blue-50">{t("clickToPlay")}</div>
+              <div className="text-pretty text-blue-50/65 text-sm leading-5">{t("autoplayBlocked")}</div>
             </div>
           </div>
         </button>
@@ -1623,7 +1623,7 @@ export function VideoPlayer({
     <div className="relative w-full bg-[radial-gradient(circle_at_50%_20%,#102044_0%,#050b18_52%,#01030a_100%)] pt-[env(safe-area-inset-top)] md:h-full">
       <div ref={playerDockRef} className="contents">
         {isDocumentPiP && (
-          <div className="@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-[radial-gradient(circle_at_center,#102044_0%,#050b18_62%,#01030a_100%)] px-4 text-center font-medium text-cyan-50/65 text-sm md:aspect-auto md:h-full md:text-base">
+          <div className="@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-[radial-gradient(circle_at_center,#102044_0%,#050b18_62%,#01030a_100%)] px-4 text-center font-medium text-blue-50/65 text-sm md:aspect-auto md:h-full md:text-base">
             {t("playingInPictureInPicture")}
           </div>
         )}

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -164,23 +164,23 @@ function PlayerTopLeftOverlay({
     <div
       className={clsx(
         PLAYER_OVERLAY_SURFACE_CLASS,
-        "absolute top-4 left-4 z-10 flex items-center gap-1.5 rounded-lg px-2 py-1.5 transition-opacity duration-300 md:top-8 md:left-8 md:gap-2 md:px-3 md:py-2",
+        "absolute top-4 left-4 z-10 flex max-w-[calc(100%-2rem)] items-center gap-1.5 rounded-xl px-2 py-1.5 transition-opacity duration-300 md:top-8 md:left-8 md:gap-2 md:px-3 md:py-2",
         visible ? "opacity-100" : "opacity-0 pointer-events-none",
       )}
     >
-      <span className="text-xs md:text-base text-white font-medium tabular-nums">
+      <span className="shrink-0 font-medium text-xs text-cyan-50 tabular-nums drop-shadow-sm md:text-base">
         {time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
       </span>
       {loading && (
         <>
-          <span className="text-xs md:text-sm text-white/50" aria-hidden="true">
+          <span className="shrink-0 text-cyan-100/35 text-xs md:text-sm" aria-hidden="true">
             ·
           </span>
           <div className="relative h-3 w-3 md:h-3.5 md:w-3.5 shrink-0">
-            <div className="absolute inset-0 rounded-full border border-white/30" />
-            <div className="absolute inset-0 rounded-full border border-white border-t-transparent animate-spin" />
+            <div className="absolute inset-0 rounded-full border border-cyan-100/25" />
+            <div className="absolute inset-0 animate-spin rounded-full border border-cyan-200 border-t-transparent shadow-[0_0_8px_rgba(103,232,249,0.5)]" />
           </div>
-          <span className="text-xs md:text-sm text-white/70">{loadingText}</span>
+          <span className="min-w-0 truncate text-cyan-50/70 text-xs md:text-sm">{loadingText}</span>
         </>
       )}
     </div>
@@ -1446,7 +1446,7 @@ export function VideoPlayer({
       role="application"
       ref={playerSurfaceRef}
       className={clsx(
-        "@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-black",
+        "@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-[radial-gradient(circle_at_50%_35%,#102044_0%,#050b18_58%,#01030a_100%)]",
         isDocumentPiP ? "h-screen min-h-screen aspect-auto" : "md:aspect-auto md:h-full",
         !showControls && "cursor-none",
       )}
@@ -1509,7 +1509,7 @@ export function VideoPlayer({
           <div
             className={clsx(
               PLAYER_OVERLAY_SURFACE_CLASS,
-              "flex max-w-[calc(100vw-2rem)] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-lg px-2 py-1.5 md:max-w-none md:gap-2 md:px-3 md:py-2",
+              "flex max-w-[calc(100vw-2rem)] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-xl px-2 py-1.5 md:max-w-none md:gap-2 md:px-3 md:py-2",
             )}
           >
             {channel.logo && (
@@ -1517,29 +1517,29 @@ export function VideoPlayer({
                 src={channel.logo}
                 alt={channel.name}
                 referrerPolicy="no-referrer"
-                className="h-8 w-20 md:h-14 md:w-36 object-contain"
+                className="h-8 w-20 object-contain drop-shadow-[0_0_14px_rgba(103,232,249,0.2)] md:h-14 md:w-36"
                 onError={(e) => {
                   (e.target as HTMLImageElement).style.display = "none";
                 }}
               />
             )}
-            <div className="flex items-center justify-center w-full">
-              <div className="flex items-center gap-1.5 md:gap-2 min-w-0">
+            <div className="flex w-full min-w-0 items-center justify-center">
+              <div className="flex min-w-0 items-center gap-1.5 md:gap-2">
                 <span
                   className={clsx(
-                    "rounded px-1 py-0.5 md:px-1.5 text-[10px] md:text-xs font-medium shrink-0 transition-[color,background-color,box-shadow,scale] duration-300",
+                    "shrink-0 rounded-md px-1 py-0.5 font-semibold text-[10px] transition-[color,background-color,box-shadow,scale] duration-300 md:px-1.5 md:text-xs",
                     digitBuffer
-                      ? "bg-primary text-primary-foreground scale-110 shadow-lg ring-2 ring-primary/50"
-                      : "bg-white/10 text-white/60",
+                      ? "scale-110 bg-[linear-gradient(135deg,#22d3ee,#6366f1)] text-white shadow-[0_0_20px_rgba(34,211,238,0.45)] ring-2 ring-cyan-200/40"
+                      : "bg-cyan-100/10 text-cyan-50/65 ring-1 ring-cyan-100/10",
                   )}
                 >
                   {digitBuffer || channel.id}
                 </span>
-                <h2 className="text-xs md:text-base font-bold text-white truncate">{channel.name}</h2>
+                <h2 className="truncate font-bold text-white text-xs tracking-[0.01em] md:text-base">{channel.name}</h2>
                 {channel.groups.length > 0 && (
                   <>
-                    <span className="text-xs md:text-sm text-white/50 hidden sm:inline">·</span>
-                    <div className="text-xs md:text-sm text-white/70 truncate hidden sm:block">
+                    <span className="hidden text-cyan-100/35 text-xs sm:inline md:text-sm">·</span>
+                    <div className="hidden truncate text-cyan-50/65 text-xs sm:block md:text-sm">
                       {channel.groups.join(" / ")}
                     </div>
                   </>
@@ -1553,24 +1553,29 @@ export function VideoPlayer({
       {needsUserInteraction && (
         <button
           type="button"
-          className="absolute inset-0 z-10 flex cursor-pointer items-center justify-center bg-black/80 p-4 transition-opacity hover:bg-black/85 border-none"
+          className="absolute inset-0 z-10 flex cursor-pointer items-center justify-center border-none bg-[radial-gradient(circle_at_center,rgba(18,50,91,0.78),rgba(2,6,23,0.94)_68%)] p-4 transition-[filter,background-color] backdrop-blur-[2px] hover:brightness-110"
           onClick={handleUserInteraction}
         >
           <div className="flex flex-col items-center gap-4 text-white">
-            <Play className="h-20 w-20 opacity-90 fill-current" />
-            <div className="text-center">
-              <div className="mb-2 text-2xl font-semibold">{t("clickToPlay")}</div>
-              <div className="text-sm text-white/70">{t("autoplayBlocked")}</div>
+            <Play className="h-20 w-20 fill-cyan-100/20 text-cyan-100 opacity-95 drop-shadow-[0_0_24px_rgba(34,211,238,0.55)]" />
+            <div className="max-w-lg px-2 text-center">
+              <div className="mb-2 font-semibold text-2xl tracking-tight text-cyan-50">{t("clickToPlay")}</div>
+              <div className="text-pretty text-cyan-50/65 text-sm leading-5">{t("autoplayBlocked")}</div>
             </div>
           </div>
         </button>
       )}
 
       {error && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/90 p-4">
-          <div className="max-w-md rounded-lg bg-red-500/20 p-4 text-white">
-            <div className="mb-2 text-lg font-semibold">{t("playbackError")}</div>
-            <div className="text-sm">{error}</div>
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(76,20,55,0.46),rgba(2,6,23,0.96)_72%)] p-4 backdrop-blur-[3px]">
+          <div
+            className={clsx(
+              PLAYER_OVERLAY_SURFACE_CLASS,
+              "w-full max-w-md rounded-2xl border-rose-300/25 bg-[linear-gradient(145deg,rgba(52,18,50,0.82),rgba(12,22,51,0.8))] p-5 text-white shadow-[0_20px_60px_rgba(43,5,32,0.58)]",
+            )}
+          >
+            <div className="mb-2 font-semibold text-lg text-rose-100">{t("playbackError")}</div>
+            <div className="break-words text-pretty text-rose-50/75 text-sm leading-relaxed">{error}</div>
           </div>
         </div>
       )}
@@ -1615,10 +1620,10 @@ export function VideoPlayer({
   );
 
   return (
-    <div className="relative w-full bg-black md:h-full pt-[env(safe-area-inset-top)]">
+    <div className="relative w-full bg-[radial-gradient(circle_at_50%_20%,#102044_0%,#050b18_52%,#01030a_100%)] pt-[env(safe-area-inset-top)] md:h-full">
       <div ref={playerDockRef} className="contents">
         {isDocumentPiP && (
-          <div className="@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-black px-4 text-center text-sm font-medium text-white/70 md:aspect-auto md:h-full md:text-base">
+          <div className="@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-[radial-gradient(circle_at_center,#102044_0%,#050b18_62%,#01030a_100%)] px-4 text-center font-medium text-cyan-50/65 text-sm md:aspect-auto md:h-full md:text-base">
             {t("playingInPictureInPicture")}
           </div>
         )}

--- a/web-ui/src/components/status/classnames.ts
+++ b/web-ui/src/components/status/classnames.ts
@@ -1,0 +1,13 @@
+export const STATUS_PANEL_CLASS =
+  "relative isolate rounded-3xl border border-border/60 bg-card/80 shadow-[0_1px_0_rgba(255,255,255,0.7),0_24px_64px_-38px_rgba(15,23,42,0.45)] backdrop-blur-xl backdrop-saturate-[1.35] dark:border-white/10 dark:bg-card/70 dark:shadow-[0_1px_0_rgba(255,255,255,0.08),0_28px_80px_-42px_rgba(0,0,0,0.9)]";
+
+export const STATUS_INSET_CLASS =
+  "rounded-2xl border border-border/50 bg-background/50 shadow-[inset_0_1px_0_rgba(255,255,255,0.7),0_14px_36px_-30px_rgba(15,23,42,0.45)] backdrop-blur-md dark:border-white/8 dark:bg-background/35 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_18px_42px_-30px_rgba(0,0,0,0.75)]";
+
+export const STATUS_METRIC_TILE_CLASS =
+  "rounded-xl border border-border/40 bg-card/55 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-sm dark:border-white/8 dark:bg-white/3 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
+
+export const STATUS_SECTION_TITLE_CLASS = "text-xl font-semibold tracking-[-0.025em] text-card-foreground";
+
+export const STATUS_CONTROL_GROUP_CLASS =
+  "min-h-11 rounded-xl border border-border/40 bg-background/35 px-1.5 py-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-md dark:border-white/8 dark:bg-background/25 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";

--- a/web-ui/src/components/status/classnames.ts
+++ b/web-ui/src/components/status/classnames.ts
@@ -2,10 +2,10 @@ export const STATUS_PANEL_CLASS =
   "relative isolate rounded-3xl border border-border/60 bg-card/80 shadow-[0_1px_0_rgba(255,255,255,0.7),0_24px_64px_-38px_rgba(15,23,42,0.45)] backdrop-blur-xl backdrop-saturate-[1.35] dark:border-white/10 dark:bg-card/70 dark:shadow-[0_1px_0_rgba(255,255,255,0.08),0_28px_80px_-42px_rgba(0,0,0,0.9)]";
 
 export const STATUS_INSET_CLASS =
-  "rounded-2xl border border-border/50 bg-background/50 shadow-[inset_0_1px_0_rgba(255,255,255,0.7),0_14px_36px_-30px_rgba(15,23,42,0.45)] backdrop-blur-md dark:border-white/8 dark:bg-background/35 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_18px_42px_-30px_rgba(0,0,0,0.75)]";
+  "rounded-2xl border border-border/50 bg-background/60 shadow-[inset_0_1px_0_rgba(255,255,255,0.58),0_12px_30px_-28px_rgba(15,23,42,0.34)] dark:border-white/8 dark:bg-background/48 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.045),0_16px_36px_-30px_rgba(0,0,0,0.62)]";
 
 export const STATUS_METRIC_TILE_CLASS =
-  "rounded-xl border border-border/40 bg-card/55 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-sm dark:border-white/8 dark:bg-white/3 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
+  "rounded-xl border border-border/40 bg-card/68 shadow-[inset_0_1px_0_rgba(255,255,255,0.48)] dark:border-white/8 dark:bg-white/4 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]";
 
 export const STATUS_SECTION_TITLE_CLASS = "text-xl font-semibold tracking-[-0.025em] text-card-foreground";
 

--- a/web-ui/src/components/status/classnames.ts
+++ b/web-ui/src/components/status/classnames.ts
@@ -10,4 +10,4 @@ export const STATUS_METRIC_TILE_CLASS =
 export const STATUS_SECTION_TITLE_CLASS = "text-xl font-semibold tracking-[-0.025em] text-card-foreground";
 
 export const STATUS_CONTROL_GROUP_CLASS =
-  "min-h-11 rounded-xl border border-border/40 bg-background/35 px-1.5 py-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-md dark:border-white/8 dark:bg-background/25 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
+  "min-h-11 rounded-xl border border-border/40 bg-background/35 px-3 py-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-md dark:border-white/8 dark:bg-background/25 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";

--- a/web-ui/src/components/status/connections-section.tsx
+++ b/web-ui/src/components/status/connections-section.tsx
@@ -10,7 +10,47 @@ import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
 import { Switch } from "../ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
+import {
+  STATUS_CONTROL_GROUP_CLASS,
+  STATUS_INSET_CLASS,
+  STATUS_METRIC_TILE_CLASS,
+  STATUS_PANEL_CLASS,
+  STATUS_SECTION_TITLE_CLASS,
+} from "./classnames";
 import { QueueUsage } from "./queue-usage";
+
+const STATE_BADGE_CLASSES: Record<ReturnType<typeof stateToVariant>, string> = {
+  default:
+    "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 shadow-[0_0_18px_-10px_rgba(16,185,129,0.9)] dark:text-emerald-300",
+  secondary:
+    "border-sky-500/25 bg-sky-500/10 text-sky-700 shadow-[0_0_18px_-10px_rgba(14,165,233,0.9)] dark:text-sky-300",
+  destructive:
+    "border-rose-500/25 bg-rose-500/10 text-rose-700 shadow-[0_0_18px_-10px_rgba(244,63,94,0.9)] dark:text-rose-300",
+  outline: "border-border/60 bg-muted/35 text-muted-foreground",
+};
+
+const STATE_DOT_CLASSES: Record<ReturnType<typeof stateToVariant>, string> = {
+  default: "bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.9)]",
+  secondary: "bg-sky-500 shadow-[0_0_8px_rgba(14,165,233,0.9)]",
+  destructive: "bg-rose-500 shadow-[0_0_8px_rgba(244,63,94,0.9)]",
+  outline: "bg-muted-foreground/60",
+};
+
+function ClientStateBadge({ client, locale }: { client: ClientRow; locale: Locale }) {
+  const variant = stateToVariant(client.state);
+  return (
+    <Badge
+      variant={null}
+      className={clsx(
+        "ml-auto shrink-0 justify-center gap-2 whitespace-nowrap px-3 py-1 text-center leading-4 lg:ml-0",
+        STATE_BADGE_CLASSES[variant],
+      )}
+    >
+      <span aria-hidden className={clsx("h-1.5 w-1.5 shrink-0 rounded-full", STATE_DOT_CLASSES[variant])} />
+      {stateToLabel(locale, client.state)}
+    </Badge>
+  );
+}
 
 interface ConnectionsSectionProps {
   clients: ClientRow[];
@@ -33,11 +73,11 @@ export function ConnectionsSection({
 }: ConnectionsSectionProps) {
   const t = useStatusTranslation(locale);
   return (
-    <section className="flex flex-col rounded-3xl border border-border/60 bg-card/90 p-6 shadow-sm">
+    <section className={clsx(STATUS_PANEL_CLASS, "flex flex-col p-5 sm:p-6")}>
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-        <h2 className="text-xl font-semibold tracking-tight text-card-foreground">{t("connections")}</h2>
-        <div className="flex items-center gap-3 text-sm text-muted-foreground">
-          <span className="font-medium text-card-foreground">{t("showDisconnected")}</span>
+        <h2 className={STATUS_SECTION_TITLE_CLASS}>{t("connections")}</h2>
+        <div className={clsx("flex items-center gap-3 text-sm text-muted-foreground", STATUS_CONTROL_GROUP_CLASS)}>
+          <span className="whitespace-nowrap font-medium text-card-foreground">{t("showDisconnected")}</span>
           <Switch
             checked={showDisconnected}
             onCheckedChange={onShowDisconnectedChange}
@@ -47,47 +87,64 @@ export function ConnectionsSection({
       </div>
 
       {clients.length === 0 ? (
-        <div className="mt-6 flex min-h-[260px] flex-1 items-center justify-center rounded-2xl border-2 border-dashed border-border/60 bg-muted/20 text-sm font-medium text-muted-foreground">
+        <div
+          className={clsx(
+            STATUS_INSET_CLASS,
+            "mt-5 flex min-h-[260px] flex-1 items-center justify-center border-dashed bg-muted/20 text-sm font-medium text-muted-foreground",
+          )}
+        >
           {t("noConnections")}
         </div>
       ) : (
-        <div className="mt-6 flex-1 overflow-hidden rounded-2xl border border-border/50 bg-card/40 backdrop-blur-sm">
-          <div className="hidden min-w-[960px] lg:block">
-            <Table>
+        <div className={clsx(STATUS_INSET_CLASS, "mt-5 flex-1 overflow-hidden")}>
+          <div className="hidden lg:block">
+            <Table className="min-w-[960px] [&_td]:border-border/20 [&_th]:text-[11px] [&_th]:font-semibold [&_th]:tracking-[0.04em]">
               <TableHeader>
-                <TableRow className="bg-muted/40">
+                <TableRow className="border-border/50 bg-muted/35 shadow-[inset_0_-1px_0_hsl(var(--border)/0.35)] hover:bg-muted/35">
                   <TableHead>{t("client")}</TableHead>
                   <TableHead>{t("service")}</TableHead>
                   <TableHead>{t("state")}</TableHead>
-                  <TableHead>{t("duration")}</TableHead>
-                  <TableHead>{t("bandwidth")}</TableHead>
-                  <TableHead>{t("dataSent")}</TableHead>
-                  <TableHead>{t("queueDrops")}</TableHead>
+                  <TableHead className="whitespace-nowrap text-right">{t("duration")}</TableHead>
+                  <TableHead className="whitespace-nowrap text-right">{t("bandwidth")}</TableHead>
+                  <TableHead className="whitespace-nowrap text-right">{t("dataSent")}</TableHead>
+                  <TableHead className="min-w-[210px]">{t("queueDrops")}</TableHead>
                   <TableHead className="text-center">{t("action")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {clients.map((client) => (
-                  <TableRow key={client.clientId} className={client.isDisconnected ? "opacity-60" : undefined}>
+                  <TableRow
+                    key={client.clientId}
+                    className={clsx(
+                      "group/row hover:bg-primary/4",
+                      client.isDisconnected && "opacity-55 grayscale-[0.2]",
+                    )}
+                  >
                     <TableCell>
-                      <div className="font-medium">{client.clientAddr}</div>
-                      <div className="text-xs text-muted-foreground">
+                      <div className="font-mono text-sm font-semibold tracking-tight tabular-nums">
+                        {client.clientAddr}
+                      </div>
+                      <div className="mt-0.5 text-xs text-muted-foreground tabular-nums">
                         {t("workerPid")}: {client.workerPid}
                       </div>
                     </TableCell>
-                    <TableCell className="max-w-[240px] wrap-break-word text-sm">{client.serviceUrl || "-"}</TableCell>
+                    <TableCell className="max-w-[240px] wrap-break-word font-mono text-xs text-foreground/80">
+                      {client.serviceUrl || "-"}
+                    </TableCell>
                     <TableCell>
-                      <Badge variant={stateToVariant(client.state)} className="px-3">
-                        {stateToLabel(locale, client.state)}
-                      </Badge>
+                      <ClientStateBadge client={client} locale={locale} />
                       {client.slow ? <div className="mt-2 text-xs text-destructive">{t("slowClient")}</div> : null}
                     </TableCell>
-                    <TableCell>
+                    <TableCell className="whitespace-nowrap text-right tabular-nums">
                       {formatDuration(client.isDisconnected ? (client.disconnectDurationMs ?? 0) : client.durationMs)}
                     </TableCell>
-                    <TableCell>{formatBandwidth(client.currentBandwidth, bandwidthUnit)}</TableCell>
-                    <TableCell>{formatBytes(client.bytesSent)}</TableCell>
-                    <TableCell>
+                    <TableCell className="whitespace-nowrap text-right font-medium tabular-nums">
+                      {formatBandwidth(client.currentBandwidth, bandwidthUnit)}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap text-right tabular-nums">
+                      {formatBytes(client.bytesSent)}
+                    </TableCell>
+                    <TableCell className="min-w-[210px]">
                       <QueueUsage
                         locale={locale}
                         queueBytes={client.queueBytes}
@@ -105,6 +162,7 @@ export function ConnectionsSection({
                           variant="destructive"
                           disabled={disconnectingIds.has(client.clientId)}
                           onClick={() => onDisconnect(client.clientId)}
+                          className="rounded-lg bg-rose-600 shadow-[0_8px_18px_-12px_rgba(225,29,72,0.9)] hover:bg-rose-700"
                         >
                           {disconnectingIds.has(client.clientId) ? t("disconnecting") : t("disconnect")}
                         </Button>
@@ -119,17 +177,25 @@ export function ConnectionsSection({
             {clients.map((client) => (
               <Card
                 key={client.clientId}
-                className={clsx("border border-border/60", client.isDisconnected && "opacity-60")}
+                className={clsx(
+                  "rounded-2xl border border-border/45 bg-card/60 shadow-[0_14px_38px_-30px_rgba(15,23,42,0.5)] dark:border-white/8 dark:bg-white/3",
+                  client.isDisconnected && "opacity-55 grayscale-[0.2]",
+                )}
               >
                 <CardContent className="space-y-4 p-4">
-                  <div className="flex items-center justify-between">
-                    <div className="text-sm font-medium">{client.clientAddr}</div>
-                    <Badge variant={stateToVariant(client.state)} className="px-3">
-                      {stateToLabel(locale, client.state)}
-                    </Badge>
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 break-all font-mono text-sm font-semibold tracking-tight tabular-nums">
+                      {client.clientAddr}
+                    </div>
+                    <ClientStateBadge client={client} locale={locale} />
                   </div>
-                  <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
-                    <span>
+                  <div
+                    className={clsx(
+                      STATUS_METRIC_TILE_CLASS,
+                      "grid grid-cols-2 gap-2 p-3 text-xs text-muted-foreground tabular-nums",
+                    )}
+                  >
+                    <span className="min-w-0 wrap-break-word">
                       {t("service")}: {client.serviceUrl || "-"}
                     </span>
                     <span>
@@ -150,8 +216,8 @@ export function ConnectionsSection({
                     queueHighwater={client.queueBytesHighwater}
                     droppedBytes={client.droppedBytes}
                   />
-                  <div className="flex items-center justify-between text-xs text-muted-foreground">
-                    <span>PID: {client.workerPid}</span>
+                  <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                    <span className="font-mono tabular-nums">PID: {client.workerPid}</span>
                     {client.isDisconnected ? (
                       <span className="text-muted-foreground">--</span>
                     ) : (
@@ -160,6 +226,7 @@ export function ConnectionsSection({
                         variant="destructive"
                         disabled={disconnectingIds.has(client.clientId)}
                         onClick={() => onDisconnect(client.clientId)}
+                        className="rounded-lg bg-rose-600 shadow-[0_8px_18px_-12px_rgba(225,29,72,0.9)] hover:bg-rose-700"
                       >
                         {disconnectingIds.has(client.clientId) ? t("disconnecting") : t("disconnect")}
                       </Button>

--- a/web-ui/src/components/status/logs-section.tsx
+++ b/web-ui/src/components/status/logs-section.tsx
@@ -86,7 +86,7 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
               onChange={(event) => onLogLevelChange(event.target.value)}
               disabled={disabled}
               containerClassName="min-w-[120px]"
-              className="border-border/40 bg-background/60 text-sm font-medium shadow-none hover:border-primary/30"
+              className="border-border/40 bg-background/70 text-sm font-medium shadow-none backdrop-blur-none hover:border-primary/30"
               aria-label={t("logLevel")}
             >
               {!logLevelValue && <option value="">--</option>}
@@ -110,7 +110,7 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
       </div>
       <div
         ref={viewportRef}
-        className="mt-5 h-100 overflow-y-auto rounded-2xl border border-slate-700/70 bg-slate-950/95 p-3 text-slate-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_20px_80px_rgba(15,23,42,0.42),0_20px_54px_-36px_rgba(2,6,23,0.9)] backdrop-blur-xl scrollbar-thin scrollbar-track-transparent scrollbar-thumb-slate-700 sm:p-4 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-700"
+        className="mt-5 h-100 overflow-y-auto rounded-2xl border border-slate-700/70 bg-slate-950/95 p-3 text-slate-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_20px_80px_rgba(15,23,42,0.42),0_20px_54px_-36px_rgba(2,6,23,0.9)] scrollbar-thin scrollbar-track-transparent scrollbar-thumb-slate-700 sm:p-4 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-700"
       >
         {logs.length === 0 ? (
           <div className="flex h-full items-center justify-center text-sm text-slate-500">--</div>

--- a/web-ui/src/components/status/logs-section.tsx
+++ b/web-ui/src/components/status/logs-section.tsx
@@ -76,8 +76,10 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <h2 className={STATUS_SECTION_TITLE_CLASS}>{t("logs")}</h2>
         <div className="flex flex-wrap items-center justify-start gap-3 text-sm text-muted-foreground sm:justify-end">
-          <div className={clsx("flex items-center gap-2", STATUS_CONTROL_GROUP_CLASS)}>
-            <List className="h-4 w-4" />
+          <div className={clsx("flex items-center gap-1.5", STATUS_CONTROL_GROUP_CLASS)}>
+            <span className="flex size-6 shrink-0 items-center justify-center text-primary/75">
+              <List className="h-4 w-4" />
+            </span>
             <span className="whitespace-nowrap">{t("logLevel")}:</span>
             <SelectBox
               value={logLevelValue ?? ""}

--- a/web-ui/src/components/status/logs-section.tsx
+++ b/web-ui/src/components/status/logs-section.tsx
@@ -1,3 +1,4 @@
+import { clsx } from "clsx";
 import { List } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useStatusTranslation } from "../../hooks/use-status-translation";
@@ -5,6 +6,22 @@ import type { Locale } from "../../lib/locale";
 import type { LogEntry } from "../../types";
 import { SelectBox } from "../ui/select-box";
 import { Switch } from "../ui/switch";
+import { STATUS_CONTROL_GROUP_CLASS, STATUS_PANEL_CLASS, STATUS_SECTION_TITLE_CLASS } from "./classnames";
+
+function getLogLevelClass(levelName: string): string {
+  switch (levelName.toUpperCase()) {
+    case "FATAL":
+    case "ERROR":
+      return "text-rose-300 drop-shadow-[0_0_8px_rgba(251,113,133,0.3)]";
+    case "WARN":
+    case "WARNING":
+      return "text-amber-300 drop-shadow-[0_0_8px_rgba(252,211,77,0.25)]";
+    case "DEBUG":
+      return "text-violet-300";
+    default:
+      return "text-cyan-300";
+  }
+}
 
 interface LogsSectionProps {
   logs: LogEntry[];
@@ -55,19 +72,19 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
   }, [locale]);
 
   return (
-    <section className="flex flex-col rounded-3xl border border-border/60 bg-card/90 p-5 shadow-sm">
+    <section className={clsx(STATUS_PANEL_CLASS, "flex flex-col p-5 sm:p-6")}>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="text-xl font-semibold tracking-tight text-card-foreground">{t("logs")}</h2>
-        <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
-          <div className="flex items-center gap-2">
+        <h2 className={STATUS_SECTION_TITLE_CLASS}>{t("logs")}</h2>
+        <div className="flex flex-wrap items-center justify-start gap-3 text-sm text-muted-foreground sm:justify-end">
+          <div className={clsx("flex items-center gap-2", STATUS_CONTROL_GROUP_CLASS)}>
             <List className="h-4 w-4" />
-            <span>{t("logLevel")}:</span>
+            <span className="whitespace-nowrap">{t("logLevel")}:</span>
             <SelectBox
               value={logLevelValue ?? ""}
               onChange={(event) => onLogLevelChange(event.target.value)}
               disabled={disabled}
               containerClassName="min-w-[120px]"
-              className="text-sm font-medium"
+              className="border-border/40 bg-background/60 text-sm font-medium shadow-none hover:border-primary/30"
               aria-label={t("logLevel")}
             >
               {!logLevelValue && <option value="">--</option>}
@@ -78,8 +95,8 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
               ))}
             </SelectBox>
           </div>
-          <div className="flex items-center gap-2">
-            <span>{t("autoScroll")}:</span>
+          <div className={clsx("flex items-center gap-2", STATUS_CONTROL_GROUP_CLASS)}>
+            <span className="whitespace-nowrap">{t("autoScroll")}:</span>
             <Switch
               checked={autoScroll}
               onCheckedChange={setAutoScroll}
@@ -91,19 +108,28 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
       </div>
       <div
         ref={viewportRef}
-        className="mt-5 h-100 overflow-y-auto rounded-2xl border border-border/50 bg-muted/20 p-4 backdrop-blur-sm scrollbar-thin scrollbar-thumb-muted-foreground scrollbar-track-transparent [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground"
+        className="mt-5 h-100 overflow-y-auto rounded-2xl border border-slate-700/70 bg-slate-950/95 p-3 text-slate-200 shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_20px_80px_rgba(15,23,42,0.42),0_20px_54px_-36px_rgba(2,6,23,0.9)] backdrop-blur-xl scrollbar-thin scrollbar-track-transparent scrollbar-thumb-slate-700 sm:p-4 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-700"
       >
         {logs.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">--</div>
+          <div className="flex h-full items-center justify-center text-sm text-slate-500">--</div>
         ) : (
-          <div className="space-y-1 font-mono text-sm">
+          <div className="space-y-1.5 font-mono text-sm">
             {logs.map((log) => (
               <div
                 key={`${log.timestamp}-${log.message}`}
-                className="rounded-lg border border-transparent bg-card/40 p-2 transition hover:border-border/60 text-sm text-card-foreground whitespace-pre-wrap"
+                className="rounded-lg border border-white/4 bg-white/[0.025] p-2 text-sm text-slate-200 whitespace-pre-wrap transition-colors hover:border-white/8 hover:bg-white/4"
               >
-                <span className="text-muted-foreground">{timestampFormatter.format(new Date(log.timestamp))}</span>{" "}
-                <span className="font-semibold uppercase tracking-wide text-primary">{log.levelName}</span>{" "}
+                <span className="text-slate-500 tabular-nums sm:inline-block sm:min-w-[10.5rem]">
+                  {timestampFormatter.format(new Date(log.timestamp))}
+                </span>{" "}
+                <span
+                  className={clsx(
+                    "inline-block w-14 font-semibold uppercase tracking-wide",
+                    getLogLevelClass(log.levelName),
+                  )}
+                >
+                  {log.levelName}
+                </span>{" "}
                 {log.message}
               </div>
             ))}

--- a/web-ui/src/components/status/queue-usage.tsx
+++ b/web-ui/src/components/status/queue-usage.tsx
@@ -1,7 +1,9 @@
+import { clsx } from "clsx";
 import { useStatusTranslation } from "../../hooks/use-status-translation";
 import { formatBytes } from "../../lib/format";
 import type { Locale } from "../../lib/locale";
 import { Progress } from "../ui/progress";
+import { STATUS_METRIC_TILE_CLASS } from "./classnames";
 
 interface QueueUsageProps {
   queueBytes: number;
@@ -11,32 +13,58 @@ interface QueueUsageProps {
   droppedBytes: number;
 }
 
+interface QueueMetricProps {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}
+
+function QueueMetric({ label, value, valueClassName }: QueueMetricProps) {
+  return (
+    <div className="min-w-0 space-y-0.5">
+      <span className="block min-w-0 text-[10px] leading-4 text-muted-foreground/85">{label}</span>
+      <span className={clsx("block font-mono text-xs text-foreground/75 tabular-nums", valueClassName)}>{value}</span>
+    </div>
+  );
+}
+
 export function QueueUsage({ locale, queueBytes, queueLimit, queueHighwater, droppedBytes }: QueueUsageProps) {
   const t = useStatusTranslation(locale);
   const usage = queueLimit > 0 ? Math.min(100, (queueBytes / queueLimit) * 100) : 0;
-  const highwaterPercent = queueLimit > 0 ? Math.min(100, (queueHighwater / queueLimit) * 100) : undefined;
+  const highwaterPercent = queueLimit > 0 ? Math.min(100, Math.max(0, (queueHighwater / queueLimit) * 100)) : undefined;
 
   return (
-    <div className="space-y-3 rounded-xl border border-border/40 bg-card/60 p-3 text-xs text-muted-foreground">
-      <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+    <div className={clsx(STATUS_METRIC_TILE_CLASS, "space-y-3 p-3 text-xs text-muted-foreground")}>
+      <div className="flex min-h-5 items-center justify-between gap-3 text-[11px] font-semibold tracking-[0.04em] text-muted-foreground/80">
         <span>{t("queueUsage")}</span>
-        <span>{usage.toFixed(1)}%</span>
+        <span className="font-mono text-foreground/80 tabular-nums">{usage.toFixed(1)}%</span>
       </div>
-      <Progress value={usage} indicatorClassName="bg-gradient-to-r from-emerald-400 via-amber-400 to-rose-500" />
-      <div className="grid grid-cols-2 gap-2">
-        <span>
-          {t("queueCurrent")}: {formatBytes(queueBytes)}
-        </span>
-        <span>
-          {t("queueLimit")}: {queueLimit > 0 ? formatBytes(queueLimit) : "--"}
-        </span>
-        <span>
-          {t("queuePeak")}: {formatBytes(queueHighwater)}
-          {typeof highwaterPercent === "number" ? ` (${highwaterPercent.toFixed(1)}%)` : ""}
-        </span>
-        <span>
-          {t("queueDroppedBytes")}: {formatBytes(droppedBytes)}
-        </span>
+      <div className="relative">
+        <Progress
+          value={usage}
+          className="h-1.5 bg-muted/70 shadow-inner"
+          indicatorClassName="bg-gradient-to-r from-emerald-400 via-amber-400 to-rose-500 shadow-[0_0_12px_rgba(16,185,129,0.35)]"
+        />
+        {typeof highwaterPercent === "number" ? (
+          <span
+            aria-hidden
+            className="absolute top-1/2 h-3 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground/75 shadow-[0_0_0_1px_hsl(var(--background)/0.7)]"
+            style={{ left: `${highwaterPercent}%` }}
+          />
+        ) : null}
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+        <QueueMetric label={t("queueCurrent")} value={formatBytes(queueBytes)} />
+        <QueueMetric label={t("queueLimit")} value={queueLimit > 0 ? formatBytes(queueLimit) : "--"} />
+        <QueueMetric
+          label={t("queuePeak")}
+          value={`${formatBytes(queueHighwater)}${typeof highwaterPercent === "number" ? ` (${highwaterPercent.toFixed(1)}%)` : ""}`}
+        />
+        <QueueMetric
+          label={t("queueDroppedBytes")}
+          value={formatBytes(droppedBytes)}
+          valueClassName={clsx(droppedBytes > 0 && "font-semibold text-rose-600 dark:text-rose-300")}
+        />
       </div>
     </div>
   );

--- a/web-ui/src/components/status/service-control-section.tsx
+++ b/web-ui/src/components/status/service-control-section.tsx
@@ -65,7 +65,7 @@ export function ServiceControlSection({
             size="sm"
             onClick={handleReloadConfig}
             disabled={disabled || reloading}
-            className="gap-2 rounded-xl border-border/50 bg-background/50 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-md transition-[color,background-color,border-color,box-shadow] hover:border-primary/25 hover:bg-primary/8 hover:shadow-[0_10px_24px_-18px_hsl(var(--primary)/0.7)] dark:border-white/10 dark:bg-background/30"
+            className="gap-2 rounded-xl border-border/50 bg-background/62 shadow-[inset_0_1px_0_rgba(255,255,255,0.48)] transition-[color,background-color,border-color,box-shadow] hover:border-primary/25 hover:bg-primary/8 hover:shadow-[0_10px_24px_-18px_hsl(var(--primary)/0.7)] dark:border-white/10 dark:bg-background/42"
           >
             <RefreshCw className={clsx("h-4 w-4 shrink-0", reloading && "animate-spin")} />
             {reloading ? t("reloading") : t("reloadConfig")}
@@ -75,7 +75,7 @@ export function ServiceControlSection({
             size="sm"
             onClick={handleRestartWorkers}
             disabled={disabled || restarting}
-            className="gap-2 rounded-xl border-border/50 bg-background/50 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-md transition-[color,background-color,border-color,box-shadow] hover:border-primary/25 hover:bg-primary/8 hover:shadow-[0_10px_24px_-18px_hsl(var(--primary)/0.7)] dark:border-white/10 dark:bg-background/30"
+            className="gap-2 rounded-xl border-border/50 bg-background/62 shadow-[inset_0_1px_0_rgba(255,255,255,0.48)] transition-[color,background-color,border-color,box-shadow] hover:border-primary/25 hover:bg-primary/8 hover:shadow-[0_10px_24px_-18px_hsl(var(--primary)/0.7)] dark:border-white/10 dark:bg-background/42"
           >
             <RotateCcw className={clsx("h-4 w-4 shrink-0", restarting && "animate-spin")} />
             {restarting ? t("restarting") : t("restartWorkers")}
@@ -85,7 +85,7 @@ export function ServiceControlSection({
             size="sm"
             onClick={handleClearLogs}
             disabled={disabled || clearing}
-            className="gap-2 rounded-xl border-rose-500/20 bg-rose-500/5 text-rose-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] backdrop-blur-md transition-[color,background-color,border-color,box-shadow] hover:border-rose-500/35 hover:bg-rose-500/10 hover:text-rose-700 hover:shadow-[0_10px_24px_-18px_rgba(244,63,94,0.75)] dark:text-rose-300 dark:hover:text-rose-200"
+            className="gap-2 rounded-xl border-rose-500/20 bg-rose-500/6 text-rose-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.42)] transition-[color,background-color,border-color,box-shadow] hover:border-rose-500/35 hover:bg-rose-500/10 hover:text-rose-700 hover:shadow-[0_10px_24px_-18px_rgba(244,63,94,0.75)] dark:text-rose-300 dark:hover:text-rose-200"
           >
             <Trash2 className={clsx("h-4 w-4 shrink-0", clearing && "animate-pulse")} />
             {clearing ? t("clearing") : t("clearLogs")}

--- a/web-ui/src/components/status/service-control-section.tsx
+++ b/web-ui/src/components/status/service-control-section.tsx
@@ -65,7 +65,7 @@ export function ServiceControlSection({
             size="sm"
             onClick={handleReloadConfig}
             disabled={disabled || reloading}
-            className="gap-2 rounded-xl border-border/50 bg-background/62 shadow-[inset_0_1px_0_rgba(255,255,255,0.48)] transition-[color,background-color,border-color,box-shadow] hover:border-primary/25 hover:bg-primary/8 hover:shadow-[0_10px_24px_-18px_hsl(var(--primary)/0.7)] dark:border-white/10 dark:bg-background/42"
+            className="gap-2 rounded-xl border-border/50 bg-muted/65 shadow-none transition-[color,background-color,border-color] hover:border-primary/25 hover:bg-primary/8 dark:border-white/10 dark:bg-muted/50"
           >
             <RefreshCw className={clsx("h-4 w-4 shrink-0", reloading && "animate-spin")} />
             {reloading ? t("reloading") : t("reloadConfig")}
@@ -75,7 +75,7 @@ export function ServiceControlSection({
             size="sm"
             onClick={handleRestartWorkers}
             disabled={disabled || restarting}
-            className="gap-2 rounded-xl border-border/50 bg-background/62 shadow-[inset_0_1px_0_rgba(255,255,255,0.48)] transition-[color,background-color,border-color,box-shadow] hover:border-primary/25 hover:bg-primary/8 hover:shadow-[0_10px_24px_-18px_hsl(var(--primary)/0.7)] dark:border-white/10 dark:bg-background/42"
+            className="gap-2 rounded-xl border-border/50 bg-muted/65 shadow-none transition-[color,background-color,border-color] hover:border-primary/25 hover:bg-primary/8 dark:border-white/10 dark:bg-muted/50"
           >
             <RotateCcw className={clsx("h-4 w-4 shrink-0", restarting && "animate-spin")} />
             {restarting ? t("restarting") : t("restartWorkers")}
@@ -85,7 +85,7 @@ export function ServiceControlSection({
             size="sm"
             onClick={handleClearLogs}
             disabled={disabled || clearing}
-            className="gap-2 rounded-xl border-rose-500/20 bg-rose-500/6 text-rose-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.42)] transition-[color,background-color,border-color,box-shadow] hover:border-rose-500/35 hover:bg-rose-500/10 hover:text-rose-700 hover:shadow-[0_10px_24px_-18px_rgba(244,63,94,0.75)] dark:text-rose-300 dark:hover:text-rose-200"
+            className="gap-2 rounded-xl border-rose-500/20 bg-rose-500/8 text-rose-700 shadow-none transition-[color,background-color,border-color] hover:border-rose-500/35 hover:bg-rose-500/12 hover:text-rose-700 dark:text-rose-300 dark:hover:text-rose-200"
           >
             <Trash2 className={clsx("h-4 w-4 shrink-0", clearing && "animate-pulse")} />
             {clearing ? t("clearing") : t("clearLogs")}

--- a/web-ui/src/components/status/service-control-section.tsx
+++ b/web-ui/src/components/status/service-control-section.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useStatusTranslation } from "../../hooks/use-status-translation";
 import type { Locale } from "../../lib/locale";
 import { Button } from "../ui/button";
+import { STATUS_PANEL_CLASS, STATUS_SECTION_TITLE_CLASS } from "./classnames";
 
 interface ServiceControlSectionProps {
   onReloadConfig: () => Promise<void>;
@@ -53,20 +54,20 @@ export function ServiceControlSection({
   };
 
   return (
-    <section className="flex flex-col rounded-3xl border border-border/60 bg-card/90 p-5 shadow-sm">
+    <section className={clsx(STATUS_PANEL_CLASS, "flex flex-col p-5 sm:p-6")}>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2">
-          <h2 className="text-xl font-semibold tracking-tight text-card-foreground">{t("serviceControl")}</h2>
+          <h2 className={STATUS_SECTION_TITLE_CLASS}>{t("serviceControl")}</h2>
         </div>
-        <div className="flex flex-wrap items-center gap-3">
+        <div className="flex flex-wrap items-center justify-start gap-3 sm:justify-end">
           <Button
             variant="outline"
             size="sm"
             onClick={handleReloadConfig}
             disabled={disabled || reloading}
-            className="gap-2"
+            className="gap-2 rounded-xl border-border/50 bg-background/50 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-md transition-[color,background-color,border-color,box-shadow] hover:border-primary/25 hover:bg-primary/8 hover:shadow-[0_10px_24px_-18px_hsl(var(--primary)/0.7)] dark:border-white/10 dark:bg-background/30"
           >
-            <RefreshCw className={clsx("h-4 w-4", reloading && "animate-spin")} />
+            <RefreshCw className={clsx("h-4 w-4 shrink-0", reloading && "animate-spin")} />
             {reloading ? t("reloading") : t("reloadConfig")}
           </Button>
           <Button
@@ -74,9 +75,9 @@ export function ServiceControlSection({
             size="sm"
             onClick={handleRestartWorkers}
             disabled={disabled || restarting}
-            className="gap-2"
+            className="gap-2 rounded-xl border-border/50 bg-background/50 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-md transition-[color,background-color,border-color,box-shadow] hover:border-primary/25 hover:bg-primary/8 hover:shadow-[0_10px_24px_-18px_hsl(var(--primary)/0.7)] dark:border-white/10 dark:bg-background/30"
           >
-            <RotateCcw className={clsx("h-4 w-4", restarting && "animate-spin")} />
+            <RotateCcw className={clsx("h-4 w-4 shrink-0", restarting && "animate-spin")} />
             {restarting ? t("restarting") : t("restartWorkers")}
           </Button>
           <Button
@@ -84,9 +85,9 @@ export function ServiceControlSection({
             size="sm"
             onClick={handleClearLogs}
             disabled={disabled || clearing}
-            className="gap-2"
+            className="gap-2 rounded-xl border-rose-500/20 bg-rose-500/5 text-rose-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] backdrop-blur-md transition-[color,background-color,border-color,box-shadow] hover:border-rose-500/35 hover:bg-rose-500/10 hover:text-rose-700 hover:shadow-[0_10px_24px_-18px_rgba(244,63,94,0.75)] dark:text-rose-300 dark:hover:text-rose-200"
           >
-            <Trash2 className={clsx("h-4 w-4", clearing && "animate-pulse")} />
+            <Trash2 className={clsx("h-4 w-4 shrink-0", clearing && "animate-pulse")} />
             {clearing ? t("clearing") : t("clearLogs")}
           </Button>
         </div>

--- a/web-ui/src/components/status/stat-card.tsx
+++ b/web-ui/src/components/status/stat-card.tsx
@@ -11,8 +11,6 @@ const STAT_CARD_TONES: Record<
     iconBackground: string;
     iconShadow: string;
     gradient: string;
-    spotlight: string;
-    cardShadowClass: string;
   }
 > = {
   violet: {
@@ -20,36 +18,24 @@ const STAT_CARD_TONES: Record<
     iconBackground: "hsla(262, 83%, 62%, 0.14)",
     iconShadow: "0 10px 28px -14px rgba(139, 92, 246, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
     gradient: "radial-gradient(120% 120% at 0% 0%, rgba(139, 92, 246, 0.22), transparent 66%)",
-    spotlight: "radial-gradient(70% 90% at 88% 115%, rgba(99, 102, 241, 0.2), transparent 72%)",
-    cardShadowClass:
-      "shadow-[0_18px_50px_-36px_rgba(124,58,237,0.78)] hover:shadow-[0_24px_60px_-34px_rgba(124,58,237,0.9)]",
   },
   emerald: {
     iconColor: "hsl(158 72% 38%)",
     iconBackground: "hsla(152, 76%, 38%, 0.14)",
     iconShadow: "0 10px 28px -14px rgba(16, 185, 129, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
     gradient: "radial-gradient(120% 120% at 0% 0%, rgba(16, 185, 129, 0.2), transparent 66%)",
-    spotlight: "radial-gradient(70% 90% at 88% 115%, rgba(6, 182, 212, 0.18), transparent 72%)",
-    cardShadowClass:
-      "shadow-[0_18px_50px_-36px_rgba(16,185,129,0.72)] hover:shadow-[0_24px_60px_-34px_rgba(16,185,129,0.84)]",
   },
   sky: {
     iconColor: "hsl(197 92% 45%)",
     iconBackground: "hsla(197, 92%, 45%, 0.16)",
     iconShadow: "0 10px 28px -14px rgba(14, 165, 233, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
     gradient: "radial-gradient(120% 120% at 0% 0%, rgba(14, 165, 233, 0.21), transparent 66%)",
-    spotlight: "radial-gradient(70% 90% at 88% 115%, rgba(59, 130, 246, 0.18), transparent 72%)",
-    cardShadowClass:
-      "shadow-[0_18px_50px_-36px_rgba(14,165,233,0.72)] hover:shadow-[0_24px_60px_-34px_rgba(14,165,233,0.84)]",
   },
   amber: {
     iconColor: "hsl(35 92% 47%)",
     iconBackground: "hsla(38, 92%, 50%, 0.18)",
     iconShadow: "0 10px 28px -14px rgba(245, 158, 11, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
     gradient: "radial-gradient(120% 120% at 0% 0%, rgba(245, 158, 11, 0.2), transparent 66%)",
-    spotlight: "radial-gradient(70% 90% at 88% 115%, rgba(249, 115, 22, 0.17), transparent 72%)",
-    cardShadowClass:
-      "shadow-[0_18px_50px_-36px_rgba(245,158,11,0.7)] hover:shadow-[0_24px_60px_-34px_rgba(245,158,11,0.82)]",
   },
 } as const;
 
@@ -65,26 +51,20 @@ export function StatCard({ title, value, icon: Icon, tone = "violet" }: StatCard
   return (
     <Card
       className={clsx(
-        "group relative overflow-hidden rounded-2xl border border-border/45 bg-card/75 backdrop-blur-xl backdrop-saturate-150 transition-[translate,box-shadow,border-color] duration-300 motion-reduce:transition-none motion-safe:hover:-translate-y-1 hover:border-white/60 dark:border-white/10 dark:bg-card/65 dark:hover:border-white/20",
-        palette.cardShadowClass,
+        "group relative overflow-hidden rounded-2xl border border-border/45 bg-card/78 shadow-[0_18px_50px_-36px_rgba(15,23,42,0.44),inset_0_1px_0_rgba(255,255,255,0.56)] backdrop-blur-lg backdrop-saturate-125 transition-[box-shadow,border-color] duration-300 motion-reduce:transition-none hover:border-white/60 hover:shadow-[0_22px_56px_-36px_rgba(15,23,42,0.56),inset_0_1px_0_rgba(255,255,255,0.62)] dark:border-white/10 dark:bg-card/68 dark:shadow-[0_22px_56px_-38px_rgba(0,0,0,0.78),inset_0_1px_0_rgba(255,255,255,0.07)] dark:hover:border-white/20 dark:hover:shadow-[0_24px_60px_-38px_rgba(0,0,0,0.86),inset_0_1px_0_rgba(255,255,255,0.09)]",
       )}
     >
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-95 transition-opacity duration-300 group-hover:opacity-100"
+        className="pointer-events-none absolute inset-0 opacity-85 transition-opacity duration-300 group-hover:opacity-95"
         style={{ background: palette.gradient }}
-      />
-      <div
-        aria-hidden
-        className="pointer-events-none absolute -right-10 top-1/2 h-40 w-40 -translate-y-1/2 rounded-full opacity-70 blur-3xl transition-[opacity,scale] duration-500 motion-reduce:transition-none motion-safe:group-hover:scale-110 group-hover:opacity-95"
-        style={{ background: palette.spotlight }}
       />
       <CardHeader className="relative flex flex-row items-center justify-between gap-0 pb-2">
         <CardDescription className="flex min-h-8 min-w-0 flex-1 items-center pr-3 text-xs font-semibold leading-4 tracking-[0.04em] text-muted-foreground/90">
           {title}
         </CardDescription>
         <span
-          className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 backdrop-blur-md transition-transform duration-300 motion-reduce:transition-none motion-safe:group-hover:scale-105 motion-safe:group-hover:-rotate-3 dark:border-white/10"
+          className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 dark:border-white/10"
           style={{
             color: palette.iconColor,
             background: palette.iconBackground,

--- a/web-ui/src/components/status/stat-card.tsx
+++ b/web-ui/src/components/status/stat-card.tsx
@@ -1,3 +1,4 @@
+import { clsx } from "clsx";
 import type { ComponentType } from "react";
 import { Card, CardContent, CardDescription, CardHeader } from "../ui/card";
 
@@ -11,40 +12,44 @@ const STAT_CARD_TONES: Record<
     iconShadow: string;
     gradient: string;
     spotlight: string;
-    cardShadow: string;
+    cardShadowClass: string;
   }
 > = {
   violet: {
-    iconColor: "hsl(262 83% 62%)",
+    iconColor: "hsl(262 83% 58%)",
     iconBackground: "hsla(262, 83%, 62%, 0.14)",
-    iconShadow: "0 12px 30px -24px rgba(139, 92, 246, 0.45)",
-    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(139, 92, 246, 0.18), transparent 70%)",
-    spotlight: "radial-gradient(80% 80% at 85% 120%, rgba(139, 92, 246, 0.14), transparent 70%)",
-    cardShadow: "0 9px 36px -30px rgba(139, 92, 246, 0.5)",
+    iconShadow: "0 10px 28px -14px rgba(139, 92, 246, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
+    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(139, 92, 246, 0.22), transparent 66%)",
+    spotlight: "radial-gradient(70% 90% at 88% 115%, rgba(99, 102, 241, 0.2), transparent 72%)",
+    cardShadowClass:
+      "shadow-[0_18px_50px_-36px_rgba(124,58,237,0.78)] hover:shadow-[0_24px_60px_-34px_rgba(124,58,237,0.9)]",
   },
   emerald: {
-    iconColor: "hsl(152 76% 38%)",
+    iconColor: "hsl(158 72% 38%)",
     iconBackground: "hsla(152, 76%, 38%, 0.14)",
-    iconShadow: "0 12px 30px -22px rgba(16, 185, 129, 0.45)",
-    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(16, 185, 129, 0.18), transparent 70%)",
-    spotlight: "radial-gradient(80% 80% at 85% 120%, rgba(16, 185, 129, 0.14), transparent 70%)",
-    cardShadow: "0 9px 36px -30px rgba(16, 185, 129, 0.45)",
+    iconShadow: "0 10px 28px -14px rgba(16, 185, 129, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
+    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(16, 185, 129, 0.2), transparent 66%)",
+    spotlight: "radial-gradient(70% 90% at 88% 115%, rgba(6, 182, 212, 0.18), transparent 72%)",
+    cardShadowClass:
+      "shadow-[0_18px_50px_-36px_rgba(16,185,129,0.72)] hover:shadow-[0_24px_60px_-34px_rgba(16,185,129,0.84)]",
   },
   sky: {
     iconColor: "hsl(197 92% 45%)",
     iconBackground: "hsla(197, 92%, 45%, 0.16)",
-    iconShadow: "0 12px 30px -22px rgba(14, 165, 233, 0.45)",
-    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(14, 165, 233, 0.18), transparent 70%)",
-    spotlight: "radial-gradient(80% 80% at 85% 120%, rgba(14, 165, 233, 0.14), transparent 70%)",
-    cardShadow: "0 9px 36px -30px rgba(14, 165, 233, 0.45)",
+    iconShadow: "0 10px 28px -14px rgba(14, 165, 233, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
+    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(14, 165, 233, 0.21), transparent 66%)",
+    spotlight: "radial-gradient(70% 90% at 88% 115%, rgba(59, 130, 246, 0.18), transparent 72%)",
+    cardShadowClass:
+      "shadow-[0_18px_50px_-36px_rgba(14,165,233,0.72)] hover:shadow-[0_24px_60px_-34px_rgba(14,165,233,0.84)]",
   },
   amber: {
-    iconColor: "hsl(38 92% 50%)",
+    iconColor: "hsl(35 92% 47%)",
     iconBackground: "hsla(38, 92%, 50%, 0.18)",
-    iconShadow: "0 12px 30px -22px rgba(245, 158, 11, 0.45)",
-    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(245, 158, 11, 0.18), transparent 70%)",
-    spotlight: "radial-gradient(80% 80% at 85% 120%, rgba(245, 158, 11, 0.16), transparent 70%)",
-    cardShadow: "0 9px 36px -30px rgba(245, 158, 11, 0.45)",
+    iconShadow: "0 10px 28px -14px rgba(245, 158, 11, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
+    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(245, 158, 11, 0.2), transparent 66%)",
+    spotlight: "radial-gradient(70% 90% at 88% 115%, rgba(249, 115, 22, 0.17), transparent 72%)",
+    cardShadowClass:
+      "shadow-[0_18px_50px_-36px_rgba(245,158,11,0.7)] hover:shadow-[0_24px_60px_-34px_rgba(245,158,11,0.82)]",
   },
 } as const;
 
@@ -59,34 +64,38 @@ export function StatCard({ title, value, icon: Icon, tone = "violet" }: StatCard
   const palette = STAT_CARD_TONES[tone];
   return (
     <Card
-      className="relative overflow-hidden border border-border/40 bg-card/95 transition-[translate,box-shadow] duration-200 hover:-translate-y-0.5 hover:shadow-lg"
-      style={{ boxShadow: palette.cardShadow }}
+      className={clsx(
+        "group relative overflow-hidden rounded-2xl border border-border/45 bg-card/75 backdrop-blur-xl backdrop-saturate-150 transition-[translate,box-shadow,border-color] duration-300 motion-reduce:transition-none motion-safe:hover:-translate-y-1 hover:border-white/60 dark:border-white/10 dark:bg-card/65 dark:hover:border-white/20",
+        palette.cardShadowClass,
+      )}
     >
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-90"
+        className="pointer-events-none absolute inset-0 opacity-95 transition-opacity duration-300 group-hover:opacity-100"
         style={{ background: palette.gradient }}
       />
       <div
         aria-hidden
-        className="pointer-events-none absolute -right-12 top-1/2 h-36 w-36 -translate-y-1/2 rounded-full blur-3xl opacity-60"
+        className="pointer-events-none absolute -right-10 top-1/2 h-40 w-40 -translate-y-1/2 rounded-full opacity-70 blur-3xl transition-[opacity,scale] duration-500 motion-reduce:transition-none motion-safe:group-hover:scale-110 group-hover:opacity-95"
         style={{ background: palette.spotlight }}
       />
-      <CardHeader className="relative flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardDescription className="text-sm font-medium text-muted-foreground">{title}</CardDescription>
+      <CardHeader className="relative flex flex-row items-center justify-between gap-0 pb-2">
+        <CardDescription className="flex min-h-8 min-w-0 flex-1 items-center pr-3 text-xs font-semibold leading-4 tracking-[0.04em] text-muted-foreground/90">
+          {title}
+        </CardDescription>
         <span
-          className="flex h-10 w-10 items-center justify-center rounded-full backdrop-blur-sm"
+          className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 backdrop-blur-md transition-transform duration-300 motion-reduce:transition-none motion-safe:group-hover:scale-105 motion-safe:group-hover:-rotate-3 dark:border-white/10"
           style={{
             color: palette.iconColor,
             background: palette.iconBackground,
             boxShadow: palette.iconShadow,
           }}
         >
-          <Icon className="h-4 w-4" />
+          <Icon className="h-5 w-5" />
         </span>
       </CardHeader>
       <CardContent className="relative">
-        <p className="text-3xl font-semibold tracking-tight text-card-foreground">{value}</p>
+        <p className="text-3xl font-semibold tracking-[-0.04em] text-card-foreground tabular-nums">{value}</p>
       </CardContent>
     </Card>
   );

--- a/web-ui/src/components/status/stat-card.tsx
+++ b/web-ui/src/components/status/stat-card.tsx
@@ -4,40 +4,24 @@ import { Card, CardContent, CardDescription, CardHeader } from "../ui/card";
 
 export type StatTone = "violet" | "emerald" | "sky" | "amber";
 
-const STAT_CARD_TONES: Record<
-  StatTone,
-  {
-    iconColor: string;
-    iconBackground: string;
-    iconShadow: string;
-    gradient: string;
-  }
-> = {
-  violet: {
-    iconColor: "hsl(262 83% 58%)",
-    iconBackground: "hsla(262, 83%, 62%, 0.14)",
-    iconShadow: "0 10px 28px -14px rgba(139, 92, 246, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
-    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(139, 92, 246, 0.22), transparent 66%)",
-  },
-  emerald: {
-    iconColor: "hsl(158 72% 38%)",
-    iconBackground: "hsla(152, 76%, 38%, 0.14)",
-    iconShadow: "0 10px 28px -14px rgba(16, 185, 129, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
-    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(16, 185, 129, 0.2), transparent 66%)",
-  },
-  sky: {
-    iconColor: "hsl(197 92% 45%)",
-    iconBackground: "hsla(197, 92%, 45%, 0.16)",
-    iconShadow: "0 10px 28px -14px rgba(14, 165, 233, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
-    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(14, 165, 233, 0.21), transparent 66%)",
-  },
-  amber: {
-    iconColor: "hsl(35 92% 47%)",
-    iconBackground: "hsla(38, 92%, 50%, 0.18)",
-    iconShadow: "0 10px 28px -14px rgba(245, 158, 11, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35)",
-    gradient: "radial-gradient(120% 120% at 0% 0%, rgba(245, 158, 11, 0.2), transparent 66%)",
-  },
-} as const;
+const STAT_CARD_TONES = {
+  violet: [
+    "bg-[radial-gradient(120%_120%_at_0%_0%,rgba(139,92,246,0.22),transparent_66%)]",
+    "bg-violet-500/14 text-violet-600 shadow-[0_10px_28px_-14px_rgba(139,92,246,0.55),inset_0_1px_0_rgba(255,255,255,0.35)]",
+  ],
+  emerald: [
+    "bg-[radial-gradient(120%_120%_at_0%_0%,rgba(16,185,129,0.2),transparent_66%)]",
+    "bg-emerald-500/14 text-emerald-600 shadow-[0_10px_28px_-14px_rgba(16,185,129,0.55),inset_0_1px_0_rgba(255,255,255,0.35)]",
+  ],
+  sky: [
+    "bg-[radial-gradient(120%_120%_at_0%_0%,rgba(14,165,233,0.21),transparent_66%)]",
+    "bg-sky-500/16 text-sky-600 shadow-[0_10px_28px_-14px_rgba(14,165,233,0.55),inset_0_1px_0_rgba(255,255,255,0.35)]",
+  ],
+  amber: [
+    "bg-[radial-gradient(120%_120%_at_0%_0%,rgba(245,158,11,0.2),transparent_66%)]",
+    "bg-amber-500/18 text-amber-600 shadow-[0_10px_28px_-14px_rgba(245,158,11,0.55),inset_0_1px_0_rgba(255,255,255,0.35)]",
+  ],
+} as const satisfies Record<StatTone, readonly [string, string]>;
 
 interface StatCardProps {
   title: string;
@@ -47,7 +31,7 @@ interface StatCardProps {
 }
 
 export function StatCard({ title, value, icon: Icon, tone = "violet" }: StatCardProps) {
-  const palette = STAT_CARD_TONES[tone];
+  const [glowClass, iconClass] = STAT_CARD_TONES[tone];
   return (
     <Card
       className={clsx(
@@ -56,20 +40,20 @@ export function StatCard({ title, value, icon: Icon, tone = "violet" }: StatCard
     >
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-85 transition-opacity duration-300 group-hover:opacity-95"
-        style={{ background: palette.gradient }}
+        className={clsx(
+          "pointer-events-none absolute inset-0 opacity-85 transition-opacity duration-300 group-hover:opacity-95",
+          glowClass,
+        )}
       />
       <CardHeader className="relative flex flex-row items-center justify-between gap-0 pb-2">
         <CardDescription className="flex min-h-8 min-w-0 flex-1 items-center pr-3 text-xs font-semibold leading-4 tracking-[0.04em] text-muted-foreground/90">
           {title}
         </CardDescription>
         <span
-          className="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 dark:border-white/10"
-          style={{
-            color: palette.iconColor,
-            background: palette.iconBackground,
-            boxShadow: palette.iconShadow,
-          }}
+          className={clsx(
+            "flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 dark:border-white/10",
+            iconClass,
+          )}
         >
           <Icon className="h-5 w-5" />
         </span>

--- a/web-ui/src/components/status/status-header.tsx
+++ b/web-ui/src/components/status/status-header.tsx
@@ -7,6 +7,7 @@ import type { Locale } from "../../lib/locale";
 import type { BandwidthUnit, ThemeMode } from "../../types/ui";
 import { Badge } from "../ui/badge";
 import { SelectBox } from "../ui/select-box";
+import { STATUS_CONTROL_GROUP_CLASS, STATUS_PANEL_CLASS } from "./classnames";
 
 interface StatusHeaderProps {
   statusAccent: string;
@@ -45,16 +46,17 @@ function HeaderSelect<T extends string>({
   value,
   onChange,
   options,
-  containerClassName = "min-w-[140px]",
+  containerClassName = "md:min-w-[128px]",
 }: HeaderSelectProps<T>) {
   return (
-    <div className="flex items-center gap-2">
-      {icon}
-      <span className="hidden text-xs font-semibold uppercase tracking-wide md:inline">{label}</span>
+    <div className={clsx("group flex w-full items-center gap-1.5 md:w-auto md:shrink-0", STATUS_CONTROL_GROUP_CLASS)}>
+      <span className="shrink-0 text-primary/75 transition-colors group-hover:text-primary">{icon}</span>
+      <span className="hidden whitespace-nowrap text-xs font-semibold tracking-[0.06em] xl:inline">{label}</span>
       <SelectBox
         value={value}
         onChange={(event) => onChange(event.target.value as T)}
-        containerClassName={containerClassName}
+        containerClassName={clsx("min-w-0 flex-1 md:flex-none", containerClassName)}
+        className="border-border/40 bg-background/60 shadow-none transition-colors hover:border-primary/30"
         aria-label={label}
       >
         {options.map((option) => (
@@ -86,55 +88,63 @@ export function StatusHeader({
   const t = useStatusTranslation(locale);
   const themeSelectOptions = themeOptions.map((option) => ({ value: option, label: t(themeLabels[option]) }));
   return (
-    <header className="rounded-3xl border border-border/60 bg-card/85 p-4 shadow-sm backdrop-blur">
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+    <header
+      className={clsx(STATUS_PANEL_CLASS, "overflow-hidden p-4 sm:p-5")}
+      style={{
+        backgroundImage:
+          "radial-gradient(circle at 0% 0%, rgba(99, 102, 241, 0.14), transparent 36%), radial-gradient(circle at 92% -20%, rgba(14, 165, 233, 0.12), transparent 34%)",
+      }}
+    >
+      <div className="relative flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-3">
-          <div className="flex flex-wrap items-center gap-2 text-sm">
-            <span className={clsx("inline-flex items-center gap-2 font-medium", statusAccent)}>
+          <div className="flex min-h-11 flex-wrap items-center gap-2 text-sm">
+            <span
+              className={clsx(
+                "inline-flex h-9 items-center gap-2 whitespace-nowrap rounded-full border px-3 text-xs font-semibold tracking-wide",
+                statusAccent,
+              )}
+            >
               <Wifi className="h-4 w-4" />
               {statusLabel}
             </span>
-            <Badge variant="outline" className="border-border/60">
-              {t("lastUpdated")}: {lastUpdated}
+            <Badge
+              variant="outline"
+              className="h-9 whitespace-nowrap border-border/50 bg-background/45 px-3 font-medium text-muted-foreground shadow-sm backdrop-blur-md dark:border-white/10"
+            >
+              {t("lastUpdated")}: <span className="ml-1 font-mono tabular-nums">{lastUpdated}</span>
             </Badge>
           </div>
           <div className="space-y-1">
             <p className="text-sm text-muted-foreground">
-              {t("uptime")}: {uptime}
+              {t("uptime")}: <span className="font-mono font-medium tabular-nums text-foreground/85">{uptime}</span>
             </p>
             <p className="text-sm text-muted-foreground">
-              {t("version")}: {version}
+              {t("version")}: <span className="font-mono font-medium text-foreground/85">{version}</span>
             </p>
           </div>
         </div>
-        <div className="flex flex-col gap-2 text-sm text-muted-foreground md:flex-row md:flex-wrap md:items-start lg:justify-end">
+        <div className="flex flex-col gap-2 text-sm text-muted-foreground md:flex-row md:flex-wrap md:items-start lg:flex-nowrap lg:justify-end">
           <HeaderSelect
-            icon={<Globe className="h-4 w-4 text-muted-foreground" />}
+            icon={<Globe className="h-4 w-4" />}
             label={t("language")}
             value={locale}
             onChange={onLocaleChange}
             options={localeOptions}
           />
           <HeaderSelect
-            icon={
-              theme === "dark" ? (
-                <Moon className="h-4 w-4 text-muted-foreground" />
-              ) : (
-                <Sun className="h-4 w-4 text-muted-foreground" />
-              )
-            }
+            icon={theme === "dark" ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
             label={t("appearance")}
             value={theme}
             onChange={onThemeChange}
             options={themeSelectOptions}
           />
           <HeaderSelect
-            icon={<Activity className="h-4 w-4 text-muted-foreground" />}
+            icon={<Activity className="h-4 w-4" />}
             label={t("bandwidthUnit")}
             value={bandwidthUnit}
             onChange={onBandwidthUnitChange}
             options={BANDWIDTH_UNIT_OPTIONS}
-            containerClassName="min-w-[120px]"
+            containerClassName="md:min-w-[108px]"
           />
         </div>
       </div>

--- a/web-ui/src/components/status/status-header.tsx
+++ b/web-ui/src/components/status/status-header.tsx
@@ -58,7 +58,7 @@ function HeaderSelect<T extends string>({
         value={value}
         onChange={(event) => onChange(event.target.value as T)}
         containerClassName={clsx("min-w-0 flex-1 md:flex-none", containerClassName)}
-        className="border-border/40 bg-background/60 shadow-none transition-colors hover:border-primary/30"
+        className="border-border/40 bg-background/70 shadow-none backdrop-blur-none transition-colors hover:border-primary/30"
         aria-label={label}
       >
         {options.map((option) => (

--- a/web-ui/src/components/status/status-header.tsx
+++ b/web-ui/src/components/status/status-header.tsx
@@ -50,7 +50,9 @@ function HeaderSelect<T extends string>({
 }: HeaderSelectProps<T>) {
   return (
     <div className={clsx("group flex w-full items-center gap-1.5 md:w-auto md:shrink-0", STATUS_CONTROL_GROUP_CLASS)}>
-      <span className="shrink-0 text-primary/75 transition-colors group-hover:text-primary">{icon}</span>
+      <span className="flex size-6 shrink-0 items-center justify-center text-primary/75 transition-colors group-hover:text-primary">
+        {icon}
+      </span>
       <span className="hidden whitespace-nowrap text-xs font-semibold tracking-[0.06em] xl:inline">{label}</span>
       <SelectBox
         value={value}

--- a/web-ui/src/components/status/status-header.tsx
+++ b/web-ui/src/components/status/status-header.tsx
@@ -91,11 +91,10 @@ export function StatusHeader({
   const themeSelectOptions = themeOptions.map((option) => ({ value: option, label: t(themeLabels[option]) }));
   return (
     <header
-      className={clsx(STATUS_PANEL_CLASS, "overflow-hidden p-4 sm:p-5")}
-      style={{
-        backgroundImage:
-          "radial-gradient(circle at 0% 0%, rgba(99, 102, 241, 0.14), transparent 36%), radial-gradient(circle at 92% -20%, rgba(14, 165, 233, 0.12), transparent 34%)",
-      }}
+      className={clsx(
+        STATUS_PANEL_CLASS,
+        "overflow-hidden bg-[radial-gradient(circle_at_0%_0%,rgba(99,102,241,0.14),transparent_36%),radial-gradient(circle_at_92%_-20%,rgba(14,165,233,0.12),transparent_34%)] p-4 sm:p-5",
+      )}
     >
       <div className="relative flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-3">

--- a/web-ui/src/components/status/workers-section.tsx
+++ b/web-ui/src/components/status/workers-section.tsx
@@ -82,7 +82,7 @@ export function WorkersSection({ workers, locale, bandwidthUnit }: WorkersSectio
             return (
               <Card
                 key={worker.id}
-                className="overflow-hidden rounded-2xl border border-border/50 bg-card/65 shadow-[0_18px_46px_-34px_rgba(15,23,42,0.55)] backdrop-blur-lg dark:border-white/8 dark:bg-white/3 dark:shadow-[0_22px_52px_-34px_rgba(0,0,0,0.8)]"
+                className="overflow-hidden rounded-2xl border border-border/50 bg-card/72 shadow-[0_16px_42px_-34px_rgba(15,23,42,0.46)] dark:border-white/8 dark:bg-white/4 dark:shadow-[0_20px_48px_-36px_rgba(0,0,0,0.68)]"
               >
                 <CardHeader className="pb-4">
                   <div className="flex items-start justify-between gap-4">

--- a/web-ui/src/components/status/workers-section.tsx
+++ b/web-ui/src/components/status/workers-section.tsx
@@ -38,47 +38,15 @@ export function WorkersSection({ workers, locale, bandwidthUnit }: WorkersSectio
         <div className={clsx("grid gap-6", workers.length > 1 && "lg:grid-cols-2")}>
           {workers.map((worker) => {
             const metrics = [
-              {
-                key: "bandwidth",
-                label: t("bandwidth"),
-                value: formatBandwidth(worker.totalBandwidth, bandwidthUnit),
-              },
-              {
-                key: "dataSent",
-                label: t("dataSent"),
-                value: formatBytes(worker.totalBytes),
-              },
-              {
-                key: "sendTotal",
-                label: t("sendTotal"),
-                value: worker.send.total.toLocaleString(),
-              },
-              {
-                key: "sendCompletions",
-                label: t("sendCompletions"),
-                value: worker.send.completions.toLocaleString(),
-              },
-              {
-                key: "sendCopied",
-                label: t("sendCopied"),
-                value: worker.send.copied.toLocaleString(),
-              },
-              {
-                key: "sendBatch",
-                label: t("sendBatch"),
-                value: worker.send.batch.toLocaleString(),
-              },
-              {
-                key: "sendEagain",
-                label: t("sendEagain"),
-                value: worker.send.eagain.toLocaleString(),
-              },
-              {
-                key: "sendEnobufs",
-                label: t("sendEnobufs"),
-                value: worker.send.enobufs.toLocaleString(),
-              },
-            ];
+              ["bandwidth", t("bandwidth"), formatBandwidth(worker.totalBandwidth, bandwidthUnit)],
+              ["dataSent", t("dataSent"), formatBytes(worker.totalBytes)],
+              ["sendTotal", t("sendTotal"), worker.send.total.toLocaleString()],
+              ["sendCompletions", t("sendCompletions"), worker.send.completions.toLocaleString()],
+              ["sendCopied", t("sendCopied"), worker.send.copied.toLocaleString()],
+              ["sendBatch", t("sendBatch"), worker.send.batch.toLocaleString()],
+              ["sendEagain", t("sendEagain"), worker.send.eagain.toLocaleString()],
+              ["sendEnobufs", t("sendEnobufs"), worker.send.enobufs.toLocaleString()],
+            ] as const;
             return (
               <Card
                 key={worker.id}
@@ -102,17 +70,17 @@ export function WorkersSection({ workers, locale, bandwidthUnit }: WorkersSectio
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
-                    {metrics.map((metric) => (
+                    {metrics.map(([key, label, value]) => (
                       <div
-                        key={metric.key}
+                        key={key}
                         className={clsx(
                           STATUS_METRIC_TILE_CLASS,
                           "flex min-h-9 items-center justify-between gap-3 px-3 py-2 transition-colors hover:border-primary/15 hover:bg-primary/3",
                         )}
                       >
-                        <span className="min-w-0 font-medium leading-4 text-muted-foreground/80">{metric.label}</span>
+                        <span className="min-w-0 font-medium leading-4 text-muted-foreground/80">{label}</span>
                         <span className="shrink-0 text-right font-mono font-medium text-card-foreground tabular-nums">
-                          {metric.value}
+                          {value}
                         </span>
                       </div>
                     ))}
@@ -142,13 +110,13 @@ function PoolCard({ title, pool, locale }: PoolCardProps) {
   const t = useStatusTranslation(locale);
   const utilization = Math.min(100, Math.max(0, pool.utilization));
   const metrics = [
-    { key: "total", label: t("poolTotal"), value: pool.total },
-    { key: "free", label: t("poolFree"), value: pool.free },
-    { key: "used", label: t("poolUsed"), value: pool.used },
-    { key: "max", label: t("poolMax"), value: pool.max },
-    { key: "expansions", label: t("poolExpansions"), value: pool.expansions },
-    { key: "exhaustions", label: t("poolExhaustions"), value: pool.exhaustions },
-  ];
+    ["total", t("poolTotal"), pool.total],
+    ["free", t("poolFree"), pool.free],
+    ["used", t("poolUsed"), pool.used],
+    ["max", t("poolMax"), pool.max],
+    ["expansions", t("poolExpansions"), pool.expansions],
+    ["exhaustions", t("poolExhaustions"), pool.exhaustions],
+  ] as const;
   const indicatorClassName =
     utilization >= 90
       ? "bg-gradient-to-r from-rose-400 to-rose-500 shadow-[0_0_12px_rgba(244,63,94,0.45)]"
@@ -167,10 +135,10 @@ function PoolCard({ title, pool, locale }: PoolCardProps) {
         indicatorClassName={indicatorClassName}
       />
       <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-muted-foreground">
-        {metrics.map((metric) => (
-          <div key={metric.key} className="flex min-w-0 items-baseline justify-between gap-2">
-            <span className="min-w-0 leading-4">{metric.label}</span>
-            <span className="shrink-0 font-mono text-foreground/75 tabular-nums">{metric.value}</span>
+        {metrics.map(([key, label, value]) => (
+          <div key={key} className="flex min-w-0 items-baseline justify-between gap-2">
+            <span className="min-w-0 leading-4">{label}</span>
+            <span className="shrink-0 font-mono text-foreground/75 tabular-nums">{value}</span>
           </div>
         ))}
       </div>

--- a/web-ui/src/components/status/workers-section.tsx
+++ b/web-ui/src/components/status/workers-section.tsx
@@ -8,6 +8,12 @@ import { Badge } from "../ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import { Progress } from "../ui/progress";
 import { Separator } from "../ui/separator";
+import {
+  STATUS_INSET_CLASS,
+  STATUS_METRIC_TILE_CLASS,
+  STATUS_PANEL_CLASS,
+  STATUS_SECTION_TITLE_CLASS,
+} from "./classnames";
 
 interface WorkersSectionProps {
   workers: WorkerEntry[];
@@ -18,14 +24,16 @@ interface WorkersSectionProps {
 export function WorkersSection({ workers, locale, bandwidthUnit }: WorkersSectionProps) {
   const t = useStatusTranslation(locale);
   return (
-    <section className="rounded-3xl border border-border/60 bg-card/90 p-6 shadow-sm">
-      <div className="mb-4 flex items-center justify-between">
+    <section className={clsx(STATUS_PANEL_CLASS, "p-5 sm:p-6")}>
+      <div className="mb-5 flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold tracking-tight text-card-foreground">{t("workerStats")}</h2>
+          <h2 className={STATUS_SECTION_TITLE_CLASS}>{t("workerStats")}</h2>
         </div>
       </div>
       {workers.length === 0 ? (
-        <div className="rounded-2xl border border-dashed p-6 text-sm text-muted-foreground">{t("noWorkerStats")}</div>
+        <div className={clsx(STATUS_INSET_CLASS, "border-dashed p-6 text-sm text-muted-foreground")}>
+          {t("noWorkerStats")}
+        </div>
       ) : (
         <div className={clsx("grid gap-6", workers.length > 1 && "lg:grid-cols-2")}>
           {workers.map((worker) => {
@@ -72,33 +80,44 @@ export function WorkersSection({ workers, locale, bandwidthUnit }: WorkersSectio
               },
             ];
             return (
-              <Card key={worker.id} className="border border-border/60 bg-card/95">
+              <Card
+                key={worker.id}
+                className="overflow-hidden rounded-2xl border border-border/50 bg-card/65 shadow-[0_18px_46px_-34px_rgba(15,23,42,0.55)] backdrop-blur-lg dark:border-white/8 dark:bg-white/3 dark:shadow-[0_22px_52px_-34px_rgba(0,0,0,0.8)]"
+              >
                 <CardHeader className="pb-4">
                   <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <CardTitle className="text-lg">Worker #{worker.id}</CardTitle>
+                    <div className="min-w-0">
+                      <CardTitle className="text-lg tracking-[-0.02em]">Worker #{worker.id}</CardTitle>
                       <CardDescription>
-                        {t("workerPid")}: {worker.pid}
+                        {t("workerPid")}: <span className="font-mono tabular-nums">{worker.pid}</span>
                       </CardDescription>
                     </div>
-                    <Badge variant="secondary">
+                    <Badge
+                      variant={null}
+                      className="shrink-0 whitespace-nowrap border border-violet-500/20 bg-violet-500/10 px-3 py-1 text-violet-700 shadow-[0_0_18px_-10px_rgba(139,92,246,0.9)] dark:text-violet-300"
+                    >
                       {worker.activeClients} {t("clientsPerWorker")}
                     </Badge>
                   </div>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  <div className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+                  <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
                     {metrics.map((metric) => (
                       <div
                         key={metric.key}
-                        className="flex items-center justify-between gap-2 rounded-lg bg-muted/20 px-3 py-2"
+                        className={clsx(
+                          STATUS_METRIC_TILE_CLASS,
+                          "flex min-h-9 items-center justify-between gap-3 px-3 py-2 transition-colors hover:border-primary/15 hover:bg-primary/3",
+                        )}
                       >
-                        <span className="font-medium text-muted-foreground/80">{metric.label}</span>
-                        <span className="text-right font-medium text-card-foreground">{metric.value}</span>
+                        <span className="min-w-0 font-medium leading-4 text-muted-foreground/80">{metric.label}</span>
+                        <span className="shrink-0 text-right font-mono font-medium text-card-foreground tabular-nums">
+                          {metric.value}
+                        </span>
                       </div>
                     ))}
                   </div>
-                  <Separator />
+                  <Separator className="bg-border/50 dark:bg-white/8" />
                   <div className="grid gap-4 md:grid-cols-2">
                     <PoolCard title={t("bufferPool")} pool={worker.pool} locale={locale} />
                     <PoolCard title={t("controlPool")} pool={worker.controlPool} locale={locale} />
@@ -122,32 +141,38 @@ interface PoolCardProps {
 function PoolCard({ title, pool, locale }: PoolCardProps) {
   const t = useStatusTranslation(locale);
   const utilization = Math.min(100, Math.max(0, pool.utilization));
+  const metrics = [
+    { key: "total", label: t("poolTotal"), value: pool.total },
+    { key: "free", label: t("poolFree"), value: pool.free },
+    { key: "used", label: t("poolUsed"), value: pool.used },
+    { key: "max", label: t("poolMax"), value: pool.max },
+    { key: "expansions", label: t("poolExpansions"), value: pool.expansions },
+    { key: "exhaustions", label: t("poolExhaustions"), value: pool.exhaustions },
+  ];
+  const indicatorClassName =
+    utilization >= 90
+      ? "bg-gradient-to-r from-rose-400 to-rose-500 shadow-[0_0_12px_rgba(244,63,94,0.45)]"
+      : utilization >= 70
+        ? "bg-gradient-to-r from-amber-300 to-orange-500 shadow-[0_0_12px_rgba(245,158,11,0.4)]"
+        : "bg-gradient-to-r from-emerald-400 to-cyan-400 shadow-[0_0_12px_rgba(16,185,129,0.35)]";
   return (
-    <div className="space-y-2 rounded-xl border border-border/40 bg-muted/20 p-4">
+    <div className={clsx(STATUS_INSET_CLASS, "space-y-3 p-4")}>
       <div className="flex items-center justify-between text-sm font-medium text-muted-foreground">
         <span>{title}</span>
-        <span>{utilization.toFixed(1)}%</span>
+        <span className="font-mono text-foreground/80 tabular-nums">{utilization.toFixed(1)}%</span>
       </div>
-      <Progress value={utilization} indicatorClassName="bg-gradient-to-r from-emerald-400 via-amber-400 to-rose-500" />
-      <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
-        <span>
-          {t("poolTotal")}: {pool.total}
-        </span>
-        <span>
-          {t("poolFree")}: {pool.free}
-        </span>
-        <span>
-          {t("poolUsed")}: {pool.used}
-        </span>
-        <span>
-          {t("poolMax")}: {pool.max}
-        </span>
-        <span>
-          {t("poolExpansions")}: {pool.expansions}
-        </span>
-        <span>
-          {t("poolExhaustions")}: {pool.exhaustions}
-        </span>
+      <Progress
+        value={utilization}
+        className="h-1.5 bg-muted/70 shadow-inner"
+        indicatorClassName={indicatorClassName}
+      />
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-muted-foreground">
+        {metrics.map((metric) => (
+          <div key={metric.key} className="flex min-w-0 items-baseline justify-between gap-2">
+            <span className="min-w-0 leading-4">{metric.label}</span>
+            <span className="shrink-0 font-mono text-foreground/75 tabular-nums">{metric.value}</span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/web-ui/src/components/ui/badge.tsx
+++ b/web-ui/src/components/ui/badge.tsx
@@ -3,14 +3,14 @@ import { clsx } from "clsx";
 import type * as React from "react";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "ui-badge inline-flex items-center whitespace-nowrap px-2.5 py-1 text-[11px] font-semibold tracking-wide transition-[color,background-color,border-color,box-shadow] motion-reduce:transition-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
-        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        destructive: "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
+        default: "ui-badge--default",
+        secondary: "ui-badge--secondary",
+        destructive: "ui-badge--destructive",
+        outline: "ui-badge--outline",
       },
     },
     defaultVariants: {

--- a/web-ui/src/components/ui/badge.tsx
+++ b/web-ui/src/components/ui/badge.tsx
@@ -3,14 +3,16 @@ import { clsx } from "clsx";
 import type * as React from "react";
 
 const badgeVariants = cva(
-  "ui-badge inline-flex items-center whitespace-nowrap px-2.5 py-1 text-[11px] font-semibold tracking-wide transition-[color,background-color,border-color,box-shadow] motion-reduce:transition-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center whitespace-nowrap rounded-full border border-transparent px-2.5 py-1 text-[11px] font-semibold tracking-wide shadow-[0_4px_12px_-10px_rgba(15,23,42,0.35)] transition-[color,background-color,border-color,box-shadow] motion-reduce:transition-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default: "ui-badge--default",
-        secondary: "ui-badge--secondary",
-        destructive: "ui-badge--destructive",
-        outline: "ui-badge--outline",
+        default:
+          "border-primary/24 bg-primary/12 text-[hsl(252_72%_34%)] hover:bg-primary/18 dark:text-[hsl(250_100%_88%)]",
+        secondary: "border-border/70 bg-secondary/80 text-secondary-foreground hover:bg-secondary",
+        destructive:
+          "border-destructive/24 bg-destructive/12 text-[hsl(354_76%_34%)] hover:bg-destructive/18 dark:text-[hsl(350_100%_88%)]",
+        outline: "border-border/65 bg-background/35 text-foreground backdrop-blur-sm",
       },
     },
     defaultVariants: {

--- a/web-ui/src/components/ui/button.tsx
+++ b/web-ui/src/components/ui/button.tsx
@@ -3,16 +3,19 @@ import { clsx } from "clsx";
 import * as React from "react";
 
 const buttonVariants = cva(
-  "ui-button inline-flex items-center justify-center whitespace-nowrap text-sm font-semibold transition-[color,background-color,border-color,box-shadow,transform,filter] duration-200 motion-reduce:transition-none disabled:pointer-events-none disabled:opacity-45",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-[var(--radius)] border border-transparent text-sm font-semibold transition-[color,background-color,border-color,box-shadow,transform,filter] duration-200 motion-reduce:transition-none disabled:pointer-events-none disabled:opacity-45",
   {
     variants: {
       variant: {
-        default: "ui-button--default",
-        destructive: "ui-button--destructive",
-        outline: "ui-button--outline",
-        secondary: "ui-button--secondary",
-        ghost: "ui-button--ghost",
-        link: "ui-button--link",
+        default:
+          "border-primary/20 bg-primary text-primary-foreground shadow-[0_8px_20px_-10px_hsl(var(--primary)/0.55)] hover:bg-primary hover:shadow-[0_12px_26px_-10px_hsl(var(--primary)/0.68)] active:brightness-[0.94] motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0",
+        destructive:
+          "border-destructive/24 bg-destructive text-destructive-foreground shadow-[0_8px_20px_-10px_hsl(var(--destructive)/0.5)] hover:bg-destructive hover:brightness-[0.92] motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0",
+        outline:
+          "border-input/80 bg-secondary/90 text-foreground shadow-none hover:border-primary/30 hover:bg-accent hover:text-accent-foreground",
+        secondary: "border-border/60 bg-secondary/90 text-secondary-foreground shadow-none hover:bg-secondary",
+        ghost: "text-foreground hover:bg-accent/82 hover:text-accent-foreground active:bg-accent/82",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",

--- a/web-ui/src/components/ui/button.tsx
+++ b/web-ui/src/components/ui/button.tsx
@@ -3,21 +3,21 @@ import { clsx } from "clsx";
 import * as React from "react";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition disabled:pointer-events-none disabled:opacity-50",
+  "ui-button inline-flex items-center justify-center whitespace-nowrap text-sm font-semibold transition-[color,background-color,border-color,box-shadow,transform,filter] duration-200 motion-reduce:transition-none disabled:pointer-events-none disabled:opacity-45",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        outline: "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        default: "ui-button--default",
+        destructive: "ui-button--destructive",
+        outline: "ui-button--outline",
+        secondary: "ui-button--secondary",
+        ghost: "ui-button--ghost",
+        link: "ui-button--link",
       },
       size: {
         default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3",
-        lg: "h-10 rounded-md px-8",
+        sm: "h-8 rounded-lg px-3",
+        lg: "h-10 rounded-xl px-8",
         icon: "h-9 w-9",
       },
     },

--- a/web-ui/src/components/ui/card.tsx
+++ b/web-ui/src/components/ui/card.tsx
@@ -2,32 +2,40 @@ import { clsx } from "clsx";
 import * as React from "react";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={clsx("ui-card text-card-foreground", className)} {...props} />
+  <div ref={ref} className={clsx("rounded-2xl border text-card-foreground", className)} {...props} />
 ));
 Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={clsx("ui-card-header", className)} {...props} />,
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={clsx("flex flex-col gap-1.5 p-6", className)} {...props} />
+  ),
 );
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => <h3 ref={ref} className={clsx("ui-card-title", className)} {...props} />,
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={clsx("font-semibold text-2xl leading-none tracking-[-0.02em]", className)} {...props} />
+  ),
 );
 CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => <p ref={ref} className={clsx("ui-card-description", className)} {...props} />,
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={clsx("text-muted-foreground text-sm leading-5", className)} {...props} />
+  ),
 );
 CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={clsx("ui-card-content", className)} {...props} />,
+  ({ className, ...props }, ref) => <div ref={ref} className={clsx("px-6 pb-6", className)} {...props} />,
 );
 CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={clsx("ui-card-footer", className)} {...props} />,
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={clsx("flex items-center px-6 pb-6", className)} {...props} />
+  ),
 );
 CardFooter.displayName = "CardFooter";
 

--- a/web-ui/src/components/ui/card.tsx
+++ b/web-ui/src/components/ui/card.tsx
@@ -2,40 +2,32 @@ import { clsx } from "clsx";
 import * as React from "react";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
-  <div ref={ref} className={clsx("rounded-xl border bg-card text-card-foreground shadow", className)} {...props} />
+  <div ref={ref} className={clsx("ui-card text-card-foreground", className)} {...props} />
 ));
 Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={clsx("flex flex-col space-y-1.5 p-6", className)} {...props} />
-  ),
+  ({ className, ...props }, ref) => <div ref={ref} className={clsx("ui-card-header", className)} {...props} />,
 );
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={clsx("text-2xl font-semibold leading-none tracking-tight", className)} {...props} />
-  ),
+  ({ className, ...props }, ref) => <h3 ref={ref} className={clsx("ui-card-title", className)} {...props} />,
 );
 CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => (
-    <p ref={ref} className={clsx("text-sm text-muted-foreground", className)} {...props} />
-  ),
+  ({ className, ...props }, ref) => <p ref={ref} className={clsx("ui-card-description", className)} {...props} />,
 );
 CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={clsx("p-6 pt-0", className)} {...props} />,
+  ({ className, ...props }, ref) => <div ref={ref} className={clsx("ui-card-content", className)} {...props} />,
 );
 CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={clsx("flex items-center p-6 pt-0", className)} {...props} />
-  ),
+  ({ className, ...props }, ref) => <div ref={ref} className={clsx("ui-card-footer", className)} {...props} />,
 );
 CardFooter.displayName = "CardFooter";
 

--- a/web-ui/src/components/ui/progress.tsx
+++ b/web-ui/src/components/ui/progress.tsx
@@ -8,10 +8,17 @@ export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
   ({ className, value = 0, indicatorClassName, ...props }, ref) => (
-    <div ref={ref} className={clsx("ui-progress relative w-full overflow-hidden", className)} {...props}>
+    <div
+      ref={ref}
+      className={clsx(
+        "relative h-2 w-full overflow-hidden rounded-full bg-muted/90 shadow-[inset_0_1px_2px_rgba(15,23,42,0.12),inset_0_0_0_1px_hsl(var(--border)/0.3)]",
+        className,
+      )}
+      {...props}
+    >
       <div
         className={clsx(
-          "ui-progress-indicator h-full w-full flex-1 transition-transform duration-300 motion-reduce:transition-none",
+          "h-full w-full flex-1 rounded-full bg-primary shadow-[0_0_12px_hsl(var(--primary)/0.35)] transition-transform duration-300 motion-reduce:transition-none",
           indicatorClassName,
         )}
         style={{

--- a/web-ui/src/components/ui/progress.tsx
+++ b/web-ui/src/components/ui/progress.tsx
@@ -8,9 +8,12 @@ export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
   ({ className, value = 0, indicatorClassName, ...props }, ref) => (
-    <div ref={ref} className={clsx("relative h-2 w-full overflow-hidden rounded-full bg-muted", className)} {...props}>
+    <div ref={ref} className={clsx("ui-progress relative w-full overflow-hidden", className)} {...props}>
       <div
-        className={clsx("h-full w-full flex-1 rounded-full transition-transform", indicatorClassName)}
+        className={clsx(
+          "ui-progress-indicator h-full w-full flex-1 transition-transform duration-300 motion-reduce:transition-none",
+          indicatorClassName,
+        )}
         style={{
           transform: `translateX(-${100 - Math.max(0, Math.min(100, value))}%)`,
         }}

--- a/web-ui/src/components/ui/select-box.tsx
+++ b/web-ui/src/components/ui/select-box.tsx
@@ -11,7 +11,7 @@ export function SelectBox({ containerClassName = "min-w-[120px]", className, chi
     <div className={clsx("relative inline-flex items-center justify-end", containerClassName)}>
       <select
         className={clsx(
-          "ui-select peer h-9 w-full cursor-pointer appearance-none px-3 pr-10 text-sm text-foreground transition-[color,background-color,border-color,box-shadow] motion-reduce:transition-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          "peer h-9 w-full cursor-pointer appearance-none rounded-[var(--radius)] border border-input/80 bg-background/82 px-3 pr-10 font-semibold text-foreground text-sm shadow-none transition-[color,background-color,border-color,box-shadow] hover:border-primary/30 hover:bg-background/75 motion-reduce:transition-none focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 dark:bg-secondary/72",
           className,
         )}
         {...props}

--- a/web-ui/src/components/ui/select-box.tsx
+++ b/web-ui/src/components/ui/select-box.tsx
@@ -6,19 +6,19 @@ export interface SelectBoxProps extends SelectHTMLAttributes<HTMLSelectElement> 
   containerClassName?: string;
 }
 
-export function SelectBox({ containerClassName, className, children, ...props }: SelectBoxProps) {
+export function SelectBox({ containerClassName = "min-w-[120px]", className, children, ...props }: SelectBoxProps) {
   return (
-    <div className={clsx("relative inline-flex min-w-[120px] items-center justify-end", containerClassName)}>
+    <div className={clsx("relative inline-flex items-center justify-end", containerClassName)}>
       <select
         className={clsx(
-          "peer h-9 w-full appearance-none rounded-lg border border-input bg-background/90 px-3 pr-10 text-sm font-medium text-foreground shadow-sm transition focus:outline-none focus:ring-2 focus:ring-ring cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
+          "ui-select peer h-9 w-full cursor-pointer appearance-none px-3 pr-10 text-sm text-foreground transition-[color,background-color,border-color,box-shadow] motion-reduce:transition-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         {...props}
       >
         {children}
       </select>
-      <ChevronDown className="pointer-events-none absolute right-3 h-4 w-4 text-muted-foreground transition-transform duration-200 peer-focus:rotate-180" />
+      <ChevronDown className="pointer-events-none absolute right-3 h-4 w-4 text-muted-foreground transition-transform duration-200 peer-focus:rotate-180 peer-focus:text-primary" />
     </div>
   );
 }

--- a/web-ui/src/components/ui/separator.tsx
+++ b/web-ui/src/components/ui/separator.tsx
@@ -3,7 +3,14 @@ import * as React from "react";
 
 const Separator = React.forwardRef<HTMLHRElement, React.HTMLAttributes<HTMLHRElement>>(
   ({ className, ...props }, ref) => (
-    <hr ref={ref} className={clsx("shrink-0 border-0 bg-border", "h-px w-full", className)} {...props} />
+    <hr
+      ref={ref}
+      className={clsx(
+        "h-px w-full shrink-0 border-0 bg-linear-to-r from-transparent via-border/80 to-transparent",
+        className,
+      )}
+      {...props}
+    />
   ),
 );
 Separator.displayName = "Separator";

--- a/web-ui/src/components/ui/switch.tsx
+++ b/web-ui/src/components/ui/switch.tsx
@@ -31,8 +31,8 @@ export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
         onClick={toggle}
         onKeyDown={handleKeyDown}
         className={clsx(
-          "ui-switch relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border transition-[background-color,border-color,box-shadow] duration-200 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-50",
-          checked ? "ui-switch--checked" : "ui-switch--unchecked",
+          "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border shadow-[inset_0_1px_3px_rgba(15,23,42,0.16)] transition-[background-color,border-color,box-shadow] duration-200 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-50",
+          checked ? "border-primary/30 bg-primary" : "border-input/80 bg-muted/90",
           className,
         )}
         {...props}

--- a/web-ui/src/components/ui/switch.tsx
+++ b/web-ui/src/components/ui/switch.tsx
@@ -31,15 +31,15 @@ export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
         onClick={toggle}
         onKeyDown={handleKeyDown}
         className={clsx(
-          "relative shrink-0 inline-flex h-6 w-11 items-center rounded-full border border-input bg-input transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
-          checked ? "bg-primary" : "bg-input",
+          "ui-switch relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border transition-[background-color,border-color,box-shadow] duration-200 motion-reduce:transition-none disabled:cursor-not-allowed disabled:opacity-50",
+          checked ? "ui-switch--checked" : "ui-switch--unchecked",
           className,
         )}
         {...props}
       >
         <span
           className={clsx(
-            "ml-0.5 inline-block h-5 w-5 rounded-full bg-background shadow transition-transform",
+            "ml-0.5 inline-block h-5 w-5 rounded-full bg-white shadow-md ring-1 ring-black/5 transition-transform duration-200 motion-reduce:transition-none",
             checked ? "translate-x-5" : "translate-x-0",
           )}
         />

--- a/web-ui/src/components/ui/table.tsx
+++ b/web-ui/src/components/ui/table.tsx
@@ -11,7 +11,9 @@ const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableE
 Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
-  ({ className, ...props }, ref) => <thead ref={ref} className={clsx("[&_tr]:border-b", className)} {...props} />,
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={clsx("bg-muted/35 [&_tr]:border-b", className)} {...props} />
+  ),
 );
 TableHeader.displayName = "TableHeader";
 
@@ -34,7 +36,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
     <tr
       ref={ref}
       className={clsx(
-        "border-b border-border/60 transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        "border-b border-border/45 transition-colors hover:bg-primary/4 data-[state=selected]:bg-primary/7",
         className,
       )}
       {...props}
@@ -47,7 +49,10 @@ const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<
   ({ className, ...props }, ref) => (
     <th
       ref={ref}
-      className={clsx("h-9 px-4 text-left align-middle font-medium text-muted-foreground", className)}
+      className={clsx(
+        "h-10 px-4 text-left align-middle text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground",
+        className,
+      )}
       {...props}
     />
   ),
@@ -55,7 +60,9 @@ const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<
 TableHead.displayName = "TableHead";
 
 const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
-  ({ className, ...props }, ref) => <td ref={ref} className={clsx("p-4 align-top", className)} {...props} />,
+  ({ className, ...props }, ref) => (
+    <td ref={ref} className={clsx("p-4 align-top tabular-nums", className)} {...props} />
+  ),
 );
 TableCell.displayName = "TableCell";
 

--- a/web-ui/src/hooks/use-locale.ts
+++ b/web-ui/src/hooks/use-locale.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { detectBrowserLocale, type Locale, SUPPORTED_LOCALES } from "../lib/locale";
 import { usePersistedEnum } from "./use-persisted-enum";
 
@@ -8,5 +8,10 @@ export function useLocale(storageKey: string) {
     [],
   );
   const [locale, setLocale] = usePersistedEnum<Locale>(storageKey, browserLocale, SUPPORTED_LOCALES);
+
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
   return { locale, setLocale };
 }

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -201,10 +201,9 @@
 
   :where(.ui-button--outline) {
     border-color: hsl(var(--input) / 0.8);
-    background: hsl(var(--background) / 0.6);
+    background: hsl(var(--secondary) / 0.9);
     color: hsl(var(--foreground));
-    box-shadow: 0 4px 12px -8px rgba(15, 23, 42, 0.28);
-    backdrop-filter: blur(12px);
+    box-shadow: none;
   }
 
   :where(.ui-button--outline:hover) {
@@ -215,9 +214,9 @@
 
   :where(.ui-button--secondary) {
     border-color: hsl(var(--border) / 0.6);
-    background: hsl(var(--secondary) / 0.85);
+    background: hsl(var(--secondary) / 0.9);
     color: hsl(var(--secondary-foreground));
-    box-shadow: 0 4px 12px -8px rgba(15, 23, 42, 0.24);
+    box-shadow: none;
   }
 
   :where(.ui-button--secondary:hover) {
@@ -297,9 +296,8 @@
   :where(.ui-select) {
     border: 1px solid hsl(var(--input) / 0.8);
     border-radius: var(--radius);
-    background: hsl(var(--background) / 0.55);
-    box-shadow: 0 4px 12px -8px rgba(15, 23, 42, 0.28);
-    backdrop-filter: blur(12px);
+    background: hsl(var(--background) / 0.82);
+    box-shadow: none;
     font-weight: 600;
   }
 
@@ -313,7 +311,7 @@
   }
 
   .dark :where(.ui-select) {
-    box-shadow: 0 4px 12px -8px rgba(0, 0, 0, 0.55);
+    background: hsl(var(--secondary) / 0.72);
   }
 
   :where(.ui-progress) {
@@ -347,16 +345,12 @@
 
   @media (prefers-reduced-motion: no-preference) {
     :where(.ui-button--default:hover),
-    :where(.ui-button--destructive:hover),
-    :where(.ui-button--outline:hover),
-    :where(.ui-button--secondary:hover) {
+    :where(.ui-button--destructive:hover) {
       transform: translateY(-0.125rem);
     }
 
     :where(.ui-button--default:active),
-    :where(.ui-button--destructive:active),
-    :where(.ui-button--outline:active),
-    :where(.ui-button--secondary:active) {
+    :where(.ui-button--destructive:active) {
       transform: translateY(0);
     }
   }

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -87,16 +87,13 @@
 
 @layer base {
   html {
-    min-height: 100%;
-    background: hsl(var(--background));
-    font-family: var(--font-sans);
+    @apply min-h-full bg-background font-sans;
     font-synthesis: none;
     text-rendering: optimizeLegibility;
   }
 
   body {
-    min-height: 100%;
-    min-width: 320px;
+    @apply min-h-full min-w-80;
     font-feature-settings:
       "kern" 1,
       "liga" 1,
@@ -111,266 +108,11 @@
   }
 
   ::selection {
-    background: hsl(var(--primary) / 0.2);
-    color: hsl(var(--foreground));
+    @apply bg-primary/20 text-foreground;
   }
 
   :focus-visible {
     @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
-  }
-}
-
-@layer components {
-  :where(.ui-card) {
-    border: 1px solid hsl(var(--border) / 0.55);
-    border-radius: 1.5rem;
-    background: hsl(var(--card) / 0.8);
-    box-shadow:
-      0 18px 55px -36px rgba(45, 39, 94, 0.42),
-      inset 0 0 0 1px rgba(255, 255, 255, 0.6);
-  }
-
-  .dark :where(.ui-card) {
-    box-shadow:
-      0 22px 65px -38px rgba(0, 0, 0, 0.9),
-      inset 0 0 0 1px rgba(255, 255, 255, 0.05);
-  }
-
-  :where(.ui-card-header) {
-    display: flex;
-    flex-direction: column;
-    gap: 0.375rem;
-    padding: 1.5rem;
-  }
-
-  :where(.ui-card-title) {
-    font-size: 1.5rem;
-    font-weight: 600;
-    line-height: 1;
-    letter-spacing: -0.02em;
-  }
-
-  :where(.ui-card-description) {
-    color: hsl(var(--muted-foreground));
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-  }
-
-  :where(.ui-card-content) {
-    padding: 0 1.5rem 1.5rem;
-  }
-
-  :where(.ui-card-footer) {
-    display: flex;
-    align-items: center;
-    padding: 0 1.5rem 1.5rem;
-  }
-
-  :where(.ui-button) {
-    border: 1px solid transparent;
-    border-radius: var(--radius);
-  }
-
-  :where(.ui-button--default) {
-    border-color: hsl(var(--primary) / 0.2);
-    background: hsl(var(--primary));
-    color: hsl(var(--primary-foreground));
-    box-shadow: 0 8px 20px -10px hsl(var(--primary) / 0.55);
-  }
-
-  :where(.ui-button--default:hover) {
-    background: hsl(var(--primary));
-    box-shadow: 0 12px 26px -10px hsl(var(--primary) / 0.68);
-  }
-
-  :where(.ui-button--default:active) {
-    filter: brightness(0.94);
-  }
-
-  :where(.ui-button--destructive) {
-    border-color: hsl(var(--destructive) / 0.24);
-    background: hsl(var(--destructive));
-    color: hsl(var(--destructive-foreground));
-    box-shadow: 0 8px 20px -10px hsl(var(--destructive) / 0.5);
-  }
-
-  :where(.ui-button--destructive:hover) {
-    background: hsl(var(--destructive));
-    filter: brightness(0.92);
-  }
-
-  :where(.ui-button--outline) {
-    border-color: hsl(var(--input) / 0.8);
-    background: hsl(var(--secondary) / 0.9);
-    color: hsl(var(--foreground));
-    box-shadow: none;
-  }
-
-  :where(.ui-button--outline:hover) {
-    border-color: hsl(var(--primary) / 0.3);
-    background: hsl(var(--accent));
-    color: hsl(var(--accent-foreground));
-  }
-
-  :where(.ui-button--secondary) {
-    border-color: hsl(var(--border) / 0.6);
-    background: hsl(var(--secondary) / 0.9);
-    color: hsl(var(--secondary-foreground));
-    box-shadow: none;
-  }
-
-  :where(.ui-button--secondary:hover) {
-    background: hsl(var(--secondary));
-  }
-
-  :where(.ui-button--ghost) {
-    color: hsl(var(--foreground));
-  }
-
-  :where(.ui-button--ghost:hover),
-  :where(.ui-button--ghost:active) {
-    background: hsl(var(--accent) / 0.82);
-    color: hsl(var(--accent-foreground));
-  }
-
-  :where(.ui-button--link) {
-    color: hsl(var(--primary));
-    text-underline-offset: 4px;
-  }
-
-  :where(.ui-button--link:hover) {
-    text-decoration: underline;
-  }
-
-  :where(.ui-badge) {
-    border: 1px solid transparent;
-    border-radius: 9999px;
-    box-shadow: 0 4px 12px -10px rgba(15, 23, 42, 0.35);
-  }
-
-  :where(.ui-badge--default) {
-    border-color: hsl(var(--primary) / 0.24);
-    background: hsl(var(--primary) / 0.12);
-    color: hsl(252 72% 34%);
-  }
-
-  :where(.ui-badge--default:hover) {
-    background: hsl(var(--primary) / 0.18);
-  }
-
-  .dark :where(.ui-badge--default) {
-    color: hsl(250 100% 88%);
-  }
-
-  :where(.ui-badge--secondary) {
-    border-color: hsl(var(--border) / 0.7);
-    background: hsl(var(--secondary) / 0.8);
-    color: hsl(var(--secondary-foreground));
-  }
-
-  :where(.ui-badge--secondary:hover) {
-    background: hsl(var(--secondary));
-  }
-
-  :where(.ui-badge--destructive) {
-    border-color: hsl(var(--destructive) / 0.24);
-    background: hsl(var(--destructive) / 0.12);
-    color: hsl(354 76% 34%);
-  }
-
-  :where(.ui-badge--destructive:hover) {
-    background: hsl(var(--destructive) / 0.18);
-  }
-
-  .dark :where(.ui-badge--destructive) {
-    color: hsl(350 100% 88%);
-  }
-
-  :where(.ui-badge--outline) {
-    border-color: hsl(var(--border) / 0.65);
-    background: hsl(var(--background) / 0.35);
-    color: hsl(var(--foreground));
-    backdrop-filter: blur(4px);
-  }
-
-  :where(.ui-select) {
-    border: 1px solid hsl(var(--input) / 0.8);
-    border-radius: var(--radius);
-    background: hsl(var(--background) / 0.82);
-    box-shadow: none;
-    font-weight: 600;
-  }
-
-  :where(.ui-select:hover) {
-    border-color: hsl(var(--primary) / 0.3);
-    background: hsl(var(--background) / 0.75);
-  }
-
-  :where(.ui-select:focus-visible) {
-    border-color: hsl(var(--primary) / 0.5);
-  }
-
-  .dark :where(.ui-select) {
-    background: hsl(var(--secondary) / 0.72);
-  }
-
-  :where(.ui-progress) {
-    height: 0.5rem;
-    border-radius: 9999px;
-    background: hsl(var(--muted) / 0.9);
-    box-shadow:
-      inset 0 1px 2px rgba(15, 23, 42, 0.12),
-      inset 0 0 0 1px hsl(var(--border) / 0.3);
-  }
-
-  :where(.ui-progress-indicator) {
-    border-radius: 9999px;
-    background: hsl(var(--primary));
-    box-shadow: 0 0 12px hsl(var(--primary) / 0.35);
-  }
-
-  :where(.ui-switch) {
-    box-shadow: inset 0 1px 3px rgba(15, 23, 42, 0.16);
-  }
-
-  :where(.ui-switch--checked) {
-    border-color: hsl(var(--primary) / 0.3);
-    background: hsl(var(--primary));
-  }
-
-  :where(.ui-switch--unchecked) {
-    border-color: hsl(var(--input) / 0.8);
-    background: hsl(var(--muted) / 0.9);
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    :where(.ui-button--default:hover),
-    :where(.ui-button--destructive:hover) {
-      transform: translateY(-0.125rem);
-    }
-
-    :where(.ui-button--default:active),
-    :where(.ui-button--destructive:active) {
-      transform: translateY(0);
-    }
-  }
-}
-
-@layer utilities {
-  .app-ambient {
-    background-color: hsl(var(--background));
-    background-image:
-      radial-gradient(circle at 8% -8%, hsl(252 92% 72% / 0.2), transparent 34rem),
-      radial-gradient(circle at 96% 2%, hsl(190 96% 60% / 0.14), transparent 30rem),
-      linear-gradient(180deg, hsl(226 56% 98% / 0.68), hsl(var(--background)) 28rem);
-    background-attachment: fixed;
-  }
-
-  .dark .app-ambient {
-    background-image:
-      radial-gradient(circle at 8% -10%, hsl(252 92% 66% / 0.18), transparent 36rem),
-      radial-gradient(circle at 94% 0%, hsl(190 96% 52% / 0.11), transparent 32rem),
-      linear-gradient(180deg, hsl(231 48% 9% / 0.8), hsl(var(--background)) 30rem);
   }
 }
 
@@ -382,11 +124,5 @@
     animation-duration: 0.01ms;
     animation-iteration-count: 1;
     transition-duration: 0.01ms;
-  }
-}
-
-@media (max-width: 767px) {
-  .app-ambient {
-    background-attachment: scroll;
   }
 }

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -3,6 +3,10 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
+  --font-sans:
+    "Inter Variable", "SF Pro Display", "SF Pro Text", "Segoe UI Variable", "Segoe UI", "PingFang SC",
+    "Microsoft YaHei", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "SFMono-Regular", "Cascadia Code", "Roboto Mono", ui-monospace, monospace;
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
@@ -37,52 +41,358 @@
 }
 
 :root {
-  --background: 0 0% 98%;
-  --foreground: 220 15% 15%;
+  --background: 226 44% 97%;
+  --foreground: 229 36% 14%;
   --card: 0 0% 100%;
-  --card-foreground: 220 15% 15%;
+  --card-foreground: 229 36% 14%;
   --popover: 0 0% 100%;
-  --popover-foreground: 220 15% 15%;
-  --primary: 221 83% 53%;
+  --popover-foreground: 229 36% 14%;
+  --primary: 252 82% 59%;
   --primary-foreground: 0 0% 100%;
-  --secondary: 210 40% 96%;
-  --secondary-foreground: 222 47% 11%;
-  --muted: 210 40% 96%;
-  --muted-foreground: 215 16% 46%;
-  --accent: 210 40% 96%;
-  --accent-foreground: 222 47% 11%;
-  --destructive: 0 84% 60%;
+  --secondary: 228 46% 94%;
+  --secondary-foreground: 232 36% 22%;
+  --muted: 225 31% 93%;
+  --muted-foreground: 226 15% 43%;
+  --accent: 250 58% 94%;
+  --accent-foreground: 252 52% 29%;
+  --destructive: 354 75% 48%;
   --destructive-foreground: 0 0% 98%;
-  --border: 214 32% 91%;
-  --input: 214 32% 91%;
-  --ring: 221 83% 53%;
-  --radius: 0.75rem;
+  --border: 226 27% 86%;
+  --input: 226 27% 82%;
+  --ring: 252 82% 59%;
+  --radius: 0.875rem;
 }
 
 .dark {
-  --background: 222 47% 8%;
-  --foreground: 210 40% 98%;
-  --card: 222 47% 11%;
-  --card-foreground: 210 40% 98%;
-  --popover: 222 47% 11%;
-  --popover-foreground: 210 40% 98%;
-  --primary: 217 91% 60%;
-  --primary-foreground: 210 40% 98%;
-  --secondary: 217 32% 17%;
-  --secondary-foreground: 210 40% 98%;
-  --muted: 217 32% 17%;
-  --muted-foreground: 215 20% 65%;
-  --accent: 217 32% 17%;
-  --accent-foreground: 210 40% 98%;
-  --destructive: 0 63% 47%;
-  --destructive-foreground: 210 40% 98%;
-  --border: 217 32% 17%;
-  --input: 217 32% 17%;
-  --ring: 224 76% 48%;
+  --background: 231 46% 7%;
+  --foreground: 220 32% 96%;
+  --card: 229 37% 11%;
+  --card-foreground: 220 32% 96%;
+  --popover: 229 38% 10%;
+  --popover-foreground: 220 32% 96%;
+  --primary: 252 92% 70%;
+  --primary-foreground: 235 44% 10%;
+  --secondary: 228 30% 17%;
+  --secondary-foreground: 220 32% 96%;
+  --muted: 228 25% 17%;
+  --muted-foreground: 224 16% 66%;
+  --accent: 248 33% 19%;
+  --accent-foreground: 246 82% 88%;
+  --destructive: 354 72% 50%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 228 23% 22%;
+  --input: 228 24% 24%;
+  --ring: 252 92% 70%;
 }
 
 @layer base {
+  html {
+    min-height: 100%;
+    background: hsl(var(--background));
+    font-family: var(--font-sans);
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+  }
+
+  body {
+    min-height: 100%;
+    min-width: 320px;
+    font-feature-settings:
+      "kern" 1,
+      "liga" 1,
+      "calt" 1;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+  }
+
+  ::selection {
+    background: hsl(var(--primary) / 0.2);
+    color: hsl(var(--foreground));
+  }
+
   :focus-visible {
-    @apply outline-none ring-2 ring-ring;
+    @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
+  }
+}
+
+@layer components {
+  :where(.ui-card) {
+    border: 1px solid hsl(var(--border) / 0.55);
+    border-radius: 1.5rem;
+    background: hsl(var(--card) / 0.8);
+    box-shadow:
+      0 18px 55px -36px rgba(45, 39, 94, 0.42),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  }
+
+  .dark :where(.ui-card) {
+    box-shadow:
+      0 22px 65px -38px rgba(0, 0, 0, 0.9),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  }
+
+  :where(.ui-card-header) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding: 1.5rem;
+  }
+
+  :where(.ui-card-title) {
+    font-size: 1.5rem;
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: -0.02em;
+  }
+
+  :where(.ui-card-description) {
+    color: hsl(var(--muted-foreground));
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+
+  :where(.ui-card-content) {
+    padding: 0 1.5rem 1.5rem;
+  }
+
+  :where(.ui-card-footer) {
+    display: flex;
+    align-items: center;
+    padding: 0 1.5rem 1.5rem;
+  }
+
+  :where(.ui-button) {
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+  }
+
+  :where(.ui-button--default) {
+    border-color: hsl(var(--primary) / 0.2);
+    background: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    box-shadow: 0 8px 20px -10px hsl(var(--primary) / 0.55);
+  }
+
+  :where(.ui-button--default:hover) {
+    background: hsl(var(--primary));
+    box-shadow: 0 12px 26px -10px hsl(var(--primary) / 0.68);
+  }
+
+  :where(.ui-button--default:active) {
+    filter: brightness(0.94);
+  }
+
+  :where(.ui-button--destructive) {
+    border-color: hsl(var(--destructive) / 0.24);
+    background: hsl(var(--destructive));
+    color: hsl(var(--destructive-foreground));
+    box-shadow: 0 8px 20px -10px hsl(var(--destructive) / 0.5);
+  }
+
+  :where(.ui-button--destructive:hover) {
+    background: hsl(var(--destructive));
+    filter: brightness(0.92);
+  }
+
+  :where(.ui-button--outline) {
+    border-color: hsl(var(--input) / 0.8);
+    background: hsl(var(--background) / 0.6);
+    color: hsl(var(--foreground));
+    box-shadow: 0 4px 12px -8px rgba(15, 23, 42, 0.28);
+    backdrop-filter: blur(12px);
+  }
+
+  :where(.ui-button--outline:hover) {
+    border-color: hsl(var(--primary) / 0.3);
+    background: hsl(var(--accent));
+    color: hsl(var(--accent-foreground));
+  }
+
+  :where(.ui-button--secondary) {
+    border-color: hsl(var(--border) / 0.6);
+    background: hsl(var(--secondary) / 0.85);
+    color: hsl(var(--secondary-foreground));
+    box-shadow: 0 4px 12px -8px rgba(15, 23, 42, 0.24);
+  }
+
+  :where(.ui-button--secondary:hover) {
+    background: hsl(var(--secondary));
+  }
+
+  :where(.ui-button--ghost) {
+    color: hsl(var(--foreground));
+  }
+
+  :where(.ui-button--ghost:hover),
+  :where(.ui-button--ghost:active) {
+    background: hsl(var(--accent) / 0.82);
+    color: hsl(var(--accent-foreground));
+  }
+
+  :where(.ui-button--link) {
+    color: hsl(var(--primary));
+    text-underline-offset: 4px;
+  }
+
+  :where(.ui-button--link:hover) {
+    text-decoration: underline;
+  }
+
+  :where(.ui-badge) {
+    border: 1px solid transparent;
+    border-radius: 9999px;
+    box-shadow: 0 4px 12px -10px rgba(15, 23, 42, 0.35);
+  }
+
+  :where(.ui-badge--default) {
+    border-color: hsl(var(--primary) / 0.24);
+    background: hsl(var(--primary) / 0.12);
+    color: hsl(252 72% 34%);
+  }
+
+  :where(.ui-badge--default:hover) {
+    background: hsl(var(--primary) / 0.18);
+  }
+
+  .dark :where(.ui-badge--default) {
+    color: hsl(250 100% 88%);
+  }
+
+  :where(.ui-badge--secondary) {
+    border-color: hsl(var(--border) / 0.7);
+    background: hsl(var(--secondary) / 0.8);
+    color: hsl(var(--secondary-foreground));
+  }
+
+  :where(.ui-badge--secondary:hover) {
+    background: hsl(var(--secondary));
+  }
+
+  :where(.ui-badge--destructive) {
+    border-color: hsl(var(--destructive) / 0.24);
+    background: hsl(var(--destructive) / 0.12);
+    color: hsl(354 76% 34%);
+  }
+
+  :where(.ui-badge--destructive:hover) {
+    background: hsl(var(--destructive) / 0.18);
+  }
+
+  .dark :where(.ui-badge--destructive) {
+    color: hsl(350 100% 88%);
+  }
+
+  :where(.ui-badge--outline) {
+    border-color: hsl(var(--border) / 0.65);
+    background: hsl(var(--background) / 0.35);
+    color: hsl(var(--foreground));
+    backdrop-filter: blur(4px);
+  }
+
+  :where(.ui-select) {
+    border: 1px solid hsl(var(--input) / 0.8);
+    border-radius: var(--radius);
+    background: hsl(var(--background) / 0.55);
+    box-shadow: 0 4px 12px -8px rgba(15, 23, 42, 0.28);
+    backdrop-filter: blur(12px);
+    font-weight: 600;
+  }
+
+  :where(.ui-select:hover) {
+    border-color: hsl(var(--primary) / 0.3);
+    background: hsl(var(--background) / 0.75);
+  }
+
+  :where(.ui-select:focus-visible) {
+    border-color: hsl(var(--primary) / 0.5);
+  }
+
+  .dark :where(.ui-select) {
+    box-shadow: 0 4px 12px -8px rgba(0, 0, 0, 0.55);
+  }
+
+  :where(.ui-progress) {
+    height: 0.5rem;
+    border-radius: 9999px;
+    background: hsl(var(--muted) / 0.9);
+    box-shadow:
+      inset 0 1px 2px rgba(15, 23, 42, 0.12),
+      inset 0 0 0 1px hsl(var(--border) / 0.3);
+  }
+
+  :where(.ui-progress-indicator) {
+    border-radius: 9999px;
+    background: hsl(var(--primary));
+    box-shadow: 0 0 12px hsl(var(--primary) / 0.35);
+  }
+
+  :where(.ui-switch) {
+    box-shadow: inset 0 1px 3px rgba(15, 23, 42, 0.16);
+  }
+
+  :where(.ui-switch--checked) {
+    border-color: hsl(var(--primary) / 0.3);
+    background: hsl(var(--primary));
+  }
+
+  :where(.ui-switch--unchecked) {
+    border-color: hsl(var(--input) / 0.8);
+    background: hsl(var(--muted) / 0.9);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    :where(.ui-button--default:hover),
+    :where(.ui-button--destructive:hover),
+    :where(.ui-button--outline:hover),
+    :where(.ui-button--secondary:hover) {
+      transform: translateY(-0.125rem);
+    }
+
+    :where(.ui-button--default:active),
+    :where(.ui-button--destructive:active),
+    :where(.ui-button--outline:active),
+    :where(.ui-button--secondary:active) {
+      transform: translateY(0);
+    }
+  }
+}
+
+@layer utilities {
+  .app-ambient {
+    background-color: hsl(var(--background));
+    background-image:
+      radial-gradient(circle at 8% -8%, hsl(252 92% 72% / 0.2), transparent 34rem),
+      radial-gradient(circle at 96% 2%, hsl(190 96% 60% / 0.14), transparent 30rem),
+      linear-gradient(180deg, hsl(226 56% 98% / 0.68), hsl(var(--background)) 28rem);
+    background-attachment: fixed;
+  }
+
+  .dark .app-ambient {
+    background-image:
+      radial-gradient(circle at 8% -10%, hsl(252 92% 66% / 0.18), transparent 36rem),
+      radial-gradient(circle at 94% 0%, hsl(190 96% 52% / 0.11), transparent 32rem),
+      linear-gradient(180deg, hsl(231 48% 9% / 0.8), hsl(var(--background)) 30rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto;
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+    transition-duration: 0.01ms;
+  }
+}
+
+@media (max-width: 767px) {
+  .app-ambient {
+    background-attachment: scroll;
   }
 }

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -438,36 +438,25 @@ function PlayerPage() {
         >
           {/* Sidebar Tabs */}
           <div className="flex shrink-0 items-center border-blue-950/10 border-b bg-white/44 shadow-[0_8px_24px_rgba(30,64,175,0.045)] backdrop-blur-xl dark:border-blue-100/10 dark:bg-slate-950/28">
-            <button
-              type="button"
-              onClick={() => {
-                channelListNextScrollBehaviorRef.current = "instant";
-                setSidebarView("channels");
-              }}
-              className={clsx(
-                "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap px-3 py-2 text-center font-semibold text-xs leading-5 tracking-[0.01em] transition-[color,background-color,border-color,box-shadow] md:px-4 md:py-3 md:text-sm",
-                sidebarView === "channels"
-                  ? "border-blue-500 border-b-2 bg-[linear-gradient(to_top,rgba(59,130,246,0.12),transparent)] text-blue-700 shadow-[inset_0_-1px_0_rgba(59,130,246,0.18)] dark:border-blue-300 dark:text-blue-200"
-                  : "cursor-pointer border-transparent border-b-2 text-slate-500 hover:bg-blue-400/5 hover:text-blue-700 dark:text-slate-400 dark:hover:text-blue-100",
-              )}
-            >
-              {t("channels")} ({metadata?.channels.length || 0})
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                epgViewNextScrollBehaviorRef.current = "instant";
-                setSidebarView("epg");
-              }}
-              className={clsx(
-                "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap px-3 py-2 text-center font-semibold text-xs leading-5 tracking-[0.01em] transition-[color,background-color,border-color,box-shadow] md:px-4 md:py-3 md:text-sm",
-                sidebarView === "epg"
-                  ? "border-blue-500 border-b-2 bg-[linear-gradient(to_top,rgba(59,130,246,0.12),transparent)] text-blue-700 shadow-[inset_0_-1px_0_rgba(59,130,246,0.18)] dark:border-blue-300 dark:text-blue-200"
-                  : "cursor-pointer border-transparent border-b-2 text-slate-500 hover:bg-blue-400/5 hover:text-blue-700 dark:text-slate-400 dark:hover:text-blue-100",
-              )}
-            >
-              {t("programGuide")}
-            </button>
+            {(["channels", "epg"] as const).map((view) => (
+              <button
+                type="button"
+                key={view}
+                onClick={() => {
+                  (view === "channels" ? channelListNextScrollBehaviorRef : epgViewNextScrollBehaviorRef).current =
+                    "instant";
+                  setSidebarView(view);
+                }}
+                className={clsx(
+                  "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap border-b-2 px-3 py-2 text-center font-semibold text-xs leading-5 tracking-[0.01em] transition-[color,background-color,border-color,box-shadow] md:px-4 md:py-3 md:text-sm",
+                  sidebarView === view
+                    ? "border-blue-500 bg-[linear-gradient(to_top,rgba(59,130,246,0.12),transparent)] text-blue-700 shadow-[inset_0_-1px_0_rgba(59,130,246,0.18)] dark:border-blue-300 dark:text-blue-200"
+                    : "cursor-pointer border-transparent text-slate-500 hover:bg-blue-400/5 hover:text-blue-700 dark:text-slate-400 dark:hover:text-blue-100",
+                )}
+              >
+                {view === "channels" ? `${t("channels")} (${metadata?.channels.length || 0})` : t("programGuide")}
+              </button>
+            ))}
           </div>
 
           {/* Sidebar Content */}

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -364,7 +364,7 @@ function PlayerPage() {
 
   const settingsSlot = useMemo(() => {
     return (
-      <div className="ml-2">
+      <div className="shrink-0">
         <SettingsDropdown
           locale={locale}
           onLocaleChange={setLocale}
@@ -394,7 +394,10 @@ function PlayerPage() {
 
   // Main UI content
   const mainContent = (
-    <div ref={pageContainerRef} className="flex h-dvh flex-col bg-background">
+    <div
+      ref={pageContainerRef}
+      className="flex h-dvh flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(34,211,238,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_88%_10%,rgba(34,211,238,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
+    >
       <title>{t("title")}</title>
 
       {/* Main Content */}
@@ -429,12 +432,12 @@ function PlayerPage() {
         {/* Sidebar - Mobile: always visible (below video, hidden in fullscreen), Desktop: toggle-able side panel (visible in fullscreen) */}
         <div
           className={clsx(
-            "flex flex-col w-full md:w-80 md:border-l border-t md:border-t-0 border-border bg-card flex-1 md:flex-initial overflow-hidden",
+            "flex w-full flex-1 flex-col overflow-hidden border-cyan-950/10 border-t bg-white/68 shadow-[-14px_0_40px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-cyan-100/10 dark:bg-[linear-gradient(160deg,rgba(8,20,43,0.82),rgba(22,24,65,0.74))] dark:shadow-[-18px_0_48px_rgba(1,7,24,0.28)] md:w-80 md:flex-initial md:border-t-0 md:border-l",
             (showSidebar || isMobile) && !(isFullscreen && isMobile) ? "" : "hidden",
           )}
         >
           {/* Sidebar Tabs */}
-          <div className="flex items-center border-b border-border shrink-0">
+          <div className="flex shrink-0 items-center border-cyan-950/10 border-b bg-white/44 shadow-[0_8px_24px_rgba(30,64,175,0.045)] backdrop-blur-xl dark:border-cyan-100/10 dark:bg-slate-950/28">
             <button
               type="button"
               onClick={() => {
@@ -442,10 +445,10 @@ function PlayerPage() {
                 setSidebarView("channels");
               }}
               className={clsx(
-                "flex-1 px-3 md:px-4 py-2 md:py-3 text-xs md:text-sm font-medium transition-[color]",
+                "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap px-3 py-2 text-center font-semibold text-xs leading-5 tracking-[0.01em] transition-[color,background-color,border-color,box-shadow] md:px-4 md:py-3 md:text-sm",
                 sidebarView === "channels"
-                  ? "border-b-2 border-primary text-primary"
-                  : "text-muted-foreground cursor-pointer hover:text-foreground",
+                  ? "border-cyan-500 border-b-2 bg-[linear-gradient(to_top,rgba(34,211,238,0.12),transparent)] text-cyan-700 shadow-[inset_0_-1px_0_rgba(34,211,238,0.18)] dark:border-cyan-300 dark:text-cyan-200"
+                  : "cursor-pointer border-transparent border-b-2 text-slate-500 hover:bg-cyan-400/5 hover:text-cyan-700 dark:text-slate-400 dark:hover:text-cyan-100",
               )}
             >
               {t("channels")} ({metadata?.channels.length || 0})
@@ -457,10 +460,10 @@ function PlayerPage() {
                 setSidebarView("epg");
               }}
               className={clsx(
-                "flex-1 px-3 md:px-4 py-2 md:py-3 text-xs md:text-sm font-medium transition-[color]",
+                "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap px-3 py-2 text-center font-semibold text-xs leading-5 tracking-[0.01em] transition-[color,background-color,border-color,box-shadow] md:px-4 md:py-3 md:text-sm",
                 sidebarView === "epg"
-                  ? "border-b-2 border-primary text-primary"
-                  : "text-muted-foreground cursor-pointer hover:text-foreground",
+                  ? "border-cyan-500 border-b-2 bg-[linear-gradient(to_top,rgba(34,211,238,0.12),transparent)] text-cyan-700 shadow-[inset_0_-1px_0_rgba(34,211,238,0.18)] dark:border-cyan-300 dark:text-cyan-200"
+                  : "cursor-pointer border-transparent border-b-2 text-slate-500 hover:bg-cyan-400/5 hover:text-cyan-700 dark:text-slate-400 dark:hover:text-cyan-100",
               )}
             >
               {t("programGuide")}
@@ -500,39 +503,48 @@ function PlayerPage() {
     const playlistErrorHints = [t("playlistErrorHintReachable"), t("playlistErrorHintFormat")];
 
     return (
-      <div className="min-h-dvh bg-background">
+      <div className="min-h-dvh bg-[radial-gradient(circle_at_18%_14%,rgba(34,211,238,0.16),transparent_28%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.16),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_18%_14%,rgba(34,211,238,0.1),transparent_30%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.13),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]">
         <title>{t("title")}</title>
         <div className="mx-auto flex min-h-dvh w-[calc(100%-2rem)] max-w-5xl items-center py-8 sm:w-[calc(100%-3rem)]">
-          <Card className="min-w-0 w-full overflow-hidden rounded-lg border-border/70 bg-card shadow-xl shadow-black/5 dark:shadow-black/40">
+          <Card className="min-w-0 w-full overflow-hidden rounded-3xl border-cyan-900/10 bg-white/72 shadow-[0_28px_80px_rgba(30,64,175,0.16),inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-2xl dark:border-cyan-100/12 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.9),rgba(26,24,72,0.82))] dark:shadow-[0_30px_90px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
             <div className="grid min-w-0 md:grid-cols-[minmax(0,1fr)_18rem]">
               <div className="min-w-0 p-6 sm:p-8 md:p-10">
-                <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
+                <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-2xl border border-rose-300/20 bg-[linear-gradient(145deg,rgba(251,113,133,0.16),rgba(99,102,241,0.12))] text-rose-500 shadow-[0_12px_28px_rgba(225,29,72,0.12)] dark:text-rose-300">
                   <AlertTriangle className="h-6 w-6" aria-hidden="true" />
                 </div>
 
-                <div className="text-sm font-semibold text-primary">{t("playlistLoadEyebrow")}</div>
-                <h1 className="mt-2 text-2xl font-semibold text-foreground sm:text-3xl">{t("playlistLoadTitle")}</h1>
-                <p className="mt-3 max-w-2xl break-words text-sm leading-6 text-muted-foreground sm:text-base">
+                <div className="font-semibold text-cyan-700 text-sm dark:text-cyan-200">{t("playlistLoadEyebrow")}</div>
+                <h1 className="mt-2 text-balance font-semibold text-2xl text-foreground leading-tight tracking-tight sm:text-3xl">
+                  {t("playlistLoadTitle")}
+                </h1>
+                <p className="mt-3 max-w-2xl text-pretty break-words text-sm leading-6 text-muted-foreground sm:text-base">
                   {t("playlistLoadDescription")}
                 </p>
 
-                <div className="mt-6 min-w-0 rounded-lg border border-border/70 bg-muted/40 p-4">
+                <div className="mt-6 min-w-0 rounded-2xl border border-cyan-900/10 bg-cyan-50/45 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] dark:border-cyan-100/10 dark:bg-cyan-300/6">
                   <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                    <ListChecks className="h-4 w-4 text-primary" aria-hidden="true" />
+                    <ListChecks className="h-4 w-4 text-cyan-600 dark:text-cyan-300" aria-hidden="true" />
                     {t("playlistErrorChecklist")}
                   </div>
-                  <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                  <ul className="mt-3 space-y-2 text-sm leading-5 text-muted-foreground">
                     {playlistErrorHints.map((hint) => (
                       <li key={hint} className="flex min-w-0 gap-2">
-                        <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" aria-hidden="true" />
+                        <span
+                          className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-500 shadow-[0_0_8px_rgba(34,211,238,0.45)]"
+                          aria-hidden="true"
+                        />
                         <span className="min-w-0 break-words">{hint}</span>
                       </li>
                     ))}
                   </ul>
                 </div>
 
-                <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-                  <Button type="button" onClick={loadPlaylist} className="gap-2">
+                <div className="mt-6 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+                  <Button
+                    type="button"
+                    onClick={loadPlaylist}
+                    className="w-full gap-2 rounded-xl bg-[linear-gradient(135deg,#0e7490,#4338ca)] text-white shadow-[0_10px_28px_rgba(8,145,178,0.24)] hover:brightness-105 sm:w-auto"
+                  >
                     <RefreshCw className="h-4 w-4" aria-hidden="true" />
                     {t("retry")}
                   </Button>
@@ -540,7 +552,11 @@ function PlayerPage() {
                     href={getM3UIntegrationGuideUrl(locale)}
                     target="_blank"
                     rel="noreferrer"
-                    className={buttonVariants({ variant: "outline", className: "gap-2" })}
+                    className={buttonVariants({
+                      variant: "outline",
+                      className:
+                        "w-full gap-2 rounded-xl border-cyan-900/12 bg-white/55 text-cyan-800 shadow-sm hover:bg-cyan-50 dark:border-cyan-100/15 dark:bg-slate-950/35 dark:text-cyan-100 dark:hover:bg-cyan-300/10 sm:w-auto",
+                    })}
                   >
                     {t("m3uIntegrationGuide")}
                     <ExternalLink className="h-4 w-4" aria-hidden="true" />
@@ -548,9 +564,9 @@ function PlayerPage() {
                 </div>
               </div>
 
-              <div className="min-w-0 border-t border-border/70 bg-muted/30 p-6 md:border-t-0 md:border-l md:p-8">
+              <div className="min-w-0 border-cyan-900/10 border-t bg-[linear-gradient(145deg,rgba(224,242,254,0.42),rgba(238,242,255,0.58))] p-6 dark:border-cyan-100/10 dark:bg-[linear-gradient(145deg,rgba(8,47,73,0.22),rgba(30,27,75,0.3))] md:border-t-0 md:border-l md:p-8">
                 <div className="text-sm font-semibold text-foreground">{t("playlistEndpoint")}</div>
-                <div className="mt-3 rounded-lg border border-border/70 bg-background px-3 py-2 font-mono text-sm text-foreground">
+                <div className="mt-3 break-all rounded-xl border border-cyan-900/10 bg-white/55 px-3 py-2 font-mono text-foreground text-sm leading-5 shadow-inner dark:border-cyan-100/10 dark:bg-slate-950/42">
                   {buildAppPath("/playlist.m3u")}
                 </div>
                 <div className="mt-6 text-sm font-semibold text-foreground">{t("technicalDetails")}</div>
@@ -571,13 +587,13 @@ function PlayerPage() {
       {isLoading && (
         <div
           className={clsx(
-            "fixed inset-0 z-50 flex items-center justify-center bg-background",
+            "fixed inset-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(34,211,238,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_center,rgba(34,211,238,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
             isRevealing && "animate-zoom-fade-out",
           )}
         >
           <div className="text-center space-y-4">
             {/* Loading spinner */}
-            <div className="h-12 w-12 mx-auto rounded-full border-4 border-muted border-t-primary animate-spin" />
+            <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-cyan-950/10 border-t-cyan-500 border-r-indigo-500 shadow-[0_0_28px_rgba(34,211,238,0.22)] dark:border-cyan-100/10 dark:border-t-cyan-300 dark:border-r-indigo-400" />
           </div>
         </div>
       )}

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -396,7 +396,7 @@ function PlayerPage() {
   const mainContent = (
     <div
       ref={pageContainerRef}
-      className="flex h-dvh flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(34,211,238,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_88%_10%,rgba(34,211,238,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
+      className="flex h-dvh flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(59,130,246,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_88%_10%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
     >
       <title>{t("title")}</title>
 
@@ -432,12 +432,12 @@ function PlayerPage() {
         {/* Sidebar - Mobile: always visible (below video, hidden in fullscreen), Desktop: toggle-able side panel (visible in fullscreen) */}
         <div
           className={clsx(
-            "flex w-full flex-1 flex-col overflow-hidden border-cyan-950/10 border-t bg-white/68 shadow-[-14px_0_40px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-cyan-100/10 dark:bg-[linear-gradient(160deg,rgba(8,20,43,0.82),rgba(22,24,65,0.74))] dark:shadow-[-18px_0_48px_rgba(1,7,24,0.28)] md:w-80 md:flex-initial md:border-t-0 md:border-l",
+            "flex w-full flex-1 flex-col overflow-hidden border-blue-950/10 border-t bg-white/68 shadow-[-14px_0_40px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-blue-100/10 dark:bg-[linear-gradient(160deg,rgba(8,20,43,0.82),rgba(22,24,65,0.74))] dark:shadow-[-18px_0_48px_rgba(1,7,24,0.28)] md:w-80 md:flex-initial md:border-t-0 md:border-l",
             (showSidebar || isMobile) && !(isFullscreen && isMobile) ? "" : "hidden",
           )}
         >
           {/* Sidebar Tabs */}
-          <div className="flex shrink-0 items-center border-cyan-950/10 border-b bg-white/44 shadow-[0_8px_24px_rgba(30,64,175,0.045)] backdrop-blur-xl dark:border-cyan-100/10 dark:bg-slate-950/28">
+          <div className="flex shrink-0 items-center border-blue-950/10 border-b bg-white/44 shadow-[0_8px_24px_rgba(30,64,175,0.045)] backdrop-blur-xl dark:border-blue-100/10 dark:bg-slate-950/28">
             <button
               type="button"
               onClick={() => {
@@ -447,8 +447,8 @@ function PlayerPage() {
               className={clsx(
                 "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap px-3 py-2 text-center font-semibold text-xs leading-5 tracking-[0.01em] transition-[color,background-color,border-color,box-shadow] md:px-4 md:py-3 md:text-sm",
                 sidebarView === "channels"
-                  ? "border-cyan-500 border-b-2 bg-[linear-gradient(to_top,rgba(34,211,238,0.12),transparent)] text-cyan-700 shadow-[inset_0_-1px_0_rgba(34,211,238,0.18)] dark:border-cyan-300 dark:text-cyan-200"
-                  : "cursor-pointer border-transparent border-b-2 text-slate-500 hover:bg-cyan-400/5 hover:text-cyan-700 dark:text-slate-400 dark:hover:text-cyan-100",
+                  ? "border-blue-500 border-b-2 bg-[linear-gradient(to_top,rgba(59,130,246,0.12),transparent)] text-blue-700 shadow-[inset_0_-1px_0_rgba(59,130,246,0.18)] dark:border-blue-300 dark:text-blue-200"
+                  : "cursor-pointer border-transparent border-b-2 text-slate-500 hover:bg-blue-400/5 hover:text-blue-700 dark:text-slate-400 dark:hover:text-blue-100",
               )}
             >
               {t("channels")} ({metadata?.channels.length || 0})
@@ -462,8 +462,8 @@ function PlayerPage() {
               className={clsx(
                 "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap px-3 py-2 text-center font-semibold text-xs leading-5 tracking-[0.01em] transition-[color,background-color,border-color,box-shadow] md:px-4 md:py-3 md:text-sm",
                 sidebarView === "epg"
-                  ? "border-cyan-500 border-b-2 bg-[linear-gradient(to_top,rgba(34,211,238,0.12),transparent)] text-cyan-700 shadow-[inset_0_-1px_0_rgba(34,211,238,0.18)] dark:border-cyan-300 dark:text-cyan-200"
-                  : "cursor-pointer border-transparent border-b-2 text-slate-500 hover:bg-cyan-400/5 hover:text-cyan-700 dark:text-slate-400 dark:hover:text-cyan-100",
+                  ? "border-blue-500 border-b-2 bg-[linear-gradient(to_top,rgba(59,130,246,0.12),transparent)] text-blue-700 shadow-[inset_0_-1px_0_rgba(59,130,246,0.18)] dark:border-blue-300 dark:text-blue-200"
+                  : "cursor-pointer border-transparent border-b-2 text-slate-500 hover:bg-blue-400/5 hover:text-blue-700 dark:text-slate-400 dark:hover:text-blue-100",
               )}
             >
               {t("programGuide")}
@@ -503,17 +503,17 @@ function PlayerPage() {
     const playlistErrorHints = [t("playlistErrorHintReachable"), t("playlistErrorHintFormat")];
 
     return (
-      <div className="min-h-dvh bg-[radial-gradient(circle_at_18%_14%,rgba(34,211,238,0.16),transparent_28%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.16),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_18%_14%,rgba(34,211,238,0.1),transparent_30%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.13),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]">
+      <div className="min-h-dvh bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.16),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.13),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]">
         <title>{t("title")}</title>
         <div className="mx-auto flex min-h-dvh w-[calc(100%-2rem)] max-w-5xl items-center py-8 sm:w-[calc(100%-3rem)]">
-          <Card className="min-w-0 w-full overflow-hidden rounded-3xl border-cyan-900/10 bg-white/72 shadow-[0_28px_80px_rgba(30,64,175,0.16),inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-2xl dark:border-cyan-100/12 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.9),rgba(26,24,72,0.82))] dark:shadow-[0_30px_90px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
+          <Card className="min-w-0 w-full overflow-hidden rounded-3xl border-blue-900/10 bg-white/72 shadow-[0_28px_80px_rgba(30,64,175,0.16),inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-2xl dark:border-blue-100/12 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.9),rgba(26,24,72,0.82))] dark:shadow-[0_30px_90px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
             <div className="grid min-w-0 md:grid-cols-[minmax(0,1fr)_18rem]">
               <div className="min-w-0 p-6 sm:p-8 md:p-10">
                 <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-2xl border border-rose-300/20 bg-[linear-gradient(145deg,rgba(251,113,133,0.16),rgba(99,102,241,0.12))] text-rose-500 shadow-[0_12px_28px_rgba(225,29,72,0.12)] dark:text-rose-300">
                   <AlertTriangle className="h-6 w-6" aria-hidden="true" />
                 </div>
 
-                <div className="font-semibold text-cyan-700 text-sm dark:text-cyan-200">{t("playlistLoadEyebrow")}</div>
+                <div className="font-semibold text-blue-700 text-sm dark:text-blue-200">{t("playlistLoadEyebrow")}</div>
                 <h1 className="mt-2 text-balance font-semibold text-2xl text-foreground leading-tight tracking-tight sm:text-3xl">
                   {t("playlistLoadTitle")}
                 </h1>
@@ -521,16 +521,16 @@ function PlayerPage() {
                   {t("playlistLoadDescription")}
                 </p>
 
-                <div className="mt-6 min-w-0 rounded-2xl border border-cyan-900/10 bg-cyan-50/45 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] dark:border-cyan-100/10 dark:bg-cyan-300/6">
+                <div className="mt-6 min-w-0 rounded-2xl border border-blue-900/10 bg-blue-50/45 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] dark:border-blue-100/10 dark:bg-blue-300/6">
                   <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                    <ListChecks className="h-4 w-4 text-cyan-600 dark:text-cyan-300" aria-hidden="true" />
+                    <ListChecks className="h-4 w-4 text-blue-600 dark:text-blue-300" aria-hidden="true" />
                     {t("playlistErrorChecklist")}
                   </div>
                   <ul className="mt-3 space-y-2 text-sm leading-5 text-muted-foreground">
                     {playlistErrorHints.map((hint) => (
                       <li key={hint} className="flex min-w-0 gap-2">
                         <span
-                          className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-cyan-500 shadow-[0_0_8px_rgba(34,211,238,0.45)]"
+                          className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.45)]"
                           aria-hidden="true"
                         />
                         <span className="min-w-0 break-words">{hint}</span>
@@ -543,7 +543,7 @@ function PlayerPage() {
                   <Button
                     type="button"
                     onClick={loadPlaylist}
-                    className="w-full gap-2 rounded-xl bg-[linear-gradient(135deg,#0e7490,#4338ca)] text-white shadow-[0_10px_28px_rgba(8,145,178,0.24)] hover:brightness-105 sm:w-auto"
+                    className="w-full gap-2 rounded-xl bg-[linear-gradient(135deg,#0e7490,#4338ca)] text-white shadow-[0_10px_28px_rgba(37,99,235,0.24)] hover:brightness-105 sm:w-auto"
                   >
                     <RefreshCw className="h-4 w-4" aria-hidden="true" />
                     {t("retry")}
@@ -555,7 +555,7 @@ function PlayerPage() {
                     className={buttonVariants({
                       variant: "outline",
                       className:
-                        "w-full gap-2 rounded-xl border-cyan-900/12 bg-white/55 text-cyan-800 shadow-sm hover:bg-cyan-50 dark:border-cyan-100/15 dark:bg-slate-950/35 dark:text-cyan-100 dark:hover:bg-cyan-300/10 sm:w-auto",
+                        "w-full gap-2 rounded-xl border-blue-900/12 bg-white/55 text-blue-800 shadow-sm hover:bg-blue-50 dark:border-blue-100/15 dark:bg-slate-950/35 dark:text-blue-100 dark:hover:bg-blue-300/10 sm:w-auto",
                     })}
                   >
                     {t("m3uIntegrationGuide")}
@@ -564,9 +564,9 @@ function PlayerPage() {
                 </div>
               </div>
 
-              <div className="min-w-0 border-cyan-900/10 border-t bg-[linear-gradient(145deg,rgba(224,242,254,0.42),rgba(238,242,255,0.58))] p-6 dark:border-cyan-100/10 dark:bg-[linear-gradient(145deg,rgba(8,47,73,0.22),rgba(30,27,75,0.3))] md:border-t-0 md:border-l md:p-8">
+              <div className="min-w-0 border-blue-900/10 border-t bg-[linear-gradient(145deg,rgba(224,242,254,0.42),rgba(238,242,255,0.58))] p-6 dark:border-blue-100/10 dark:bg-[linear-gradient(145deg,rgba(8,47,73,0.22),rgba(30,27,75,0.3))] md:border-t-0 md:border-l md:p-8">
                 <div className="text-sm font-semibold text-foreground">{t("playlistEndpoint")}</div>
-                <div className="mt-3 break-all rounded-xl border border-cyan-900/10 bg-white/55 px-3 py-2 font-mono text-foreground text-sm leading-5 shadow-inner dark:border-cyan-100/10 dark:bg-slate-950/42">
+                <div className="mt-3 break-all rounded-xl border border-blue-900/10 bg-white/55 px-3 py-2 font-mono text-foreground text-sm leading-5 shadow-inner dark:border-blue-100/10 dark:bg-slate-950/42">
                   {buildAppPath("/playlist.m3u")}
                 </div>
                 <div className="mt-6 text-sm font-semibold text-foreground">{t("technicalDetails")}</div>
@@ -587,13 +587,13 @@ function PlayerPage() {
       {isLoading && (
         <div
           className={clsx(
-            "fixed inset-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(34,211,238,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_center,rgba(34,211,238,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
+            "fixed inset-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
             isRevealing && "animate-zoom-fade-out",
           )}
         >
           <div className="text-center space-y-4">
             {/* Loading spinner */}
-            <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-cyan-950/10 border-t-cyan-500 border-r-indigo-500 shadow-[0_0_28px_rgba(34,211,238,0.22)] dark:border-cyan-100/10 dark:border-t-cyan-300 dark:border-r-indigo-400" />
+            <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-blue-950/10 border-t-blue-500 border-r-indigo-500 shadow-[0_0_28px_rgba(59,130,246,0.22)] dark:border-blue-100/10 dark:border-t-blue-300 dark:border-r-indigo-400" />
           </div>
         </div>
       )}

--- a/web-ui/src/pages/status.tsx
+++ b/web-ui/src/pages/status.tsx
@@ -164,10 +164,10 @@ function StatusPage() {
 
   const statusAccent =
     connectionState === "connected"
-      ? "text-emerald-500"
+      ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 shadow-[0_0_24px_-12px_rgba(16,185,129,0.85)] dark:text-emerald-300"
       : connectionState === "reconnecting"
-        ? "text-amber-500"
-        : "text-destructive";
+        ? "border-amber-500/25 bg-amber-500/10 text-amber-700 shadow-[0_0_24px_-12px_rgba(245,158,11,0.8)] dark:text-amber-300"
+        : "border-rose-500/25 bg-rose-500/10 text-rose-700 shadow-[0_0_24px_-12px_rgba(244,63,94,0.8)] dark:text-rose-300";
 
   const stats = useMemo(
     () => [
@@ -202,8 +202,8 @@ function StatusPage() {
   return (
     <>
       <title>{t("title")}</title>
-      <div className="min-h-screen bg-background pb-12">
-        <div className="mx-auto flex w-full flex-col gap-4 sm:gap-6 p-3 sm:p-6">
+      <div className="app-ambient relative isolate min-h-screen overflow-x-hidden bg-background pb-12">
+        <div className="relative z-10 mx-auto flex w-full flex-col gap-4 p-3 sm:gap-6 sm:p-6">
           <StatusHeader
             statusAccent={statusAccent}
             statusLabel={statusLabel}

--- a/web-ui/src/pages/status.tsx
+++ b/web-ui/src/pages/status.tsx
@@ -202,7 +202,7 @@ function StatusPage() {
   return (
     <>
       <title>{t("title")}</title>
-      <div className="app-ambient relative isolate min-h-screen overflow-x-hidden bg-background pb-12">
+      <div className="relative isolate min-h-screen overflow-x-hidden bg-background bg-[radial-gradient(circle_at_8%_-8%,hsl(252_92%_72%/0.2),transparent_34rem),radial-gradient(circle_at_96%_2%,hsl(190_96%_60%/0.14),transparent_30rem),linear-gradient(180deg,hsl(226_56%_98%/0.68),hsl(var(--background))_28rem)] bg-fixed pb-12 dark:bg-[radial-gradient(circle_at_8%_-10%,hsl(252_92%_66%/0.18),transparent_36rem),radial-gradient(circle_at_94%_0%,hsl(190_96%_52%/0.11),transparent_32rem),linear-gradient(180deg,hsl(231_48%_9%/0.8),hsl(var(--background))_30rem)] max-md:bg-scroll">
         <div className="relative z-10 mx-auto flex w-full flex-col gap-4 p-3 sm:gap-6 sm:p-6">
           <StatusHeader
             statusAccent={statusAccent}

--- a/web-ui/status.html
+++ b/web-ui/status.html
@@ -7,6 +7,8 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>rtp2httpd Status</title>
     <link rel="icon" type="image/png" href="./assets/icon.png" />
+    <meta name="theme-color" content="#f4f6fc" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#090b1a" media="(prefers-color-scheme: dark)" />
     <script>
       (() => {
         try {


### PR DESCRIPTION
## Summary

Refresh the built-in web player and status dashboard with a cohesive modern visual system while preserving the existing information architecture and interaction structure.

- introduce updated color, radius, typography, shadow, transparency, and blur treatments
- refine bilingual spacing, alignment, and responsive behavior across English and Chinese
- improve player navigation, channel cards, settings, controls, and error states
- improve dashboard headers, statistics, connections, worker metrics, logs, and service controls
- synchronize the document language with the selected locale and respect reduced-motion preferences

## Impact

The player and dashboard now feel more polished and consistent across desktop and mobile layouts. Long English labels and compact Chinese labels retain balanced padding, stable control heights, and predictable wrapping without page-level horizontal overflow.

## Screenshots

Screenshots will be attached to this PR description.

## Validation

- `pnpm run lint:biome`
- `pnpm run type-check:tsc`
- `pnpm exec vite build web-ui`
- `git diff --check`
- visual checks in English and Simplified Chinese at 390, 768, 1024, and 1280 px