### PR TITLE
perf(web-ui): optimize rendering and share settings controls

### DIFF
--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -9,6 +9,7 @@ import {
   PLAYER_LIST_SURFACE_DEFAULT_CLASS,
   PLAYER_LIST_SURFACE_HOVER_CLASS,
   PLAYER_LIST_SURFACE_SELECTED_CLASS,
+  PLAYER_SCROLL_LIST_ITEM_CLASS,
 } from "./classnames";
 import { PlayerSelectedGlassLayers } from "./player-selected-glass-layers";
 
@@ -36,6 +37,7 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
         ref={ref}
         className={clsx(
           PLAYER_LIST_SURFACE_BASE_CLASS,
+          PLAYER_SCROLL_LIST_ITEM_CLASS,
           "group flex w-full cursor-pointer items-center gap-2 p-2 text-left",
           isCurrentChannel ? PLAYER_LIST_SURFACE_SELECTED_CLASS : PLAYER_LIST_SURFACE_DEFAULT_CLASS,
           !isCurrentChannel && PLAYER_LIST_SURFACE_HOVER_CLASS,

--- a/web-ui/src/components/player/classnames.ts
+++ b/web-ui/src/components/player/classnames.ts
@@ -7,6 +7,9 @@ export const PLAYER_CONTROL_BUTTON_CLASS =
 export const PLAYER_LIST_SURFACE_BASE_CLASS =
   "relative isolate overflow-hidden rounded-2xl border text-card-foreground transition-[color,background-color,border-color,box-shadow,backdrop-filter] duration-300 ease-out motion-reduce:transition-none";
 
+export const PLAYER_SCROLL_LIST_ITEM_CLASS =
+  "[content-visibility:auto] [contain-intrinsic-size:auto_3.25rem] md:[contain-intrinsic-size:auto_3.75rem]";
+
 export const PLAYER_LIST_SURFACE_SELECTED_CLASS =
   "border-blue-300/65 bg-white/38 shadow-[0_16px_32px_-18px_rgba(37,99,235,0.46),0_0_20px_-12px_rgba(59,130,246,0.42),inset_0_1px_0_rgba(255,255,255,0.78),inset_0_-1px_0_rgba(37,99,235,0.12)] backdrop-blur-md backdrop-saturate-150 dark:border-blue-200/55 dark:bg-slate-900/30 dark:shadow-[0_18px_36px_-18px_rgba(0,0,0,0.82),0_0_28px_-12px_rgba(59,130,246,0.62),inset_0_1px_0_rgba(255,255,255,0.17),inset_0_-1px_0_rgba(59,130,246,0.14)]";
 

--- a/web-ui/src/components/player/epg-view.tsx
+++ b/web-ui/src/components/player/epg-view.tsx
@@ -10,6 +10,7 @@ import {
   PLAYER_LIST_SURFACE_DEFAULT_CLASS,
   PLAYER_LIST_SURFACE_HOVER_CLASS,
   PLAYER_LIST_SURFACE_SELECTED_CLASS,
+  PLAYER_SCROLL_LIST_ITEM_CLASS,
 } from "./classnames";
 import { PlayerSelectedGlassLayers } from "./player-selected-glass-layers";
 
@@ -186,6 +187,7 @@ function EPGViewComponent({
                         ref={playing ? currentProgramRef : null}
                         className={clsx(
                           PLAYER_LIST_SURFACE_BASE_CLASS,
+                          PLAYER_SCROLL_LIST_ITEM_CLASS,
                           "w-full text-left",
                           playing ? PLAYER_LIST_SURFACE_SELECTED_CLASS : PLAYER_LIST_SURFACE_DEFAULT_CLASS,
                           !playing && isPast && "opacity-65",

--- a/web-ui/src/components/player/settings-dropdown.tsx
+++ b/web-ui/src/components/player/settings-dropdown.tsx
@@ -1,10 +1,10 @@
 import { Settings } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
-import type { TranslationKey } from "../../i18n/player";
-import type { Locale } from "../../lib/locale";
-import type { ThemeMode } from "../../types/ui";
-import { Switch } from "../ui/switch";
+import { LOCALE_OPTIONS, type Locale } from "../../lib/locale";
+import { THEME_LABEL_KEYS, THEME_MODES, type ThemeMode } from "../../types/ui";
+import { LabeledSwitch } from "../ui/labeled-switch";
+import { SelectBox } from "../ui/select-box";
 
 interface SettingsDropdownProps {
   locale: Locale;
@@ -19,43 +19,11 @@ interface SettingsDropdownProps {
   onPictureEnhancementChange: (enabled: boolean) => void;
 }
 
-const localeOptions: Array<{ value: Locale; label: string }> = [
-  { value: "en", label: "English" },
-  { value: "zh-Hans", label: "简体中文" },
-  { value: "zh-Hant", label: "繁體中文" },
-];
-
-const themeOptions: ThemeMode[] = ["auto", "light", "dark"];
-
-const themeLabels: Record<ThemeMode, TranslationKey> = {
-  auto: "themeAuto",
-  light: "themeLight",
-  dark: "themeDark",
-};
-
 const SETTING_LABEL_CLASS = "mb-1.5 block px-0.5 font-medium text-slate-500 text-xs leading-4 dark:text-blue-50/55";
-const SETTING_SELECT_CLASS =
-  "h-9 w-full cursor-pointer rounded-xl border border-blue-900/10 bg-white/78 px-3 py-0 pr-8 text-foreground text-sm shadow-none transition-[color,background-color,border-color] hover:border-blue-400/25 hover:bg-blue-50/70 focus:outline-none focus:ring-2 focus:ring-blue-400/35 dark:border-blue-100/10 dark:bg-slate-900/85 dark:hover:bg-slate-800/90";
-
-interface SettingSwitchProps {
-  label: string;
-  value: boolean;
-  onChange: (checked: boolean) => void;
-}
-
-function SettingSwitch({ label, value, onChange }: SettingSwitchProps) {
-  return (
-    <div className="flex min-h-6 items-center justify-between gap-3 px-0.5">
-      <span className="min-w-0 flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">{label}</span>
-      <Switch
-        checked={value}
-        onCheckedChange={onChange}
-        aria-label={label}
-        className="border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80"
-      />
-    </div>
-  );
-}
+const SETTING_SWITCH_CLASS = "min-h-6 gap-3 px-0.5";
+const SETTING_SWITCH_LABEL_CLASS = "flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65";
+const SETTING_SWITCH_CONTROL_CLASS =
+  "border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80";
 
 function SettingsDropdownComponent({
   locale,
@@ -101,39 +69,54 @@ function SettingsDropdownComponent({
         <div className="absolute top-full right-0 z-50 mt-1 w-52 max-w-[calc(100vw-1rem)] rounded-2xl border border-blue-900/12 bg-[linear-gradient(145deg,rgba(255,255,255,0.9),rgba(238,242,255,0.82))] shadow-[0_20px_55px_rgba(30,64,175,0.18),inset_0_1px_0_rgba(255,255,255,0.82)] backdrop-blur-2xl dark:border-blue-100/15 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.94),rgba(26,24,72,0.9))] dark:shadow-[0_22px_60px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
           <div className="space-y-3.5 p-3">
             {/* Language Select */}
-            <label className="block">
-              <span className={SETTING_LABEL_CLASS}>{t("language")}</span>
-              <select
+            <div>
+              <label htmlFor="player-settings-locale" className={SETTING_LABEL_CLASS}>
+                {t("language")}
+              </label>
+              <SelectBox
+                id="player-settings-locale"
                 value={locale}
                 onChange={(e) => onLocaleChange(e.target.value as Locale)}
-                className={SETTING_SELECT_CLASS}
+                containerClassName="w-full min-w-0"
+                aria-label={t("language")}
               >
-                {localeOptions.map((option) => (
+                {LOCALE_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value}>
                     {option.label}
                   </option>
                 ))}
-              </select>
-            </label>
+              </SelectBox>
+            </div>
 
             {/* Theme Select */}
-            <label className="block">
-              <span className={SETTING_LABEL_CLASS}>{t("theme")}</span>
-              <select
+            <div>
+              <label htmlFor="player-settings-theme" className={SETTING_LABEL_CLASS}>
+                {t("theme")}
+              </label>
+              <SelectBox
+                id="player-settings-theme"
                 value={theme}
                 onChange={(e) => onThemeChange(e.target.value as ThemeMode)}
-                className={SETTING_SELECT_CLASS}
+                containerClassName="w-full min-w-0"
+                aria-label={t("theme")}
               >
-                {themeOptions.map((option) => (
+                {THEME_MODES.map((option) => (
                   <option key={option} value={option}>
-                    {t(themeLabels[option])}
+                    {t(THEME_LABEL_KEYS[option])}
                   </option>
                 ))}
-              </select>
-            </label>
+              </SelectBox>
+            </div>
 
             {/* Seamless channel/source switch (dual-slot preload) */}
-            <SettingSwitch label={t("seamlessSwitch")} value={seamlessSwitch} onChange={onSeamlessSwitchChange} />
+            <LabeledSwitch
+              label={t("seamlessSwitch")}
+              checked={seamlessSwitch}
+              onCheckedChange={onSeamlessSwitchChange}
+              className={SETTING_SWITCH_CLASS}
+              labelClassName={SETTING_SWITCH_LABEL_CLASS}
+              switchClassName={SETTING_SWITCH_CONTROL_CLASS}
+            />
 
             {/* Video processing group: deinterlace + picture enhancement.
                 Both only take effect for 1080p-and-below content, so the
@@ -149,13 +132,23 @@ function SettingsDropdownComponent({
               </div>
 
               {/* Automatic deinterlacing (heuristic detection, ≤1080 content only) */}
-              <SettingSwitch label={t("deinterlace")} value={autoDeinterlace} onChange={onAutoDeinterlaceChange} />
+              <LabeledSwitch
+                label={t("deinterlace")}
+                checked={autoDeinterlace}
+                onCheckedChange={onAutoDeinterlaceChange}
+                className={SETTING_SWITCH_CLASS}
+                labelClassName={SETTING_SWITCH_LABEL_CLASS}
+                switchClassName={SETTING_SWITCH_CONTROL_CLASS}
+              />
 
               {/* Picture enhancement (WebGL post-processing inside the render gate) */}
-              <SettingSwitch
+              <LabeledSwitch
                 label={t("pictureEnhancement")}
-                value={pictureEnhancement}
-                onChange={onPictureEnhancementChange}
+                checked={pictureEnhancement}
+                onCheckedChange={onPictureEnhancementChange}
+                className={SETTING_SWITCH_CLASS}
+                labelClassName={SETTING_SWITCH_LABEL_CLASS}
+                switchClassName={SETTING_SWITCH_CONTROL_CLASS}
               />
             </div>
           </div>

--- a/web-ui/src/components/status/classnames.ts
+++ b/web-ui/src/components/status/classnames.ts
@@ -11,3 +11,5 @@ export const STATUS_SECTION_TITLE_CLASS = "text-xl font-semibold tracking-[-0.02
 
 export const STATUS_CONTROL_GROUP_CLASS =
   "min-h-11 rounded-xl border border-border/40 bg-background/35 px-3 py-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-md dark:border-white/8 dark:bg-background/25 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
+
+export const STATUS_LOG_ENTRY_CLASS = "[content-visibility:auto] [contain-intrinsic-size:auto_2.5rem]";

--- a/web-ui/src/components/status/connections-section.tsx
+++ b/web-ui/src/components/status/connections-section.tsx
@@ -8,7 +8,7 @@ import type { BandwidthUnit } from "../../types/ui";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
-import { Switch } from "../ui/switch";
+import { LabeledSwitch } from "../ui/labeled-switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../ui/table";
 import {
   STATUS_CONTROL_GROUP_CLASS,
@@ -76,14 +76,13 @@ export function ConnectionsSection({
     <section className={clsx(STATUS_PANEL_CLASS, "flex flex-col p-5 sm:p-6")}>
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <h2 className={STATUS_SECTION_TITLE_CLASS}>{t("connections")}</h2>
-        <div className={clsx("flex items-center gap-3 text-sm text-muted-foreground", STATUS_CONTROL_GROUP_CLASS)}>
-          <span className="whitespace-nowrap font-medium text-card-foreground">{t("showDisconnected")}</span>
-          <Switch
-            checked={showDisconnected}
-            onCheckedChange={onShowDisconnectedChange}
-            aria-label={t("showDisconnected")}
-          />
-        </div>
+        <LabeledSwitch
+          label={t("showDisconnected")}
+          checked={showDisconnected}
+          onCheckedChange={onShowDisconnectedChange}
+          className={clsx("gap-3 text-sm text-muted-foreground", STATUS_CONTROL_GROUP_CLASS)}
+          labelClassName="whitespace-nowrap font-medium text-card-foreground"
+        />
       </div>
 
       {clients.length === 0 ? (

--- a/web-ui/src/components/status/logs-section.tsx
+++ b/web-ui/src/components/status/logs-section.tsx
@@ -4,8 +4,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useStatusTranslation } from "../../hooks/use-status-translation";
 import type { Locale } from "../../lib/locale";
 import type { LogEntry } from "../../types";
+import { LabeledSwitch } from "../ui/labeled-switch";
 import { SelectBox } from "../ui/select-box";
-import { Switch } from "../ui/switch";
 import {
   STATUS_CONTROL_GROUP_CLASS,
   STATUS_LOG_ENTRY_CLASS,
@@ -91,7 +91,7 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
               onChange={(event) => onLogLevelChange(event.target.value)}
               disabled={disabled}
               containerClassName="min-w-[120px]"
-              className="border-border/40 bg-background/70 text-sm font-medium shadow-none backdrop-blur-none hover:border-primary/30"
+              className="text-sm font-medium"
               aria-label={t("logLevel")}
             >
               {!logLevelValue && <option value="">--</option>}
@@ -102,15 +102,14 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
               ))}
             </SelectBox>
           </div>
-          <div className={clsx("flex items-center gap-2", STATUS_CONTROL_GROUP_CLASS)}>
-            <span className="whitespace-nowrap">{t("autoScroll")}:</span>
-            <Switch
-              checked={autoScroll}
-              onCheckedChange={setAutoScroll}
-              disabled={disabled}
-              aria-label={t("autoScroll")}
-            />
-          </div>
+          <LabeledSwitch
+            label={`${t("autoScroll")}:`}
+            checked={autoScroll}
+            onCheckedChange={setAutoScroll}
+            disabled={disabled}
+            className={clsx("gap-2", STATUS_CONTROL_GROUP_CLASS)}
+            labelClassName="whitespace-nowrap"
+          />
         </div>
       </div>
       <div

--- a/web-ui/src/components/status/logs-section.tsx
+++ b/web-ui/src/components/status/logs-section.tsx
@@ -6,7 +6,12 @@ import type { Locale } from "../../lib/locale";
 import type { LogEntry } from "../../types";
 import { SelectBox } from "../ui/select-box";
 import { Switch } from "../ui/switch";
-import { STATUS_CONTROL_GROUP_CLASS, STATUS_PANEL_CLASS, STATUS_SECTION_TITLE_CLASS } from "./classnames";
+import {
+  STATUS_CONTROL_GROUP_CLASS,
+  STATUS_LOG_ENTRY_CLASS,
+  STATUS_PANEL_CLASS,
+  STATUS_SECTION_TITLE_CLASS,
+} from "./classnames";
 
 function getLogLevelClass(levelName: string): string {
   switch (levelName.toUpperCase()) {
@@ -119,7 +124,10 @@ export function LogsSection({ logs, logLevelValue, onLogLevelChange, disabled, o
             {logs.map((log) => (
               <div
                 key={`${log.timestamp}-${log.message}`}
-                className="rounded-lg border border-white/4 bg-white/[0.025] p-2 text-sm text-slate-200 whitespace-pre-wrap transition-colors hover:border-white/8 hover:bg-white/4"
+                className={clsx(
+                  STATUS_LOG_ENTRY_CLASS,
+                  "rounded-lg border border-white/4 bg-white/[0.025] p-2 text-sm text-slate-200 whitespace-pre-wrap transition-colors hover:border-white/8 hover:bg-white/4",
+                )}
               >
                 <span className="text-slate-500 tabular-nums sm:inline-block sm:min-w-[10.5rem]">
                   {timestampFormatter.format(new Date(log.timestamp))}

--- a/web-ui/src/components/status/status-header.tsx
+++ b/web-ui/src/components/status/status-header.tsx
@@ -2,9 +2,8 @@ import { clsx } from "clsx";
 import { Activity, Globe, Moon, Sun, Wifi } from "lucide-react";
 import type { ReactNode } from "react";
 import { useStatusTranslation } from "../../hooks/use-status-translation";
-import type { TranslationKey } from "../../i18n/status";
-import type { Locale } from "../../lib/locale";
-import type { BandwidthUnit, ThemeMode } from "../../types/ui";
+import { LOCALE_OPTIONS, type Locale } from "../../lib/locale";
+import { type BandwidthUnit, THEME_LABEL_KEYS, THEME_MODES, type ThemeMode } from "../../types/ui";
 import { Badge } from "../ui/badge";
 import { SelectBox } from "../ui/select-box";
 import { STATUS_CONTROL_GROUP_CLASS, STATUS_PANEL_CLASS } from "./classnames";
@@ -17,11 +16,8 @@ interface StatusHeaderProps {
   version: string;
   locale: Locale;
   onLocaleChange: (locale: Locale) => void;
-  localeOptions: Array<{ value: Locale; label: string }>;
   theme: ThemeMode;
   onThemeChange: (theme: ThemeMode) => void;
-  themeOptions: ThemeMode[];
-  themeLabels: Record<ThemeMode, TranslationKey>;
   bandwidthUnit: BandwidthUnit;
   onBandwidthUnitChange: (unit: BandwidthUnit) => void;
 }
@@ -58,7 +54,6 @@ function HeaderSelect<T extends string>({
         value={value}
         onChange={(event) => onChange(event.target.value as T)}
         containerClassName={clsx("min-w-0 flex-1 md:flex-none", containerClassName)}
-        className="border-border/40 bg-background/70 shadow-none backdrop-blur-none transition-colors hover:border-primary/30"
         aria-label={label}
       >
         {options.map((option) => (
@@ -79,16 +74,13 @@ export function StatusHeader({
   version,
   locale,
   onLocaleChange,
-  localeOptions,
   theme,
   onThemeChange,
-  themeOptions,
-  themeLabels,
   bandwidthUnit,
   onBandwidthUnitChange,
 }: StatusHeaderProps) {
   const t = useStatusTranslation(locale);
-  const themeSelectOptions = themeOptions.map((option) => ({ value: option, label: t(themeLabels[option]) }));
+  const themeSelectOptions = THEME_MODES.map((option) => ({ value: option, label: t(THEME_LABEL_KEYS[option]) }));
   return (
     <header
       className={clsx(
@@ -130,7 +122,7 @@ export function StatusHeader({
             label={t("language")}
             value={locale}
             onChange={onLocaleChange}
-            options={localeOptions}
+            options={LOCALE_OPTIONS}
           />
           <HeaderSelect
             icon={theme === "dark" ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}

--- a/web-ui/src/components/ui/labeled-switch.tsx
+++ b/web-ui/src/components/ui/labeled-switch.tsx
@@ -1,0 +1,36 @@
+import { clsx } from "clsx";
+import type { HTMLAttributes } from "react";
+import { Switch } from "./switch";
+
+export interface LabeledSwitchProps extends HTMLAttributes<HTMLDivElement> {
+  label: string;
+  checked?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  disabled?: boolean;
+  labelClassName?: string;
+  switchClassName?: string;
+}
+
+export function LabeledSwitch({
+  label,
+  checked,
+  onCheckedChange,
+  disabled,
+  className,
+  labelClassName,
+  switchClassName,
+  ...props
+}: LabeledSwitchProps) {
+  return (
+    <div className={clsx("flex items-center justify-between", className)} {...props}>
+      <span className={clsx("min-w-0", labelClassName)}>{label}</span>
+      <Switch
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        disabled={disabled}
+        aria-label={label}
+        className={switchClassName}
+      />
+    </div>
+  );
+}

--- a/web-ui/src/components/ui/select-box.tsx
+++ b/web-ui/src/components/ui/select-box.tsx
@@ -8,7 +8,7 @@ export interface SelectBoxProps extends SelectHTMLAttributes<HTMLSelectElement> 
 
 export function SelectBox({ containerClassName = "min-w-[120px]", className, children, ...props }: SelectBoxProps) {
   return (
-    <div className={clsx("relative inline-flex items-center justify-end", containerClassName)}>
+    <div className={clsx("relative inline-flex items-center justify-end py-1", containerClassName)}>
       <select
         className={clsx(
           "peer h-9 w-full cursor-pointer appearance-none rounded-[var(--radius)] border border-input/80 bg-background/82 px-3 pr-10 font-semibold text-foreground text-sm shadow-none transition-[color,background-color,border-color,box-shadow] hover:border-primary/30 hover:bg-background/75 motion-reduce:transition-none focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 dark:bg-secondary/72",

--- a/web-ui/src/components/ui/select-box.tsx
+++ b/web-ui/src/components/ui/select-box.tsx
@@ -11,7 +11,7 @@ export function SelectBox({ containerClassName = "min-w-[120px]", className, chi
     <div className={clsx("relative inline-flex items-center justify-end py-1", containerClassName)}>
       <select
         className={clsx(
-          "peer h-9 w-full cursor-pointer appearance-none rounded-[var(--radius)] border border-input/80 bg-background/82 px-3 pr-10 font-semibold text-foreground text-sm shadow-none transition-[color,background-color,border-color,box-shadow] hover:border-primary/30 hover:bg-background/75 motion-reduce:transition-none focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 dark:bg-secondary/72",
+          "peer h-9 w-full cursor-pointer appearance-none rounded-[var(--radius)] border border-border/40 bg-background/70 px-3 pr-10 font-semibold text-foreground text-sm shadow-none transition-[color,background-color,border-color,box-shadow] hover:border-primary/30 hover:bg-background/75 motion-reduce:transition-none focus-visible:border-primary/50 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 dark:bg-secondary/72",
           className,
         )}
         {...props}

--- a/web-ui/src/lib/locale.ts
+++ b/web-ui/src/lib/locale.ts
@@ -1,6 +1,14 @@
 export const SUPPORTED_LOCALES = ["en", "zh-Hans", "zh-Hant"] as const;
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 
+export const LOCALE_LABELS: Record<Locale, string> = {
+  en: "English",
+  "zh-Hans": "简体中文",
+  "zh-Hant": "繁體中文",
+};
+
+export const LOCALE_OPTIONS = SUPPORTED_LOCALES.map((value) => ({ value, label: LOCALE_LABELS[value] }));
+
 export function normalizeLocale(locale: string | undefined): Locale | null {
   if (!locale) return null;
   const lower = locale.toLowerCase();

--- a/web-ui/src/pages/status.tsx
+++ b/web-ui/src/pages/status.tsx
@@ -13,12 +13,10 @@ import { useSse } from "../hooks/use-sse";
 import { useStatusApi } from "../hooks/use-status-api";
 import { useStatusTranslation } from "../hooks/use-status-translation";
 import { useTheme } from "../hooks/use-theme";
-import type { TranslationKey } from "../i18n/status";
 import { formatBandwidth, formatBytes, formatDuration } from "../lib/format";
-import type { Locale } from "../lib/locale";
 import { mergeClients } from "../lib/status";
 import type { ClientRow, LogEntry, StatusPayload } from "../types";
-import type { ConnectionState, ThemeMode } from "../types/ui";
+import type { ConnectionState } from "../types/ui";
 
 const LOG_LEVELS: Array<{ value: number; label: string }> = [
   { value: 0, label: "FATAL" },
@@ -27,19 +25,6 @@ const LOG_LEVELS: Array<{ value: number; label: string }> = [
   { value: 3, label: "INFO" },
   { value: 4, label: "DEBUG" },
 ];
-
-const localeOptions: Array<{ value: Locale; label: string }> = [
-  { value: "en", label: "English" },
-  { value: "zh-Hans", label: "简体中文" },
-  { value: "zh-Hant", label: "繁體中文" },
-];
-
-const THEME_OPTIONS: ThemeMode[] = ["auto", "light", "dark"];
-const THEME_LABELS: Record<ThemeMode, TranslationKey> = {
-  auto: "themeAuto",
-  light: "themeLight",
-  dark: "themeDark",
-};
 
 const MAX_LOG_ENTRIES = 500;
 
@@ -212,11 +197,8 @@ function StatusPage() {
             version={payload?.version ?? "--"}
             locale={locale}
             onLocaleChange={setLocale}
-            localeOptions={localeOptions}
             theme={theme}
             onThemeChange={setTheme}
-            themeOptions={THEME_OPTIONS}
-            themeLabels={THEME_LABELS}
             bandwidthUnit={bandwidthUnit}
             onBandwidthUnitChange={setBandwidthUnit}
           />

--- a/web-ui/src/types/ui.ts
+++ b/web-ui/src/types/ui.ts
@@ -1,6 +1,12 @@
 export const THEME_MODES = ["auto", "light", "dark"] as const;
 export type ThemeMode = (typeof THEME_MODES)[number];
 
+export const THEME_LABEL_KEYS = {
+  auto: "themeAuto",
+  light: "themeLight",
+  dark: "themeDark",
+} as const satisfies Record<ThemeMode, string>;
+
 export type ConnectionState = "connected" | "disconnected" | "reconnecting";
 
 export const BANDWIDTH_UNITS = ["bits", "bytes"] as const;


### PR DESCRIPTION
## Summary

- Apply native CSS `content-visibility: auto` to channel, program guide, and status log entries.
- Use responsive intrinsic-size fallbacks for predictable player list rows and a conservative single-line fallback for variable-height logs.
- Reuse the shared `SelectBox` in Player settings and standardize its appearance with the Status page controls.
- Centralize locale options, theme modes, and theme translation keys.
- Add a shared `LabeledSwitch` and migrate matching Player and Status controls to it.

## Rationale

Large channel, program guide, and log lists keep many DOM nodes mounted. Skipping off-screen layout and paint work reduces rendering cost without introducing JavaScript virtualization or changing existing selection, sticky header, and auto-scroll behavior.

Player and Status previously duplicated select options, native select styling, and labeled switch markup. Consolidating those patterns keeps spacing, focus behavior, accessibility labels, and supported option sets consistent across both pages.

## Validation

- `pnpm exec biome check` for all changed TypeScript files
- `pnpm run type-check:tsc`
- `pnpm exec vite build web-ui`
- Local browser verification of Status header, log-level select, and labeled switches

The generated `src/embedded_web_data.h` was not modified.