### PR TITLE
fix(status): reclaim crashed worker state

### DIFF
--- a/e2e/helpers/__init__.py
+++ b/e2e/helpers/__init__.py
@@ -28,12 +28,14 @@ from .http import (
     assert_etag_cache_behavior,
     extract_catchup_source,
     get_header,
+    get_status_payload,
     get_upstream_path,
     http_get,
     http_request,
     stream_get,
     unix_http_get,
     unix_http_request,
+    wait_for_status_payload,
 )
 from .mock_fcc import MockFCCServer
 from .mock_http import MockHTTPUpstream, MockHTTPUpstreamSilent
@@ -81,6 +83,7 @@ __all__ = [
     "find_free_udp_port",
     "find_free_udp_port_pair",
     "get_header",
+    "get_status_payload",
     "get_upstream_path",
     "http_get",
     "http_request",
@@ -91,6 +94,7 @@ __all__ = [
     "unix_http_get",
     "unix_http_request",
     "wait_for_port",
+    "wait_for_status_payload",
     "wait_for_unix_socket",
     "write_temp_file",
 ]

--- a/e2e/helpers/http.py
+++ b/e2e/helpers/http.py
@@ -34,14 +34,18 @@ def get_status_payload(host: str, port: int, timeout: float = 3.0, status_path: 
     return None
 
 
-def wait_for_status_payload(host: str, port: int, predicate, timeout: float = 6.0, status_path: str = "/status") -> dict:
+def wait_for_status_payload(
+    host: str, port: int, predicate, timeout: float = 6.0, status_path: str = "/status"
+) -> dict:
     """Poll status SSE until predicate(payload) succeeds."""
     deadline = time.monotonic() + timeout
     last_payload = None
     while time.monotonic() < deadline:
         try:
-            last_payload = get_status_payload(host, port, timeout=min(2.0, max(0.2, deadline - time.monotonic())), status_path=status_path)
-        except (OSError, TimeoutError, json.JSONDecodeError):
+            last_payload = get_status_payload(
+                host, port, timeout=min(2.0, max(0.2, deadline - time.monotonic())), status_path=status_path
+            )
+        except OSError, TimeoutError, json.JSONDecodeError:
             last_payload = None
         if last_payload is not None and predicate(last_payload):
             return last_payload

--- a/e2e/helpers/http.py
+++ b/e2e/helpers/http.py
@@ -3,9 +3,50 @@
 from __future__ import annotations
 
 import http.client
+import json
 import re
 import socket
 import time
+
+
+def get_status_payload(host: str, port: int, timeout: float = 3.0, status_path: str = "/status") -> dict | None:
+    """Return the first JSON payload from the status SSE endpoint."""
+    sock = socket.create_connection((host, port), timeout=timeout)
+    data = b""
+    try:
+        request = "GET %s/sse HTTP/1.0\r\nHost: %s\r\n\r\n" % (status_path.rstrip("/"), host)
+        sock.sendall(request.encode())
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            sock.settimeout(min(1.0, max(0.1, deadline - time.monotonic())))
+            try:
+                chunk = sock.recv(65536)
+            except TimeoutError:
+                continue
+            if not chunk:
+                break
+            data += chunk
+            for line in data.decode(errors="replace").splitlines():
+                if line.startswith("data: {"):
+                    return json.loads(line[len("data: ") :])
+    finally:
+        sock.close()
+    return None
+
+
+def wait_for_status_payload(host: str, port: int, predicate, timeout: float = 6.0, status_path: str = "/status") -> dict:
+    """Poll status SSE until predicate(payload) succeeds."""
+    deadline = time.monotonic() + timeout
+    last_payload = None
+    while time.monotonic() < deadline:
+        try:
+            last_payload = get_status_payload(host, port, timeout=min(2.0, max(0.2, deadline - time.monotonic())), status_path=status_path)
+        except (OSError, TimeoutError, json.JSONDecodeError):
+            last_payload = None
+        if last_payload is not None and predicate(last_payload):
+            return last_payload
+        time.sleep(0.05)
+    raise AssertionError("Status predicate not satisfied; last payload: %r" % last_payload)
 
 
 def http_get(

--- a/e2e/test_ipv6.py
+++ b/e2e/test_ipv6.py
@@ -211,7 +211,8 @@ class TestHTTPServerIPv6Listen:
     """rtp2httpd bound to ::1 should serve requests and validate IPv6 Hosts."""
 
     @pytest.fixture(scope="class")
-    def v6_r2h(self, r2h_binary):
+    @classmethod
+    def v6_r2h(cls, r2h_binary):
         port = find_free_port("::1")
         config = f"""\
 [global]

--- a/e2e/test_worker_recovery.py
+++ b/e2e/test_worker_recovery.py
@@ -100,9 +100,9 @@ def test_crashed_worker_releases_maxclient_slot_and_logs_recovery(r2h_binary):
         recovered = wait_for_status_payload(
             "127.0.0.1",
             port,
-            lambda value: not value["clients"]
-            and value["totalClients"] == 0
-            and _worker_pids(value).get(0, dead_pid) != dead_pid,
+            lambda value: (
+                not value["clients"] and value["totalClients"] == 0 and _worker_pids(value).get(0, dead_pid) != dead_pid
+            ),
             timeout=8,
         )
         assert _worker_pids(recovered)[0] > 0
@@ -126,8 +126,10 @@ def test_crashed_worker_releases_maxclient_slot_and_logs_recovery(r2h_binary):
         wait_for_status_payload(
             "127.0.0.1",
             port,
-            lambda value: value["logsMode"] == "full"
-            and all("Reclaimed 1 status client slot" not in entry["message"] for entry in value["logs"]),
+            lambda value: (
+                value["logsMode"] == "full"
+                and all("Reclaimed 1 status client slot" not in entry["message"] for entry in value["logs"])
+            ),
         )
     finally:
         for sock in sockets:
@@ -156,9 +158,11 @@ def test_crashed_worker_does_not_restart_other_worker(r2h_binary):
         recovered = wait_for_status_payload(
             "127.0.0.1",
             port,
-            lambda value: all(client["workerPid"] != dead_pid for client in value["clients"])
-            and survivor_pid in _worker_pids(value).values()
-            and len(_worker_pids(value)) == 2,
+            lambda value: (
+                all(client["workerPid"] != dead_pid for client in value["clients"])
+                and survivor_pid in _worker_pids(value).values()
+                and len(_worker_pids(value)) == 2
+            ),
             timeout=8,
         )
         assert survivor_pid in _worker_pids(recovered).values()
@@ -204,8 +208,10 @@ def test_worker_reduction_reaps_retiring_worker(r2h_binary):
         reduced = wait_for_status_payload(
             "127.0.0.1",
             port,
-            lambda value: len(value.get("workers", [])) == 1
-            and all(client["workerPid"] != retiring_pid for client in value["clients"]),
+            lambda value: (
+                len(value.get("workers", [])) == 1
+                and all(client["workerPid"] != retiring_pid for client in value["clients"])
+            ),
             timeout=8,
         )
         assert len(reduced["workers"]) == 1

--- a/e2e/test_worker_recovery.py
+++ b/e2e/test_worker_recovery.py
@@ -1,0 +1,255 @@
+"""E2E coverage for supervisor recovery of crashed worker status state."""
+
+from __future__ import annotations
+
+import os
+import json
+import signal
+import socket
+import time
+
+import pytest
+
+from helpers import (
+    MockRTSPServer,
+    R2HProcess,
+    build_single_service_config,
+    find_free_port,
+    http_request,
+    wait_for_status_payload,
+)
+
+pytestmark = pytest.mark.slow
+
+
+def _open_stream(port: int, rtsp_port: int) -> socket.socket:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+    sock.bind(("127.0.0.1", 0))
+    sock.connect(("127.0.0.1", port))
+    path = "/rtsp/127.0.0.1:%d/stream" % rtsp_port
+    sock.sendall(("GET %s HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n" % path).encode())
+    response = b""
+    deadline = time.monotonic() + 10
+    sock.settimeout(1.0)
+    while b"\r\n\r\n" not in response and time.monotonic() < deadline:
+        try:
+            response += sock.recv(4096)
+        except TimeoutError:
+            continue
+    assert b" 200 " in response.split(b"\r\n", 1)[0], response[:120]
+    return sock
+
+
+def _worker_pids(payload: dict) -> dict[int, int]:
+    return {worker["id"]: worker["pid"] for worker in payload.get("workers", []) if worker["pid"] > 0}
+
+
+def _wait_log_contains(r2h: R2HProcess, text: str, timeout: float = 6.0) -> str:
+    deadline = time.monotonic() + timeout
+    log = ""
+    while time.monotonic() < deadline:
+        log = r2h.read_log()
+        if text in log:
+            return log
+        time.sleep(0.05)
+    raise AssertionError("Expected log text %r; log: %s" % (text, log))
+
+
+def _read_sse_payload(sock: socket.socket, buffered: bytes, predicate, timeout: float = 6.0) -> tuple[dict, bytes]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        lines = buffered.split(b"\n")
+        buffered = lines.pop()
+        for line in lines:
+            line = line.strip()
+            if line.startswith(b"data: {"):
+                payload = json.loads(line[len(b"data: ") :])
+                if predicate(payload):
+                    return payload, buffered
+        sock.settimeout(min(1.0, max(0.1, deadline - time.monotonic())))
+        try:
+            chunk = sock.recv(65536)
+        except TimeoutError:
+            continue
+        if not chunk:
+            break
+        buffered += chunk
+    raise AssertionError("Expected SSE payload was not received")
+
+
+@pytest.mark.rtsp
+def test_crashed_worker_releases_maxclient_slot_and_logs_recovery(r2h_binary):
+    upstream = MockRTSPServer(num_packets=30000)
+    upstream.start()
+    port = find_free_port()
+    r2h = R2HProcess(
+        r2h_binary,
+        port,
+        extra_args=["-v", "4", "-m", "1", "-w", "1"],
+        capture_log=True,
+    )
+    sockets: list[socket.socket] = []
+    try:
+        r2h.start()
+        sockets.append(_open_stream(port, upstream.port))
+        payload = wait_for_status_payload("127.0.0.1", port, lambda value: len(value["clients"]) == 1)
+        dead_pid = payload["clients"][0]["workerPid"]
+
+        os.kill(dead_pid, signal.SIGKILL)
+        recovered = wait_for_status_payload(
+            "127.0.0.1",
+            port,
+            lambda value: not value["clients"]
+            and value["totalClients"] == 0
+            and _worker_pids(value).get(0, dead_pid) != dead_pid,
+            timeout=8,
+        )
+        assert _worker_pids(recovered)[0] > 0
+
+        sockets.append(_open_stream(port, upstream.port))
+        active_again = wait_for_status_payload("127.0.0.1", port, lambda value: len(value["clients"]) == 1)
+        assert "Reclaimed 1 status client slot" in r2h.read_log()
+
+        restarted_pid = active_again["clients"][0]["workerPid"]
+        assert r2h.process is not None
+        os.kill(r2h.process.pid, signal.SIGUSR1)
+        wait_for_status_payload(
+            "127.0.0.1",
+            port,
+            lambda value: not value["clients"] and _worker_pids(value).get(0, restarted_pid) != restarted_pid,
+            timeout=8,
+        )
+
+        status, _, _ = http_request("127.0.0.1", port, "POST", "/status/api/clear-logs")
+        assert status == 200
+        wait_for_status_payload(
+            "127.0.0.1",
+            port,
+            lambda value: value["logsMode"] == "full"
+            and all("Reclaimed 1 status client slot" not in entry["message"] for entry in value["logs"]),
+        )
+    finally:
+        for sock in sockets:
+            sock.close()
+        r2h.stop()
+        upstream.stop()
+
+
+@pytest.mark.rtsp
+def test_crashed_worker_does_not_restart_other_worker(r2h_binary):
+    upstream = MockRTSPServer(num_packets=30000)
+    upstream.start()
+    port = find_free_port()
+    r2h = R2HProcess(r2h_binary, port, extra_args=["-v", "4", "-m", "10", "-w", "2"])
+    sockets: list[socket.socket] = []
+    try:
+        r2h.start()
+        sockets.append(_open_stream(port, upstream.port))
+        payload = wait_for_status_payload(
+            "127.0.0.1", port, lambda value: len(value["clients"]) == 1 and len(_worker_pids(value)) == 2
+        )
+        dead_pid = payload["clients"][0]["workerPid"]
+        survivor_pid = next(pid for pid in _worker_pids(payload).values() if pid != dead_pid)
+        os.kill(dead_pid, signal.SIGKILL)
+
+        recovered = wait_for_status_payload(
+            "127.0.0.1",
+            port,
+            lambda value: all(client["workerPid"] != dead_pid for client in value["clients"])
+            and survivor_pid in _worker_pids(value).values()
+            and len(_worker_pids(value)) == 2,
+            timeout=8,
+        )
+        assert survivor_pid in _worker_pids(recovered).values()
+    finally:
+        for sock in sockets:
+            sock.close()
+        r2h.stop()
+        upstream.stop()
+
+
+@pytest.mark.rtsp
+def test_worker_reduction_reaps_retiring_worker(r2h_binary):
+    upstream = MockRTSPServer(num_packets=30000)
+    upstream.start()
+    port = find_free_port()
+    config = build_single_service_config(
+        port,
+        "Recovery",
+        "rtsp://127.0.0.1:%d/stream" % upstream.port,
+        global_lines=["maxclients = 10", "workers = 2"],
+    )
+    r2h = R2HProcess(r2h_binary, port, config_content=config, capture_log=True)
+    sockets: list[socket.socket] = []
+    try:
+        r2h.start()
+        payload = wait_for_status_payload("127.0.0.1", port, lambda value: len(_worker_pids(value)) == 2)
+        retiring_pid = _worker_pids(payload)[1]
+
+        for _ in range(8):
+            sockets.append(_open_stream(port, upstream.port))
+            payload = wait_for_status_payload("127.0.0.1", port, lambda value: bool(value["clients"]))
+            if any(client["workerPid"] == retiring_pid for client in payload["clients"]):
+                break
+        had_retiring_client = any(client["workerPid"] == retiring_pid for client in payload["clients"])
+
+        updated = config.replace("workers = 2", "workers = 1")
+        assert r2h._config_path is not None
+        with open(r2h._config_path, "w") as config_file:
+            config_file.write(updated)
+        assert r2h.process is not None
+        os.kill(r2h.process.pid, signal.SIGHUP)
+
+        reduced = wait_for_status_payload(
+            "127.0.0.1",
+            port,
+            lambda value: len(value.get("workers", [])) == 1
+            and all(client["workerPid"] != retiring_pid for client in value["clients"]),
+            timeout=8,
+        )
+        assert len(reduced["workers"]) == 1
+        log = _wait_log_contains(r2h, "Worker 1 (pid %d)" % retiring_pid)
+        assert "Reducing worker count from 2 to 1" in log
+        assert "Worker 1 (pid %d)" % retiring_pid in log
+        if had_retiring_client:
+            assert all(client["workerPid"] != retiring_pid for client in reduced["clients"])
+    finally:
+        for sock in sockets:
+            sock.close()
+        r2h.stop()
+        upstream.stop()
+
+
+def test_status_logs_remain_incremental_and_clearable(r2h_binary):
+    port = find_free_port()
+    r2h = R2HProcess(r2h_binary, port, extra_args=["-v", "4", "-w", "1"])
+    sock = None
+    try:
+        r2h.start()
+        sock = socket.create_connection(("127.0.0.1", port), timeout=3)
+        sock.sendall(b"GET /status/sse HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
+        initial, buffered = _read_sse_payload(sock, b"", lambda value: value["logsMode"] == "full")
+        assert initial["logs"]
+
+        status, _, _ = http_request("127.0.0.1", port, "GET", "/missing-status-log-test")
+        assert status == 404
+        incremental, buffered = _read_sse_payload(
+            sock,
+            buffered,
+            lambda value: value["logsMode"] == "incremental" and bool(value["logs"]),
+        )
+        assert incremental["logs"]
+
+        status, _, _ = http_request("127.0.0.1", port, "POST", "/status/api/clear-logs")
+        assert status == 200
+        cleared, _ = _read_sse_payload(
+            sock,
+            buffered,
+            lambda value: value["logsMode"] == "full" and value["logs"] == [],
+        )
+        assert cleared["logs"] == []
+    finally:
+        if sock is not None:
+            sock.close()
+        r2h.stop()

--- a/src/access_log.c
+++ b/src/access_log.c
@@ -345,9 +345,9 @@ static void access_log_parse_remote_addr(const char *client_addr, char *remote_a
 }
 
 static int access_log_append_placeholder(access_log_buffer_t *buf, const char *name, size_t name_len, connection_t *c,
-                                         service_t *service, const client_stats_t *client, const char *time_iso8601,
-                                         const char *time_local, const char *msec, const char *remote_addr,
-                                         const char *remote_port, const char *request) {
+                                         service_t *service, const client_stats_payload_t *client, pid_t worker_pid,
+                                         const char *time_iso8601, const char *time_local, const char *msec,
+                                         const char *remote_addr, const char *remote_port, const char *request) {
   char numeric[64];
   char filtered_user_agent[sizeof(c->http_req.user_agent)];
 
@@ -366,7 +366,7 @@ static int access_log_append_placeholder(access_log_buffer_t *buf, const char *n
   if (MATCH("remote_port"))
     return access_log_append_escaped(buf, remote_port);
   if (MATCH("worker_pid")) {
-    snprintf(numeric, sizeof(numeric), "%d", (int)client->worker_pid);
+    snprintf(numeric, sizeof(numeric), "%d", (int)worker_pid);
     return access_log_append_escaped(buf, numeric);
   }
   if (MATCH("request"))
@@ -397,7 +397,7 @@ static int access_log_append_placeholder(access_log_buffer_t *buf, const char *n
 }
 
 static int access_log_render(access_log_buffer_t *buf, connection_t *c, service_t *service,
-                             const client_stats_t *client, const char *format) {
+                             const client_stats_payload_t *client, pid_t worker_pid, const char *format) {
   char time_iso8601[64];
   char time_local[64];
   char msec[32];
@@ -436,8 +436,8 @@ static int access_log_render(access_log_buffer_t *buf, connection_t *c, service_
     while (isalnum((unsigned char)*end) || *end == '_')
       end++;
 
-    if (access_log_append_placeholder(buf, name, (size_t)(end - name), c, service, client, time_iso8601, time_local,
-                                      msec, remote_addr, remote_port, request) < 0) {
+    if (access_log_append_placeholder(buf, name, (size_t)(end - name), c, service, client, worker_pid, time_iso8601,
+                                      time_local, msec, remote_addr, remote_port, request) < 0) {
       return -1;
     }
     p = end - 1;
@@ -472,8 +472,9 @@ void access_log_write_connection(connection_t *c, service_t *service, int status
     return;
 
   client_stats_t *client = &status_shared->clients[status_index];
-  if (!client->active || client->service_url[0] == '\0')
+  if (!atomic_load_explicit(&client->active, memory_order_acquire) || client->payload.service_url[0] == '\0')
     return;
+  pid_t owner_pid = (pid_t)atomic_load_explicit(&client->owner_pid, memory_order_relaxed);
 
   int fd = access_log_ensure_fd(config.access_log);
   if (fd < 0)
@@ -488,7 +489,7 @@ void access_log_write_connection(connection_t *c, service_t *service, int status
     return;
   }
 
-  if (access_log_render(&buf, c, service, client, format) < 0) {
+  if (access_log_render(&buf, c, service, &client->payload, owner_pid, format) < 0) {
     logger(LOG_ERROR, "Failed to render access log line");
     access_log_buffer_free(&buf);
     return;

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -547,8 +547,8 @@ void parse_global_sec(char *line) {
 
   if (strcasecmp("workers", param) == 0) {
     int n = atoi(value);
-    if (n < 1) {
-      logger(LOG_ERROR, "Invalid workers value! Must be >= 1. Ignoring.");
+    if (n < 1 || n > CONFIG_MAX_WORKERS) {
+      logger(LOG_ERROR, "Invalid workers value! Must be between 1 and %d. Ignoring.", CONFIG_MAX_WORKERS);
       return;
     }
     config.workers = n;
@@ -1453,8 +1453,8 @@ void parse_cmd_line(int argc, char *argv[]) {
       }
       break;
     case 'w':
-      if (atoi(optarg) < 1) {
-        logger(LOG_ERROR, "Invalid workers! Ignoring.");
+      if (atoi(optarg) < 1 || atoi(optarg) > CONFIG_MAX_WORKERS) {
+        logger(LOG_ERROR, "Invalid workers! Must be between 1 and %d. Ignoring.", CONFIG_MAX_WORKERS);
       } else {
         config.workers = atoi(optarg);
         cmd_workers_set = 1;

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -536,11 +536,12 @@ void parse_global_sec(char *line) {
 
   if (strcasecmp("maxclients", param) == 0) {
     if (set_if_not_cmd_override(cmd_maxclients_set, "maxclients")) {
-      if (atoi(value) < 1) {
-        logger(LOG_ERROR, "Invalid maxclients! Ignoring.");
+      int max_clients = atoi(value);
+      if (max_clients < 1 || max_clients > CONFIG_MAX_CLIENTS) {
+        logger(LOG_ERROR, "Invalid maxclients! Must be between 1 and %d. Ignoring.", CONFIG_MAX_CLIENTS);
         return;
       }
-      config.maxclients = atoi(value);
+      config.maxclients = max_clients;
     }
     return;
   }
@@ -1444,22 +1445,26 @@ void parse_cmd_line(int argc, char *argv[]) {
       config.udpxy = 0;
       cmd_udpxy_set = 1;
       break;
-    case 'm':
-      if (atoi(optarg) < 1) {
-        logger(LOG_ERROR, "Invalid maxclients! Ignoring.");
+    case 'm': {
+      int max_clients = atoi(optarg);
+      if (max_clients < 1 || max_clients > CONFIG_MAX_CLIENTS) {
+        logger(LOG_ERROR, "Invalid maxclients! Must be between 1 and %d. Ignoring.", CONFIG_MAX_CLIENTS);
       } else {
-        config.maxclients = atoi(optarg);
+        config.maxclients = max_clients;
         cmd_maxclients_set = 1;
       }
       break;
-    case 'w':
-      if (atoi(optarg) < 1 || atoi(optarg) > CONFIG_MAX_WORKERS) {
+    }
+    case 'w': {
+      int worker_count = atoi(optarg);
+      if (worker_count < 1 || worker_count > CONFIG_MAX_WORKERS) {
         logger(LOG_ERROR, "Invalid workers! Must be between 1 and %d. Ignoring.", CONFIG_MAX_WORKERS);
       } else {
-        config.workers = atoi(optarg);
+        config.workers = worker_count;
         cmd_workers_set = 1;
       }
       break;
+    }
     case 'b':
       if (atoi(optarg) < 1) {
         logger(LOG_ERROR, "Invalid buffer-pool-max-size! Ignoring.");

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -13,6 +13,7 @@
 #define CONFIGFILE SYSCONFDIR "/rtp2httpd.conf"
 
 #define DEFAULT_ACCESS_LOG_FORMAT "$client_addr [$time_iso8601] \"$service_url\" $service_type \"$upstream_url\""
+#define CONFIG_MAX_WORKERS 32
 
 typedef enum loglevel {
   LOG_FATAL = 0, /* Always shown */

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -13,6 +13,7 @@
 #define CONFIGFILE SYSCONFDIR "/rtp2httpd.conf"
 
 #define DEFAULT_ACCESS_LOG_FORMAT "$client_addr [$time_iso8601] \"$service_url\" $service_type \"$upstream_url\""
+#define CONFIG_MAX_CLIENTS 256
 #define CONFIG_MAX_WORKERS 32
 
 typedef enum loglevel {

--- a/src/connection.c
+++ b/src/connection.c
@@ -1075,13 +1075,6 @@ int connection_route_and_start(connection_t *c) {
     service->user_agent = strdup(c->http_req.user_agent);
   }
 
-  /* Capacity check */
-  if (status_shared && status_shared->total_clients >= config.maxclients) {
-    http_send_503(c);
-    service_free(service);
-    return 0;
-  }
-
   /* Check if this is a snapshot request (X-Request-Snapshot, Accept:
    * image/jpeg, or snapshot=1) */
   /* 1 = snapshot=1, 2 = X-Request-Snapshot or Accept: image/jpeg */
@@ -1156,6 +1149,9 @@ int connection_route_and_start(connection_t *c) {
     c->status_index = status_register_client(client_addr_str, display_url);
     if (c->status_index < 0) {
       logger(LOG_ERROR, "Failed to register streaming client in status tracking");
+      http_send_503(c);
+      service_free(service);
+      return 0;
     } else {
       access_log_write_connection(c, service, c->status_index);
     }

--- a/src/connection.c
+++ b/src/connection.c
@@ -1148,7 +1148,6 @@ int connection_route_and_start(connection_t *c) {
 
     c->status_index = status_register_client(client_addr_str, display_url);
     if (c->status_index < 0) {
-      logger(LOG_ERROR, "Failed to register streaming client in status tracking");
       http_send_503(c);
       service_free(service);
       return 0;

--- a/src/connection.h
+++ b/src/connection.h
@@ -43,8 +43,8 @@ typedef struct connection_s {
   /* SSE */
   int64_t next_sse_ts; /* Next SSE heartbeat time in milliseconds */
   int sse_sent_initial;
-  int sse_last_write_index;
-  int sse_last_log_count;
+  uint32_t sse_last_log_epoch;
+  uint32_t sse_last_log_sequence;
   /* status tracking */
   int status_index; /* Index in status_shared->clients array, -1 if not
                        registered */

--- a/src/status.c
+++ b/src/status.c
@@ -757,9 +757,9 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
   if (append_sse_data(buffer, buffer_capacity, &len,
                       "data: "
                       "{\"serverStartTime\":%lld,\"uptimeMs\":%lld,\"currentLogLevel\":%d,"
-                      "\"version\":\"" VERSION "\",\"maxClients\":%d,\"clients\":[",
+                      "\"version\":\"%s\",\"maxClients\":%d,\"clients\":[",
                       (long long)status_shared->server_start_time, (long long)uptime_ms,
-                      status_shared->current_log_level, config.maxclients) < 0)
+                      status_shared->current_log_level, VERSION, config.maxclients) < 0)
     return 0;
 
   /* Add client data (only real media streams: have a service_url) */

--- a/src/status.c
+++ b/src/status.c
@@ -802,9 +802,13 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
 
       int64_t duration_ms = current_time - client.connect_time;
 
-      /* Escape client_id for JSON */
-      char escaped_client_id[256];
+      /* Escape client-controlled strings before embedding them in JSON. */
+      char escaped_client_id[sizeof(client.client_id) * 6 + 1];
+      char escaped_client_addr[sizeof(client.client_addr) * 6 + 1];
+      char escaped_service_url[sizeof(client.service_url) * 6 + 1];
       json_escape_string_to_buffer(client.client_id, escaped_client_id, sizeof(escaped_client_id));
+      json_escape_string_to_buffer(client.client_addr, escaped_client_addr, sizeof(escaped_client_addr));
+      json_escape_string_to_buffer(client.service_url, escaped_service_url, sizeof(escaped_service_url));
 
       if (append_sse_data(buffer, buffer_capacity, &len,
                           "{\"clientId\":\"%s\",\"workerPid\":%d,\"durationMs\":%lld,"
@@ -813,8 +817,8 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
                           "\"currentBandwidth\":%u,\"queueBytes\":%zu,"
                           "\"queueLimitBytes\":%zu,\"queueBytesHighwater\":%zu,"
                           "\"droppedBytes\":%llu,\"slow\":%d}",
-                          escaped_client_id, (int)owner_pid, (long long)duration_ms, client.client_addr,
-                          client.service_url, (int)client.state, (unsigned long long)client.bytes_sent,
+                          escaped_client_id, (int)owner_pid, (long long)duration_ms, escaped_client_addr,
+                          escaped_service_url, (int)client.state, (unsigned long long)client.bytes_sent,
                           client.current_bandwidth, client.queue_bytes, client.queue_limit_bytes,
                           client.queue_bytes_highwater, (unsigned long long)client.dropped_bytes,
                           client.slow_active) < 0)

--- a/src/status.c
+++ b/src/status.c
@@ -2,15 +2,16 @@
 #include "connection.h"
 #include "http.h"
 #include "rtp2httpd.h"
+#include "supervisor.h"
 #include "utils.h"
 #include <errno.h>
 #include <fcntl.h>
-#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 /* Global pointer to shared memory */
@@ -18,6 +19,98 @@ status_shared_t *status_shared = NULL;
 
 /* Path for shared memory file in /tmp */
 static char shm_path[256] = {0};
+
+typedef enum { STATUS_LOG_EVENT_ADD = 1, STATUS_LOG_EVENT_CLEAR = 2 } status_log_event_type_t;
+
+typedef struct {
+  uint32_t type;
+  int64_t timestamp;
+  loglevel_t level;
+  char message[STATUS_LOG_ENTRY_LEN];
+} status_log_event_t;
+
+static int log_event_recv_fd = -1;
+static int log_event_send_fd = -1;
+
+static void set_fd_nonblocking(int fd) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags >= 0)
+    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+static void reset_client_payload(client_stats_t *client) {
+  memset(&client->payload, 0, sizeof(client->payload));
+  client->payload.worker_index = -1;
+  client->payload.state = CLIENT_STATE_DISCONNECTED;
+  atomic_store_explicit(&client->disconnect_requested, 0, memory_order_relaxed);
+  atomic_store_explicit(&client->data_version, 0, memory_order_relaxed);
+}
+
+static int reserve_client_capacity(void) {
+  uint32_t count = atomic_load_explicit(&status_shared->total_clients, memory_order_relaxed);
+  while (count < (uint32_t)config.maxclients) {
+    if (atomic_compare_exchange_weak_explicit(&status_shared->total_clients, &count, count + 1, memory_order_acq_rel,
+                                              memory_order_relaxed))
+      return 0;
+  }
+  return -1;
+}
+
+static void client_write_begin(client_stats_t *client) {
+  atomic_fetch_add_explicit(&client->data_version, 1, memory_order_acq_rel);
+}
+
+static void client_write_end(client_stats_t *client) {
+  atomic_fetch_add_explicit(&client->data_version, 1, memory_order_release);
+}
+
+static int snapshot_client(const client_stats_t *client, client_stats_payload_t *snapshot, uint32_t *owner_pid) {
+  for (int attempt = 0; attempt < 3; attempt++) {
+    if (!atomic_load_explicit(&client->active, memory_order_acquire))
+      return 0;
+    uint32_t version_before = atomic_load_explicit(&client->data_version, memory_order_acquire);
+    if (version_before & 1U)
+      continue;
+    *owner_pid = atomic_load_explicit(&client->owner_pid, memory_order_relaxed);
+    memcpy(snapshot, &client->payload, sizeof(*snapshot));
+    atomic_thread_fence(memory_order_acquire);
+    uint32_t version_after = atomic_load_explicit(&client->data_version, memory_order_relaxed);
+    if (version_before == version_after && !(version_after & 1U) &&
+        atomic_load_explicit(&client->active, memory_order_acquire))
+      return 1;
+  }
+  return 0;
+}
+
+static void invalidate_log_ring(void) {
+  for (int i = 0; i < STATUS_MAX_LOG_ENTRIES; i++)
+    atomic_store_explicit(&status_shared->log_entries[i].sequence, 0, memory_order_relaxed);
+}
+
+static void clear_log_ring(void) {
+  invalidate_log_ring();
+  atomic_store_explicit(&status_shared->log_sequence, 0, memory_order_release);
+  uint32_t epoch = atomic_fetch_add_explicit(&status_shared->log_epoch, 1, memory_order_acq_rel) + 1;
+  if (epoch == 0)
+    atomic_store_explicit(&status_shared->log_epoch, 1, memory_order_release);
+}
+
+static void append_log_entry(int64_t timestamp, loglevel_t level, const char *message) {
+  uint32_t sequence = atomic_load_explicit(&status_shared->log_sequence, memory_order_relaxed);
+  if (sequence == UINT32_MAX) {
+    clear_log_ring();
+    sequence = 0;
+  }
+  sequence++;
+  log_entry_t *entry = &status_shared->log_entries[(sequence - 1) % STATUS_MAX_LOG_ENTRIES];
+  atomic_store_explicit(&entry->sequence, 0, memory_order_release);
+  entry->timestamp = timestamp;
+  entry->level = level;
+  strncpy(entry->message, message, sizeof(entry->message) - 1);
+  entry->message[sizeof(entry->message) - 1] = '\0';
+  atomic_store_explicit(&entry->sequence, sequence, memory_order_release);
+  atomic_store_explicit(&status_shared->log_sequence, sequence, memory_order_release);
+}
 
 int status_init(void) {
   int fd;
@@ -73,6 +166,43 @@ int status_init(void) {
   status_shared->server_start_time = get_realtime_ms();
   status_shared->current_log_level = config.verbosity;
   status_shared->event_counter = 0;
+  atomic_init(&status_shared->total_clients, 0);
+  atomic_init(&status_shared->log_epoch, 1);
+  atomic_init(&status_shared->log_sequence, 0);
+
+  for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
+    atomic_init(&status_shared->clients[i].owner_pid, 0);
+    atomic_init(&status_shared->clients[i].active, 0);
+    atomic_init(&status_shared->clients[i].disconnect_requested, 0);
+    atomic_init(&status_shared->clients[i].data_version, 0);
+    status_shared->clients[i].payload.worker_index = -1;
+  }
+  for (int i = 0; i < STATUS_MAX_LOG_ENTRIES; i++)
+    atomic_init(&status_shared->log_entries[i].sequence, 0);
+
+  if (!atomic_is_lock_free(&status_shared->total_clients) ||
+      !atomic_is_lock_free(&status_shared->clients[0].owner_pid) ||
+      !atomic_is_lock_free(&status_shared->clients[0].active) || !atomic_is_lock_free(&status_shared->log_sequence)) {
+    status_shared = NULL;
+    munmap(mapped, sizeof(status_shared_t));
+    unlink(shm_path);
+    logger(LOG_ERROR, "Required 32-bit shared-memory atomics are not lock-free");
+    return -1;
+  }
+
+  int log_fds[2];
+  if (socketpair(AF_UNIX, SOCK_DGRAM, 0, log_fds) == -1) {
+    int err = errno;
+    status_shared = NULL;
+    munmap(mapped, sizeof(status_shared_t));
+    unlink(shm_path);
+    logger(LOG_ERROR, "Failed to create status log socketpair: %s", strerror(err));
+    return -1;
+  }
+  log_event_recv_fd = log_fds[0];
+  log_event_send_fd = log_fds[1];
+  set_fd_nonblocking(log_event_recv_fd);
+  set_fd_nonblocking(log_event_send_fd);
 
   /* Initialize pipe fds to -1 (invalid) */
   for (int i = 0; i < STATUS_MAX_WORKERS; i++) {
@@ -95,6 +225,10 @@ int status_init(void) {
         if (status_shared->worker_notification_pipes[j] != -1)
           close(status_shared->worker_notification_pipes[j]);
       }
+      close(log_event_recv_fd);
+      close(log_event_send_fd);
+      log_event_recv_fd = -1;
+      log_event_send_fd = -1;
       munmap(status_shared, sizeof(status_shared_t));
       status_shared = NULL;
       unlink(shm_path);
@@ -113,14 +247,6 @@ int status_init(void) {
     status_shared->worker_notification_pipes[i] = pipe_fds[1];
   }
 
-  /* Initialize mutexes for multi-process safety */
-  pthread_mutexattr_t mutex_attr;
-  pthread_mutexattr_init(&mutex_attr);
-  pthread_mutexattr_setpshared(&mutex_attr, PTHREAD_PROCESS_SHARED);
-  pthread_mutex_init(&status_shared->log_mutex, &mutex_attr);
-  pthread_mutex_init(&status_shared->clients_mutex, &mutex_attr);
-  pthread_mutexattr_destroy(&mutex_attr);
-
   logger(LOG_INFO, "Status tracking initialized");
   return 0;
 }
@@ -138,9 +264,8 @@ int status_init(void) {
  *   status_worker_get_notif_fd)
  * - Its view of shared memory (munmap)
  *
- * Only the final cleanup process (supervisor or single worker) should:
- * - Destroy shared mutexes
- * - Unlink the shared memory file
+ * Only the final cleanup process (supervisor or single worker) unlinks the
+ * shared memory file.
  *
  * In supervisor mode, the supervisor waits for all workers to exit before
  * calling this function, ensuring it's the last process.
@@ -150,6 +275,18 @@ void status_cleanup(void) {
    * - In supervisor mode: supervisor (worker_id == -1) does final cleanup
    * - In single-worker mode: worker 0 does final cleanup */
   int is_final_cleanup = (worker_id == -1) || (worker_id == 0 && config.workers <= 1);
+
+  if (worker_id == SUPERVISOR_WORKER_ID)
+    status_supervisor_drain_logs();
+
+  if (log_event_recv_fd >= 0) {
+    close(log_event_recv_fd);
+    log_event_recv_fd = -1;
+  }
+  if (log_event_send_fd >= 0) {
+    close(log_event_send_fd);
+    log_event_send_fd = -1;
+  }
 
   if (status_shared != NULL && status_shared != MAP_FAILED) {
     /* Close all pipe fds (this process's copies)
@@ -161,14 +298,6 @@ void status_cleanup(void) {
       if (status_shared->worker_notification_pipe_read_fds[i] != -1) {
         close(status_shared->worker_notification_pipe_read_fds[i]);
       }
-    }
-
-    /* Only the final cleanup process destroys shared mutexes
-     * Destroying a mutex that other processes might still be using causes
-     * undefined behavior */
-    if (is_final_cleanup) {
-      pthread_mutex_destroy(&status_shared->log_mutex);
-      pthread_mutex_destroy(&status_shared->clients_mutex);
     }
 
     /* Each process unmaps its own view of shared memory
@@ -194,32 +323,36 @@ void status_cleanup(void) {
   }
 }
 
+void status_worker_init(void) {
+  if (log_event_recv_fd >= 0) {
+    close(log_event_recv_fd);
+    log_event_recv_fd = -1;
+  }
+}
+
 int status_register_client(const char *client_addr_str, const char *service_url) {
   int status_index = -1;
+  uint32_t owner_pid = (uint32_t)getpid();
 
   if (!status_shared || !client_addr_str)
     return -1;
 
-  /* Lock mutex to protect client slot allocation */
-  pthread_mutex_lock(&status_shared->clients_mutex);
-
-  /* Find free slot */
+  /* Reserve a slot by PID. owner_pid remains set while the slot is being
+   * initialized so the supervisor can recover a worker killed mid-register. */
   for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
-    if (!status_shared->clients[i].active) {
-      /* Initialize client slot */
-      memset(&status_shared->clients[i], 0, sizeof(client_stats_t));
-      status_shared->clients[i].active = 1;
-      status_shared->clients[i].worker_pid = getpid(); /* Store actual worker PID */
-      status_shared->clients[i].worker_index = worker_id;
-      status_shared->clients[i].connect_time = get_realtime_ms();
-      status_shared->clients[i].disconnect_requested = 0;
+    client_stats_t *client = &status_shared->clients[i];
+    uint32_t expected = 0;
+    if (atomic_compare_exchange_strong_explicit(&client->owner_pid, &expected, owner_pid, memory_order_acq_rel,
+                                                memory_order_relaxed)) {
+      reset_client_payload(client);
+      client->payload.worker_index = worker_id;
+      client->payload.connect_time = get_realtime_ms();
+      client->payload.state = CLIENT_STATE_CONNECTING;
 
       /* Copy client address string (format: "IP:port", "[IPv6]:port", or
        * "localhost" for Unix socket clients) */
-      strncpy(status_shared->clients[i].client_addr, client_addr_str,
-              sizeof(status_shared->clients[i].client_addr) - 1);
-      status_shared->clients[i].client_addr[sizeof(status_shared->clients[i].client_addr) - 1] = '\0';
-      status_shared->clients[i].state = CLIENT_STATE_CONNECTING;
+      strncpy(client->payload.client_addr, client_addr_str, sizeof(client->payload.client_addr) - 1);
+      client->payload.client_addr[sizeof(client->payload.client_addr) - 1] = '\0';
 
       /* Generate unique client ID: "IP:port-workerN-seqM"
        * Use real client IP (not X-Forwarded-For) + port + worker index +
@@ -228,23 +361,27 @@ int status_register_client(const char *client_addr_str, const char *service_url)
       if (worker_id >= 0 && worker_id < STATUS_MAX_WORKERS) {
         seq = status_shared->worker_stats[worker_id].client_id_counter++;
       }
-      snprintf(status_shared->clients[i].client_id, sizeof(status_shared->clients[i].client_id), "%s-worker%d-seq%llu",
-               client_addr_str, worker_id, (unsigned long long)seq);
+      snprintf(client->payload.client_id, sizeof(client->payload.client_id), "%s-worker%d-seq%llu", client_addr_str,
+               worker_id, (unsigned long long)seq);
 
       /* Copy service URL */
       if (service_url) {
-        strncpy(status_shared->clients[i].service_url, service_url, sizeof(status_shared->clients[i].service_url) - 1);
-        status_shared->clients[i].service_url[sizeof(status_shared->clients[i].service_url) - 1] = '\0';
+        strncpy(client->payload.service_url, service_url, sizeof(client->payload.service_url) - 1);
+        client->payload.service_url[sizeof(client->payload.service_url) - 1] = '\0';
       }
 
-      status_shared->total_clients++;
+      if (reserve_client_capacity() < 0) {
+        reset_client_payload(client);
+        atomic_store_explicit(&client->owner_pid, 0, memory_order_release);
+        logger(LOG_WARN, "Maximum client limit reached");
+        return -1;
+      }
+
+      atomic_store_explicit(&client->active, 1, memory_order_release);
       status_index = i;
       break;
     }
   }
-
-  /* Unlock mutex */
-  pthread_mutex_unlock(&status_shared->clients_mutex);
 
   if (status_index < 0) {
     logger(LOG_ERROR, "No free client slots in status tracking");
@@ -264,26 +401,69 @@ void status_unregister_client(int status_index) {
   if (status_index < 0 || status_index >= STATUS_MAX_CLIENTS)
     return;
 
-  if (!status_shared->clients[status_index].active)
+  client_stats_t *client = &status_shared->clients[status_index];
+  if (atomic_load_explicit(&client->owner_pid, memory_order_acquire) != (uint32_t)getpid())
     return;
 
-  client_stats_t *client = &status_shared->clients[status_index];
+  if (!atomic_exchange_explicit(&client->active, 0, memory_order_acq_rel))
+    return;
 
-  /* Accumulate this client's bytes_sent to global total before unregistering */
-  status_shared->total_bytes_sent_cumulative += client->bytes_sent;
+  /* Accumulate this client's bytes_sent in its single-writer worker shard. */
+  int client_worker_index = client->payload.worker_index;
+  uint64_t bytes_sent = client->payload.bytes_sent;
 
-  if (client->worker_index >= 0 && client->worker_index < STATUS_MAX_WORKERS) {
-    status_shared->worker_stats[client->worker_index].client_bytes_cumulative += client->bytes_sent;
+  if (client_worker_index >= 0 && client_worker_index < STATUS_MAX_WORKERS) {
+    status_shared->client_bytes_cumulative[client_worker_index] += bytes_sent;
+    status_shared->worker_stats[client_worker_index].client_bytes_cumulative += bytes_sent;
   }
 
-  client->active = 0;
-  client->state = CLIENT_STATE_DISCONNECTED;
-  client->disconnect_requested = 0;
-  client->worker_index = -1;
-  status_shared->total_clients--;
+  atomic_fetch_sub_explicit(&status_shared->total_clients, 1, memory_order_acq_rel);
+  reset_client_payload(client);
+  atomic_store_explicit(&client->owner_pid, 0, memory_order_release);
 
   /* Trigger event notification for client disconnect */
   status_trigger_event(STATUS_EVENT_SSE_UPDATE);
+}
+
+int status_reap_worker(pid_t dead_pid, int worker_index) {
+  if (!status_shared || dead_pid <= 0)
+    return 0;
+
+  uint32_t dead_owner = (uint32_t)dead_pid;
+  int reclaimed = 0;
+  for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
+    client_stats_t *client = &status_shared->clients[i];
+    if (atomic_load_explicit(&client->owner_pid, memory_order_acquire) != dead_owner)
+      continue;
+
+    if (atomic_exchange_explicit(&client->active, 0, memory_order_acq_rel)) {
+      int client_worker_index = client->payload.worker_index;
+      if (client_worker_index >= 0 && client_worker_index < STATUS_MAX_WORKERS)
+        status_shared->client_bytes_cumulative[client_worker_index] += client->payload.bytes_sent;
+    }
+    reset_client_payload(client);
+    atomic_store_explicit(&client->owner_pid, 0, memory_order_release);
+    reclaimed++;
+  }
+
+  uint32_t active_count = 0;
+  for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
+    if (atomic_load_explicit(&status_shared->clients[i].active, memory_order_acquire))
+      active_count++;
+  }
+  atomic_store_explicit(&status_shared->total_clients, active_count, memory_order_release);
+
+  if (worker_index >= 0 && worker_index < STATUS_MAX_WORKERS &&
+      status_shared->worker_stats[worker_index].worker_pid == dead_pid) {
+    memset(&status_shared->worker_stats[worker_index], 0, sizeof(worker_stats_t));
+  }
+
+  if (reclaimed > 0) {
+    logger(LOG_INFO, "Reclaimed %d status client slot(s) from worker %d (pid %d)", reclaimed, worker_index,
+           (int)dead_pid);
+    status_trigger_event(STATUS_EVENT_SSE_UPDATE);
+  }
+  return reclaimed;
 }
 
 int status_worker_get_notif_fd(void) {
@@ -339,12 +519,15 @@ void status_update_client_bytes(int status_index, uint64_t bytes_sent, uint32_t 
   if (status_index < 0 || status_index >= STATUS_MAX_CLIENTS)
     return;
 
-  if (!status_shared->clients[status_index].active)
+  client_stats_t *client = &status_shared->clients[status_index];
+  if (atomic_load_explicit(&client->owner_pid, memory_order_acquire) != (uint32_t)getpid() ||
+      !atomic_load_explicit(&client->active, memory_order_acquire))
     return;
 
-  /* Update client statistics */
-  status_shared->clients[status_index].bytes_sent = bytes_sent;
-  status_shared->clients[status_index].current_bandwidth = current_bandwidth;
+  client_write_begin(client);
+  client->payload.bytes_sent = bytes_sent;
+  client->payload.current_bandwidth = current_bandwidth;
+  client_write_end(client);
 }
 
 void status_update_client_state(int status_index, client_state_type_t state) {
@@ -354,11 +537,14 @@ void status_update_client_state(int status_index, client_state_type_t state) {
   if (status_index < 0 || status_index >= STATUS_MAX_CLIENTS)
     return;
 
-  if (!status_shared->clients[status_index].active)
+  client_stats_t *client = &status_shared->clients[status_index];
+  if (atomic_load_explicit(&client->owner_pid, memory_order_acquire) != (uint32_t)getpid() ||
+      !atomic_load_explicit(&client->active, memory_order_acquire))
     return;
 
-  /* Update client state */
-  status_shared->clients[status_index].state = state;
+  client_write_begin(client);
+  client->payload.state = state;
+  client_write_end(client);
 
   /* Always trigger event notification */
   status_trigger_event(STATUS_EVENT_SSE_UPDATE);
@@ -373,51 +559,72 @@ void status_update_client_queue(int status_index, size_t queue_bytes, size_t que
   if (status_index < 0 || status_index >= STATUS_MAX_CLIENTS)
     return;
 
-  if (!status_shared->clients[status_index].active)
+  client_stats_t *client = &status_shared->clients[status_index];
+  if (atomic_load_explicit(&client->owner_pid, memory_order_acquire) != (uint32_t)getpid() ||
+      !atomic_load_explicit(&client->active, memory_order_acquire))
     return;
 
-  status_shared->clients[status_index].queue_bytes = queue_bytes;
-  status_shared->clients[status_index].queue_buffers = (uint32_t)queue_buffers;
-  status_shared->clients[status_index].queue_limit_bytes = queue_limit_bytes;
-  status_shared->clients[status_index].queue_bytes_highwater = queue_bytes_highwater;
-  status_shared->clients[status_index].queue_buffers_highwater = (uint32_t)queue_buffers_highwater;
-  status_shared->clients[status_index].dropped_packets = dropped_packets;
-  status_shared->clients[status_index].dropped_bytes = dropped_bytes;
-  status_shared->clients[status_index].backpressure_events = backpressure_events;
-  status_shared->clients[status_index].slow_active = slow_active;
+  client_write_begin(client);
+  client->payload.queue_bytes = queue_bytes;
+  client->payload.queue_buffers = (uint32_t)queue_buffers;
+  client->payload.queue_limit_bytes = queue_limit_bytes;
+  client->payload.queue_bytes_highwater = queue_bytes_highwater;
+  client->payload.queue_buffers_highwater = (uint32_t)queue_buffers_highwater;
+  client->payload.dropped_packets = dropped_packets;
+  client->payload.dropped_bytes = dropped_bytes;
+  client->payload.backpressure_events = backpressure_events;
+  client->payload.slow_active = slow_active;
+  client_write_end(client);
 }
 
 void status_add_log_entry(enum loglevel level, const char *message) {
-  int index;
-
   if (!status_shared || !message)
     return;
 
-  /* Lock mutex to prevent race conditions in multi-worker environment */
-  pthread_mutex_lock(&status_shared->log_mutex);
-
-  /* Get next write index */
-  index = status_shared->log_write_index;
-
-  /* Store log entry */
-  status_shared->log_entries[index].timestamp = get_realtime_ms();
-  status_shared->log_entries[index].level = level;
-  strncpy(status_shared->log_entries[index].message, message, sizeof(status_shared->log_entries[index].message) - 1);
-  status_shared->log_entries[index].message[sizeof(status_shared->log_entries[index].message) - 1] = '\0';
-
-  /* Update write index (circular) */
-  status_shared->log_write_index = (index + 1) % STATUS_MAX_LOG_ENTRIES;
-
-  /* Update count */
-  if (status_shared->log_count < STATUS_MAX_LOG_ENTRIES) {
-    status_shared->log_count++;
+  if (worker_id == SUPERVISOR_WORKER_ID) {
+    append_log_entry(get_realtime_ms(), level, message);
+    status_trigger_event(STATUS_EVENT_SSE_UPDATE);
+    return;
   }
 
-  /* Unlock mutex */
-  pthread_mutex_unlock(&status_shared->log_mutex);
+  if (log_event_send_fd < 0)
+    return;
 
-  /* Trigger SSE event for new log entries */
-  status_trigger_event(STATUS_EVENT_SSE_UPDATE);
+  status_log_event_t event;
+  memset(&event, 0, sizeof(event));
+  event.type = STATUS_LOG_EVENT_ADD;
+  event.timestamp = get_realtime_ms();
+  event.level = level;
+  strncpy(event.message, message, sizeof(event.message) - 1);
+  (void)send(log_event_send_fd, &event, sizeof(event), MSG_DONTWAIT);
+}
+
+void status_supervisor_drain_logs(void) {
+  if (!status_shared || worker_id != SUPERVISOR_WORKER_ID || log_event_recv_fd < 0)
+    return;
+
+  int changed = 0;
+  for (;;) {
+    status_log_event_t event;
+    ssize_t received = recv(log_event_recv_fd, &event, sizeof(event), MSG_DONTWAIT);
+    if (received < 0) {
+      if (errno == EINTR)
+        continue;
+      break;
+    }
+    if ((size_t)received != sizeof(event))
+      continue;
+    if (event.type == STATUS_LOG_EVENT_ADD) {
+      event.message[sizeof(event.message) - 1] = '\0';
+      append_log_entry(event.timestamp, event.level, event.message);
+      changed = 1;
+    } else if (event.type == STATUS_LOG_EVENT_CLEAR) {
+      clear_log_ring();
+      changed = 1;
+    }
+  }
+  if (changed)
+    status_trigger_event(STATUS_EVENT_SSE_UPDATE);
 }
 
 /* Removed format_bytes and format_bandwidth - formatting is done in JavaScript
@@ -440,15 +647,15 @@ const char *status_get_log_level_name(enum loglevel level) {
   }
 }
 
-int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_initial, int *p_last_write_index,
-                          int *p_last_log_count) {
+int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_initial, uint32_t *p_last_log_epoch,
+                          uint32_t *p_last_log_sequence) {
   if (!status_shared)
     return 0;
 
   int sent_initial = *p_sent_initial;
-  int last_write_index = *p_last_write_index;
-  int last_log_count = *p_last_log_count;
-  int i, log_start, log_idx;
+  uint32_t last_log_epoch = *p_last_log_epoch;
+  uint32_t last_log_sequence = *p_last_log_sequence;
+  int i;
   uint64_t total_bytes = 0;
   uint32_t total_bw = 0;
   int streams_count = 0;
@@ -473,41 +680,40 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
   /* Add client data (only real media streams: have a service_url) */
   int first_client = 1;
   for (i = 0; i < STATUS_MAX_CLIENTS; i++) {
-    if (status_shared->clients[i].active && status_shared->clients[i].service_url[0] != '\0') {
+    client_stats_payload_t client;
+    uint32_t owner_pid = 0;
+    if (snapshot_client(&status_shared->clients[i], &client, &owner_pid) && client.service_url[0] != '\0') {
       if (!first_client)
         len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",");
       first_client = 0;
 
-      int64_t duration_ms = current_time - status_shared->clients[i].connect_time;
+      int64_t duration_ms = current_time - client.connect_time;
 
       /* Escape client_id for JSON */
       char escaped_client_id[256];
-      json_escape_string_to_buffer(status_shared->clients[i].client_id, escaped_client_id, sizeof(escaped_client_id));
+      json_escape_string_to_buffer(client.client_id, escaped_client_id, sizeof(escaped_client_id));
 
-      len +=
-          snprintf(buffer + len, buffer_capacity - (size_t)len,
-                   "{\"clientId\":\"%s\",\"workerPid\":%d,\"durationMs\":%lld,"
-                   "\"clientAddr\":\"%s\","
-                   "\"serviceUrl\":\"%s\",\"state\":%d,\"bytesSent\":%llu,"
-                   "\"currentBandwidth\":%u,\"queueBytes\":%zu,"
-                   "\"queueLimitBytes\":%zu,\"queueBytesHighwater\":%zu,"
-                   "\"droppedBytes\":%llu,\"slow\":%d}",
-                   escaped_client_id, status_shared->clients[i].worker_pid, (long long)duration_ms,
-                   status_shared->clients[i].client_addr, status_shared->clients[i].service_url,
-                   (int)status_shared->clients[i].state, (unsigned long long)status_shared->clients[i].bytes_sent,
-                   status_shared->clients[i].current_bandwidth, status_shared->clients[i].queue_bytes,
-                   status_shared->clients[i].queue_limit_bytes, status_shared->clients[i].queue_bytes_highwater,
-                   (unsigned long long)status_shared->clients[i].dropped_bytes, status_shared->clients[i].slow_active);
+      len += snprintf(buffer + len, buffer_capacity - (size_t)len,
+                      "{\"clientId\":\"%s\",\"workerPid\":%d,\"durationMs\":%lld,"
+                      "\"clientAddr\":\"%s\","
+                      "\"serviceUrl\":\"%s\",\"state\":%d,\"bytesSent\":%llu,"
+                      "\"currentBandwidth\":%u,\"queueBytes\":%zu,"
+                      "\"queueLimitBytes\":%zu,\"queueBytesHighwater\":%zu,"
+                      "\"droppedBytes\":%llu,\"slow\":%d}",
+                      escaped_client_id, (int)owner_pid, (long long)duration_ms, client.client_addr, client.service_url,
+                      (int)client.state, (unsigned long long)client.bytes_sent, client.current_bandwidth,
+                      client.queue_bytes, client.queue_limit_bytes, client.queue_bytes_highwater,
+                      (unsigned long long)client.dropped_bytes, client.slow_active);
 
       streams_count++;
-      total_bytes += status_shared->clients[i].bytes_sent;
-      total_bw += status_shared->clients[i].current_bandwidth;
+      total_bytes += client.bytes_sent;
+      total_bw += client.current_bandwidth;
 
-      int worker_index = status_shared->clients[i].worker_index;
+      int worker_index = client.worker_index;
       if (worker_index >= 0 && worker_index < STATUS_MAX_WORKERS) {
         worker_active_clients[worker_index]++;
-        worker_active_bytes[worker_index] += status_shared->clients[i].bytes_sent;
-        worker_bandwidth_sum[worker_index] += status_shared->clients[i].current_bandwidth;
+        worker_active_bytes[worker_index] += client.bytes_sent;
+        worker_bandwidth_sum[worker_index] += client.current_bandwidth;
       }
     }
   }
@@ -515,7 +721,9 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
   /* Close clients array and add computed totals
    * total_bytes_sent = accumulated bytes from disconnected clients + current
    * active clients */
-  uint64_t total_bytes_sent = status_shared->total_bytes_sent_cumulative + total_bytes;
+  uint64_t total_bytes_sent = total_bytes;
+  for (i = 0; i < STATUS_MAX_WORKERS; i++)
+    total_bytes_sent += status_shared->client_bytes_cumulative[i];
   len += snprintf(buffer + len, buffer_capacity - (size_t)len,
                   "],\"totalClients\":%d,\"totalBytesSent\":%llu,\"totalBandwidth\":%u", streams_count,
                   (unsigned long long)total_bytes_sent, total_bw);
@@ -566,96 +774,62 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
   }
   len += snprintf(buffer + len, buffer_capacity - (size_t)len, "]");
 
-  /* Decide logs mode */
-  const char *logs_mode = "none";
-  int cur_wi = status_shared->log_write_index;
-  int cur_count = status_shared->log_count;
-  int new_entries = 0;
-  int logs_cleared = 0;
-
-  /* Detect log clear: count decreased or write_index reset while count is less
-   */
-  if (sent_initial && cur_count < last_log_count) {
-    logs_cleared = 1;
+  uint32_t current_log_epoch = atomic_load_explicit(&status_shared->log_epoch, memory_order_acquire);
+  uint32_t current_log_sequence = atomic_load_explicit(&status_shared->log_sequence, memory_order_acquire);
+  int full_logs = !sent_initial || current_log_epoch != last_log_epoch || current_log_sequence < last_log_sequence ||
+                  current_log_sequence - last_log_sequence > STATUS_MAX_LOG_ENTRIES;
+  uint32_t first_sequence = 0;
+  if (full_logs) {
+    first_sequence = current_log_sequence > STATUS_MAX_LOG_ENTRIES ? current_log_sequence - STATUS_MAX_LOG_ENTRIES + 1
+                                                                   : (current_log_sequence > 0 ? 1 : 0);
+  } else if (current_log_sequence > last_log_sequence) {
+    first_sequence = last_log_sequence + 1;
   }
-
-  if (!sent_initial || logs_cleared) {
-    logs_mode = "full";
-  } else {
-    int delta_idx = (cur_wi - last_write_index + STATUS_MAX_LOG_ENTRIES) % STATUS_MAX_LOG_ENTRIES;
-    new_entries = delta_idx;
-    if (cur_count < STATUS_MAX_LOG_ENTRIES) {
-      int count_delta = cur_count - last_log_count;
-      if (count_delta < 0)
-        count_delta = 0;
-      if (new_entries > count_delta)
-        new_entries = count_delta;
-    }
-    logs_mode = (new_entries > 0) ? "incremental" : "none";
-  }
+  const char *logs_mode = full_logs ? "full" : (first_sequence ? "incremental" : "none");
 
   /* Add logs section */
   len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",\"logsMode\":\"%s\",\"logs\":[", logs_mode);
 
-  /* Add logs according to mode */
-  if (!sent_initial || logs_cleared) {
-    /* Full dump: all available logs (also used after log clear) */
-    int full_count = cur_count;
-    if (full_count > 0) {
-      if (cur_count < STATUS_MAX_LOG_ENTRIES)
-        log_start = 0;
-      else
-        log_start = cur_wi;
+  int first_log = 1;
+  for (uint32_t sequence = first_sequence; sequence > 0 && sequence <= current_log_sequence; sequence++) {
+    log_entry_t *entry = &status_shared->log_entries[(sequence - 1) % STATUS_MAX_LOG_ENTRIES];
+    uint32_t sequence_before = atomic_load_explicit(&entry->sequence, memory_order_acquire);
+    if (sequence_before != sequence)
+      continue;
+    int64_t timestamp = entry->timestamp;
+    loglevel_t level = entry->level;
+    char message[STATUS_LOG_ENTRY_LEN];
+    memcpy(message, entry->message, sizeof(message));
+    message[sizeof(message) - 1] = '\0';
+    atomic_thread_fence(memory_order_acquire);
+    if (atomic_load_explicit(&entry->sequence, memory_order_relaxed) != sequence)
+      continue;
 
-      int first_log = 1;
-      for (i = 0; i < full_count; i++) {
-        log_idx = (log_start + cur_count - full_count + i) % STATUS_MAX_LOG_ENTRIES;
-        if (!first_log)
-          len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",");
-        first_log = 0;
-
-        char escaped[STATUS_LOG_ENTRY_LEN * 2];
-        json_escape_string_to_buffer(status_shared->log_entries[log_idx].message, escaped, sizeof(escaped));
-
-        len += snprintf(buffer + len, buffer_capacity - (size_t)len,
-                        "{\"timestamp\":%lld,\"levelName\":\"%s\",\"message\":\"%s\"}",
-                        (long long)status_shared->log_entries[log_idx].timestamp,
-                        status_get_log_level_name(status_shared->log_entries[log_idx].level), escaped);
-      }
+    if (!first_log)
+      len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",");
+    first_log = 0;
+    char escaped[STATUS_LOG_ENTRY_LEN * 2];
+    json_escape_string_to_buffer(message, escaped, sizeof(escaped));
+    if (full_logs) {
+      len += snprintf(buffer + len, buffer_capacity - (size_t)len,
+                      "{\"timestamp\":%lld,\"levelName\":\"%s\",\"message\":\"%s\"}", (long long)timestamp,
+                      status_get_log_level_name(level), escaped);
+    } else {
+      len += snprintf(buffer + len, buffer_capacity - (size_t)len,
+                      "{\"timestamp\":%lld,\"level\":%d,\"levelName\":\"%s\",\"message\":\"%s\"}", (long long)timestamp,
+                      level, status_get_log_level_name(level), escaped);
     }
-    sent_initial = 1;
-    last_write_index = cur_wi;
-    last_log_count = cur_count;
-  } else if (new_entries > 0) {
-    /* Incremental: only new entries since last_write_index */
-    int first_log = 1;
-    int start_idx = (cur_wi - new_entries + STATUS_MAX_LOG_ENTRIES) % STATUS_MAX_LOG_ENTRIES;
-    for (i = 0; i < new_entries; i++) {
-      log_idx = (start_idx + i) % STATUS_MAX_LOG_ENTRIES;
-      if (!first_log)
-        len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",");
-      first_log = 0;
-
-      char escaped[STATUS_LOG_ENTRY_LEN * 2];
-      json_escape_string_to_buffer(status_shared->log_entries[log_idx].message, escaped, sizeof(escaped));
-
-      len +=
-          snprintf(buffer + len, buffer_capacity - (size_t)len,
-                   "{\"timestamp\":%lld,\"level\":%d,\"levelName\":\"%s\",\"message\":\"%"
-                   "s\"}",
-                   (long long)status_shared->log_entries[log_idx].timestamp, status_shared->log_entries[log_idx].level,
-                   status_get_log_level_name(status_shared->log_entries[log_idx].level), escaped);
-    }
-    last_write_index = cur_wi;
-    last_log_count = cur_count;
   }
+  sent_initial = 1;
+  last_log_epoch = current_log_epoch;
+  last_log_sequence = current_log_sequence;
 
   len += snprintf(buffer + len, buffer_capacity - (size_t)len, "]}\n\n");
 
   /* Update output parameters */
   *p_sent_initial = sent_initial;
-  *p_last_write_index = last_write_index;
-  *p_last_log_count = last_log_count;
+  *p_last_log_epoch = last_log_epoch;
+  *p_last_log_sequence = last_log_sequence;
 
   /* Update global bandwidth statistics */
   status_shared->total_bandwidth = total_bw;
@@ -712,13 +886,17 @@ void handle_disconnect_client(connection_t *c) {
 
   /* Find client by client_id string */
   for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
-    logger(LOG_DEBUG, "Checking client slot %d: active=%d, client_id=%s, to match=%s", i,
-           status_shared->clients[i].active, status_shared->clients[i].client_id, client_id_str);
-    if (status_shared->clients[i].active && strcmp(status_shared->clients[i].client_id, client_id_str) == 0) {
+    client_stats_payload_t client;
+    uint32_t owner_pid;
+    if (!snapshot_client(&status_shared->clients[i], &client, &owner_pid))
+      continue;
+    logger(LOG_DEBUG, "Checking client slot %d: active=1, client_id=%s, to match=%s", i, client.client_id,
+           client_id_str);
+    if (strcmp(client.client_id, client_id_str) == 0) {
       found = 1;
       /* Set disconnect flag - worker will check this and close the connection
        */
-      status_shared->clients[i].disconnect_requested = 1;
+      atomic_store_explicit(&status_shared->clients[i].disconnect_requested, 1, memory_order_release);
 
       /* Trigger disconnect request event to wake up workers */
       status_trigger_event(STATUS_EVENT_DISCONNECT_REQUEST);
@@ -757,11 +935,11 @@ void handle_clear_logs(connection_t *c) {
     return;
   }
 
-  /* Clear logs under mutex protection */
-  pthread_mutex_lock(&status_shared->log_mutex);
-  status_shared->log_write_index = 0;
-  status_shared->log_count = 0;
-  pthread_mutex_unlock(&status_shared->log_mutex);
+  status_log_event_t event;
+  memset(&event, 0, sizeof(event));
+  event.type = STATUS_LOG_EVENT_CLEAR;
+  if (log_event_send_fd >= 0)
+    (void)send(log_event_send_fd, &event, sizeof(event), MSG_DONTWAIT);
 
   /* Trigger SSE update to notify clients */
   status_trigger_event(STATUS_EVENT_SSE_UPDATE);
@@ -887,14 +1065,14 @@ int status_handle_sse_init(connection_t *c) {
   send_http_headers(c, STATUS_200, "text/event-stream", NULL);
 
   c->sse_sent_initial = 0;
-  c->sse_last_write_index = -1;
-  c->sse_last_log_count = 0;
+  c->sse_last_log_epoch = 0;
+  c->sse_last_log_sequence = 0;
   c->next_sse_ts = get_time_ms();
 
   /* Build and send initial SSE payload immediately */
   char tmp[SSE_BUFFER_SIZE];
   int len =
-      status_build_sse_json(tmp, sizeof(tmp), &c->sse_sent_initial, &c->sse_last_write_index, &c->sse_last_log_count);
+      status_build_sse_json(tmp, sizeof(tmp), &c->sse_sent_initial, &c->sse_last_log_epoch, &c->sse_last_log_sequence);
 
   if (len > 0) {
     connection_queue_output_and_flush(c, (const uint8_t *)tmp, (size_t)len);
@@ -913,15 +1091,15 @@ int status_handle_sse_notification(connection_t *conn_head) {
 
   /* Build and enqueue SSE payloads for all SSE connections
    * Note: Each connection has its own state (sse_sent_initial,
-   * sse_last_write_index, sse_last_log_count) so we must build a separate
+   * per-connection log cursors, so we must build a separate
    * payload for each connection */
   for (connection_t *cc = conn_head; cc; cc = cc->next) {
     if (cc->state != CONN_SSE)
       continue;
 
     char tmp[SSE_BUFFER_SIZE];
-    int len = status_build_sse_json(tmp, sizeof(tmp), &cc->sse_sent_initial, &cc->sse_last_write_index,
-                                    &cc->sse_last_log_count);
+    int len = status_build_sse_json(tmp, sizeof(tmp), &cc->sse_sent_initial, &cc->sse_last_log_epoch,
+                                    &cc->sse_last_log_sequence);
 
     if (len > 0) {
       if (connection_queue_output_and_flush(cc, (const uint8_t *)tmp, (size_t)len) == 0) {

--- a/src/status.c
+++ b/src/status.c
@@ -20,7 +20,9 @@ status_shared_t *status_shared = NULL;
 /* Path for shared memory file in /tmp */
 static char shm_path[256] = {0};
 
-typedef enum { STATUS_LOG_EVENT_ADD = 1, STATUS_LOG_EVENT_CLEAR = 2 } status_log_event_type_t;
+typedef enum { STATUS_LOG_EVENT_ADD = 1 } status_log_event_type_t;
+
+typedef enum { STATUS_CONTROL_EVENT_CLEAR_LOGS = 1 } status_control_event_type_t;
 
 typedef struct {
   uint32_t type;
@@ -29,8 +31,14 @@ typedef struct {
   char message[STATUS_LOG_ENTRY_LEN];
 } status_log_event_t;
 
+typedef struct {
+  uint32_t type;
+} status_control_event_t;
+
 static int log_event_recv_fd = -1;
 static int log_event_send_fd = -1;
+static int control_event_recv_fd = -1;
+static int control_event_send_fd = -1;
 
 static void set_fd_nonblocking(int fd) {
   int flags = fcntl(fd, F_GETFL, 0);
@@ -46,14 +54,15 @@ static void reset_client_payload(client_stats_t *client) {
   atomic_store_explicit(&client->data_version, 0, memory_order_relaxed);
 }
 
-static int reserve_client_capacity(void) {
-  uint32_t count = atomic_load_explicit(&status_shared->total_clients, memory_order_relaxed);
-  while (count < (uint32_t)config.maxclients) {
-    if (atomic_compare_exchange_weak_explicit(&status_shared->total_clients, &count, count + 1, memory_order_acq_rel,
-                                              memory_order_relaxed))
-      return 0;
+static int client_capacity_is_available(void) {
+  uint32_t reserved_slots = 0;
+
+  for (int client_index = 0; client_index < STATUS_MAX_CLIENTS; client_index++) {
+    if (atomic_load_explicit(&status_shared->clients[client_index].owner_pid, memory_order_seq_cst) != 0)
+      reserved_slots++;
   }
-  return -1;
+
+  return reserved_slots <= (uint32_t)config.maxclients;
 }
 
 static void client_write_begin(client_stats_t *client) {
@@ -64,20 +73,26 @@ static void client_write_end(client_stats_t *client) {
   atomic_fetch_add_explicit(&client->data_version, 1, memory_order_release);
 }
 
-static int snapshot_client(const client_stats_t *client, client_stats_payload_t *snapshot, uint32_t *owner_pid) {
+static int snapshot_client(const client_stats_t *client, client_stats_payload_t *snapshot, uint32_t *owner_pid,
+                           uint32_t *generation) {
   for (int attempt = 0; attempt < 3; attempt++) {
     if (!atomic_load_explicit(&client->active, memory_order_acquire))
       return 0;
     uint32_t version_before = atomic_load_explicit(&client->data_version, memory_order_acquire);
     if (version_before & 1U)
       continue;
+    uint32_t generation_before = atomic_load_explicit(&client->generation, memory_order_acquire);
     *owner_pid = atomic_load_explicit(&client->owner_pid, memory_order_relaxed);
     memcpy(snapshot, &client->payload, sizeof(*snapshot));
     atomic_thread_fence(memory_order_acquire);
     uint32_t version_after = atomic_load_explicit(&client->data_version, memory_order_relaxed);
-    if (version_before == version_after && !(version_after & 1U) &&
-        atomic_load_explicit(&client->active, memory_order_acquire))
+    uint32_t generation_after = atomic_load_explicit(&client->generation, memory_order_relaxed);
+    if (version_before == version_after && !(version_after & 1U) && generation_before == generation_after &&
+        atomic_load_explicit(&client->active, memory_order_acquire)) {
+      if (generation)
+        *generation = generation_after;
       return 1;
+    }
   }
   return 0;
 }
@@ -166,13 +181,13 @@ int status_init(void) {
   status_shared->server_start_time = get_realtime_ms();
   status_shared->current_log_level = config.verbosity;
   status_shared->event_counter = 0;
-  atomic_init(&status_shared->total_clients, 0);
   atomic_init(&status_shared->log_epoch, 1);
   atomic_init(&status_shared->log_sequence, 0);
 
   for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
     atomic_init(&status_shared->clients[i].owner_pid, 0);
     atomic_init(&status_shared->clients[i].active, 0);
+    atomic_init(&status_shared->clients[i].generation, 0);
     atomic_init(&status_shared->clients[i].disconnect_requested, 0);
     atomic_init(&status_shared->clients[i].data_version, 0);
     status_shared->clients[i].payload.worker_index = -1;
@@ -180,9 +195,10 @@ int status_init(void) {
   for (int i = 0; i < STATUS_MAX_LOG_ENTRIES; i++)
     atomic_init(&status_shared->log_entries[i].sequence, 0);
 
-  if (!atomic_is_lock_free(&status_shared->total_clients) ||
-      !atomic_is_lock_free(&status_shared->clients[0].owner_pid) ||
-      !atomic_is_lock_free(&status_shared->clients[0].active) || !atomic_is_lock_free(&status_shared->log_sequence)) {
+  if (!atomic_is_lock_free(&status_shared->clients[0].owner_pid) ||
+      !atomic_is_lock_free(&status_shared->clients[0].active) ||
+      !atomic_is_lock_free(&status_shared->clients[0].generation) ||
+      !atomic_is_lock_free(&status_shared->log_sequence)) {
     status_shared = NULL;
     munmap(mapped, sizeof(status_shared_t));
     unlink(shm_path);
@@ -203,6 +219,24 @@ int status_init(void) {
   log_event_send_fd = log_fds[1];
   set_fd_nonblocking(log_event_recv_fd);
   set_fd_nonblocking(log_event_send_fd);
+
+  int control_fds[2];
+  if (socketpair(AF_UNIX, SOCK_DGRAM, 0, control_fds) == -1) {
+    int err = errno;
+    close(log_event_recv_fd);
+    close(log_event_send_fd);
+    log_event_recv_fd = -1;
+    log_event_send_fd = -1;
+    status_shared = NULL;
+    munmap(mapped, sizeof(status_shared_t));
+    unlink(shm_path);
+    logger(LOG_ERROR, "Failed to create status control socketpair: %s", strerror(err));
+    return -1;
+  }
+  control_event_recv_fd = control_fds[0];
+  control_event_send_fd = control_fds[1];
+  set_fd_nonblocking(control_event_recv_fd);
+  set_fd_nonblocking(control_event_send_fd);
 
   /* Initialize pipe fds to -1 (invalid) */
   for (int i = 0; i < STATUS_MAX_WORKERS; i++) {
@@ -229,6 +263,10 @@ int status_init(void) {
       close(log_event_send_fd);
       log_event_recv_fd = -1;
       log_event_send_fd = -1;
+      close(control_event_recv_fd);
+      close(control_event_send_fd);
+      control_event_recv_fd = -1;
+      control_event_send_fd = -1;
       munmap(status_shared, sizeof(status_shared_t));
       status_shared = NULL;
       unlink(shm_path);
@@ -287,6 +325,14 @@ void status_cleanup(void) {
     close(log_event_send_fd);
     log_event_send_fd = -1;
   }
+  if (control_event_recv_fd >= 0) {
+    close(control_event_recv_fd);
+    control_event_recv_fd = -1;
+  }
+  if (control_event_send_fd >= 0) {
+    close(control_event_send_fd);
+    control_event_send_fd = -1;
+  }
 
   if (status_shared != NULL && status_shared != MAP_FAILED) {
     /* Close all pipe fds (this process's copies)
@@ -328,6 +374,10 @@ void status_worker_init(void) {
     close(log_event_recv_fd);
     log_event_recv_fd = -1;
   }
+  if (control_event_recv_fd >= 0) {
+    close(control_event_recv_fd);
+    control_event_recv_fd = -1;
+  }
 }
 
 int status_register_client(const char *client_addr_str, const char *service_url) {
@@ -342,9 +392,18 @@ int status_register_client(const char *client_addr_str, const char *service_url)
   for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
     client_stats_t *client = &status_shared->clients[i];
     uint32_t expected = 0;
-    if (atomic_compare_exchange_strong_explicit(&client->owner_pid, &expected, owner_pid, memory_order_acq_rel,
-                                                memory_order_relaxed)) {
+    if (atomic_compare_exchange_strong_explicit(&client->owner_pid, &expected, owner_pid, memory_order_seq_cst,
+                                                memory_order_seq_cst)) {
+      if (!client_capacity_is_available()) {
+        atomic_store_explicit(&client->owner_pid, 0, memory_order_seq_cst);
+        logger(LOG_WARN, "Maximum client limit reached");
+        return -1;
+      }
+
       reset_client_payload(client);
+      uint32_t generation = atomic_fetch_add_explicit(&client->generation, 1, memory_order_acq_rel) + 1;
+      if (generation == 0)
+        atomic_fetch_add_explicit(&client->generation, 1, memory_order_acq_rel);
       client->payload.worker_index = worker_id;
       client->payload.connect_time = get_realtime_ms();
       client->payload.state = CLIENT_STATE_CONNECTING;
@@ -368,13 +427,6 @@ int status_register_client(const char *client_addr_str, const char *service_url)
       if (service_url) {
         strncpy(client->payload.service_url, service_url, sizeof(client->payload.service_url) - 1);
         client->payload.service_url[sizeof(client->payload.service_url) - 1] = '\0';
-      }
-
-      if (reserve_client_capacity() < 0) {
-        reset_client_payload(client);
-        atomic_store_explicit(&client->owner_pid, 0, memory_order_release);
-        logger(LOG_WARN, "Maximum client limit reached");
-        return -1;
       }
 
       atomic_store_explicit(&client->active, 1, memory_order_release);
@@ -417,9 +469,8 @@ void status_unregister_client(int status_index) {
     status_shared->worker_stats[client_worker_index].client_bytes_cumulative += bytes_sent;
   }
 
-  atomic_fetch_sub_explicit(&status_shared->total_clients, 1, memory_order_acq_rel);
   reset_client_payload(client);
-  atomic_store_explicit(&client->owner_pid, 0, memory_order_release);
+  atomic_store_explicit(&client->owner_pid, 0, memory_order_seq_cst);
 
   /* Trigger event notification for client disconnect */
   status_trigger_event(STATUS_EVENT_SSE_UPDATE);
@@ -442,16 +493,9 @@ int status_reap_worker(pid_t dead_pid, int worker_index) {
         status_shared->client_bytes_cumulative[client_worker_index] += client->payload.bytes_sent;
     }
     reset_client_payload(client);
-    atomic_store_explicit(&client->owner_pid, 0, memory_order_release);
+    atomic_store_explicit(&client->owner_pid, 0, memory_order_seq_cst);
     reclaimed++;
   }
-
-  uint32_t active_count = 0;
-  for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
-    if (atomic_load_explicit(&status_shared->clients[i].active, memory_order_acquire))
-      active_count++;
-  }
-  atomic_store_explicit(&status_shared->total_clients, active_count, memory_order_release);
 
   if (worker_index >= 0 && worker_index < STATUS_MAX_WORKERS &&
       status_shared->worker_stats[worker_index].worker_pid == dead_pid) {
@@ -600,29 +644,47 @@ void status_add_log_entry(enum loglevel level, const char *message) {
 }
 
 void status_supervisor_drain_logs(void) {
-  if (!status_shared || worker_id != SUPERVISOR_WORKER_ID || log_event_recv_fd < 0)
+  if (!status_shared || worker_id != SUPERVISOR_WORKER_ID)
     return;
 
   int changed = 0;
-  for (;;) {
-    status_log_event_t event;
-    ssize_t received = recv(log_event_recv_fd, &event, sizeof(event), MSG_DONTWAIT);
-    if (received < 0) {
-      if (errno == EINTR)
+  if (log_event_recv_fd >= 0) {
+    for (;;) {
+      status_log_event_t event;
+      ssize_t received = recv(log_event_recv_fd, &event, sizeof(event), MSG_DONTWAIT);
+      if (received < 0) {
+        if (errno == EINTR)
+          continue;
+        break;
+      }
+      if ((size_t)received != sizeof(event))
         continue;
-      break;
-    }
-    if ((size_t)received != sizeof(event))
-      continue;
-    if (event.type == STATUS_LOG_EVENT_ADD) {
-      event.message[sizeof(event.message) - 1] = '\0';
-      append_log_entry(event.timestamp, event.level, event.message);
-      changed = 1;
-    } else if (event.type == STATUS_LOG_EVENT_CLEAR) {
-      clear_log_ring();
-      changed = 1;
+      if (event.type == STATUS_LOG_EVENT_ADD) {
+        event.message[sizeof(event.message) - 1] = '\0';
+        append_log_entry(event.timestamp, event.level, event.message);
+        changed = 1;
+      }
     }
   }
+
+  if (control_event_recv_fd >= 0) {
+    for (;;) {
+      status_control_event_t event;
+      ssize_t received = recv(control_event_recv_fd, &event, sizeof(event), MSG_DONTWAIT);
+      if (received < 0) {
+        if (errno == EINTR)
+          continue;
+        break;
+      }
+      if ((size_t)received != sizeof(event))
+        continue;
+      if (event.type == STATUS_CONTROL_EVENT_CLEAR_LOGS) {
+        clear_log_ring();
+        changed = 1;
+      }
+    }
+  }
+
   if (changed)
     status_trigger_event(STATUS_EVENT_SSE_UPDATE);
 }
@@ -682,7 +744,7 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
   for (i = 0; i < STATUS_MAX_CLIENTS; i++) {
     client_stats_payload_t client;
     uint32_t owner_pid = 0;
-    if (snapshot_client(&status_shared->clients[i], &client, &owner_pid) && client.service_url[0] != '\0') {
+    if (snapshot_client(&status_shared->clients[i], &client, &owner_pid, NULL) && client.service_url[0] != '\0') {
       if (!first_client)
         len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",");
       first_client = 0;
@@ -888,15 +950,19 @@ void handle_disconnect_client(connection_t *c) {
   for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
     client_stats_payload_t client;
     uint32_t owner_pid;
-    if (!snapshot_client(&status_shared->clients[i], &client, &owner_pid))
+    uint32_t generation;
+    if (!snapshot_client(&status_shared->clients[i], &client, &owner_pid, &generation))
       continue;
     logger(LOG_DEBUG, "Checking client slot %d: active=1, client_id=%s, to match=%s", i, client.client_id,
            client_id_str);
     if (strcmp(client.client_id, client_id_str) == 0) {
-      found = 1;
-      /* Set disconnect flag - worker will check this and close the connection
-       */
-      atomic_store_explicit(&status_shared->clients[i].disconnect_requested, 1, memory_order_release);
+      client_stats_t *shared_client = &status_shared->clients[i];
+      atomic_store_explicit(&shared_client->disconnect_requested, generation, memory_order_release);
+
+      found = atomic_load_explicit(&shared_client->active, memory_order_acquire) &&
+              atomic_load_explicit(&shared_client->generation, memory_order_acquire) == generation;
+      if (!found)
+        continue;
 
       /* Trigger disconnect request event to wake up workers */
       status_trigger_event(STATUS_EVENT_DISCONNECT_REQUEST);
@@ -935,11 +1001,19 @@ void handle_clear_logs(connection_t *c) {
     return;
   }
 
-  status_log_event_t event;
+  status_control_event_t event;
   memset(&event, 0, sizeof(event));
-  event.type = STATUS_LOG_EVENT_CLEAR;
-  if (log_event_send_fd >= 0)
-    (void)send(log_event_send_fd, &event, sizeof(event), MSG_DONTWAIT);
+  event.type = STATUS_CONTROL_EVENT_CLEAR_LOGS;
+  ssize_t bytes_sent = -1;
+  if (control_event_send_fd >= 0)
+    bytes_sent = send(control_event_send_fd, &event, sizeof(event), MSG_DONTWAIT);
+
+  if (bytes_sent != (ssize_t)sizeof(event)) {
+    send_http_headers(c, STATUS_503, "application/json", NULL);
+    snprintf(response, sizeof(response), "{\"success\":false,\"error\":\"Failed to queue log clear request\"}");
+    connection_queue_output_and_flush(c, (const uint8_t *)response, strlen(response));
+    return;
+  }
 
   /* Trigger SSE update to notify clients */
   status_trigger_event(STATUS_EVENT_SSE_UPDATE);

--- a/src/status.c
+++ b/src/status.c
@@ -75,15 +75,30 @@ static void reset_client_payload(client_stats_t *client) {
   atomic_store_explicit(&client->data_version, 0, memory_order_relaxed);
 }
 
+static void lock_client_admission(uint32_t owner_pid) {
+  uint32_t expected_owner = 0;
+  while (!atomic_compare_exchange_weak_explicit(&status_shared->client_admission_owner_pid, &expected_owner, owner_pid,
+                                                memory_order_acquire, memory_order_relaxed)) {
+    expected_owner = 0;
+    usleep(100);
+  }
+}
+
+static void unlock_client_admission(uint32_t owner_pid) {
+  uint32_t expected_owner = owner_pid;
+  atomic_compare_exchange_strong_explicit(&status_shared->client_admission_owner_pid, &expected_owner, 0,
+                                          memory_order_release, memory_order_relaxed);
+}
+
 static int client_capacity_is_available(void) {
   uint32_t reserved_slots = 0;
 
   for (int client_index = 0; client_index < STATUS_MAX_CLIENTS; client_index++) {
-    if (atomic_load_explicit(&status_shared->clients[client_index].owner_pid, memory_order_seq_cst) != 0)
+    if (atomic_load_explicit(&status_shared->clients[client_index].owner_pid, memory_order_acquire) != 0)
       reserved_slots++;
   }
 
-  return reserved_slots <= (uint32_t)config.maxclients;
+  return reserved_slots < (uint32_t)config.maxclients;
 }
 
 static void client_write_begin(client_stats_t *client) {
@@ -202,6 +217,7 @@ int status_init(void) {
   status_shared->server_start_time = get_realtime_ms();
   status_shared->current_log_level = config.verbosity;
   status_shared->event_counter = 0;
+  atomic_init(&status_shared->client_admission_owner_pid, 0);
   atomic_init(&status_shared->log_epoch, 1);
   atomic_init(&status_shared->log_sequence, 0);
 
@@ -216,9 +232,14 @@ int status_init(void) {
   for (int i = 0; i < STATUS_MAX_LOG_ENTRIES; i++)
     atomic_init(&status_shared->log_entries[i].sequence, 0);
 
-  if (!atomic_is_lock_free(&status_shared->clients[0].owner_pid) ||
+  if (!atomic_is_lock_free(&status_shared->client_admission_owner_pid) ||
+      !atomic_is_lock_free(&status_shared->clients[0].owner_pid) ||
       !atomic_is_lock_free(&status_shared->clients[0].active) ||
       !atomic_is_lock_free(&status_shared->clients[0].generation) ||
+      !atomic_is_lock_free(&status_shared->clients[0].disconnect_requested) ||
+      !atomic_is_lock_free(&status_shared->clients[0].data_version) ||
+      !atomic_is_lock_free(&status_shared->log_epoch) ||
+      !atomic_is_lock_free(&status_shared->log_entries[0].sequence) ||
       !atomic_is_lock_free(&status_shared->log_sequence)) {
     status_shared = NULL;
     munmap(mapped, sizeof(status_shared_t));
@@ -408,58 +429,62 @@ int status_register_client(const char *client_addr_str, const char *service_url)
   if (!status_shared || !client_addr_str)
     return -1;
 
+  lock_client_admission(owner_pid);
+  if (!client_capacity_is_available()) {
+    unlock_client_admission(owner_pid);
+    logger(LOG_WARN, "Maximum client limit reached");
+    return -1;
+  }
+
   /* Reserve a slot by PID. owner_pid remains set while the slot is being
    * initialized so the supervisor can recover a worker killed mid-register. */
   for (int i = 0; i < STATUS_MAX_CLIENTS; i++) {
     client_stats_t *client = &status_shared->clients[i];
     uint32_t expected = 0;
-    if (atomic_compare_exchange_strong_explicit(&client->owner_pid, &expected, owner_pid, memory_order_seq_cst,
-                                                memory_order_seq_cst)) {
-      if (!client_capacity_is_available()) {
-        atomic_store_explicit(&client->owner_pid, 0, memory_order_seq_cst);
-        logger(LOG_WARN, "Maximum client limit reached");
-        return -1;
-      }
+    if (!atomic_compare_exchange_strong_explicit(&client->owner_pid, &expected, owner_pid, memory_order_acq_rel,
+                                                 memory_order_relaxed))
+      continue;
 
-      reset_client_payload(client);
-      uint32_t generation = atomic_fetch_add_explicit(&client->generation, 1, memory_order_acq_rel) + 1;
-      if (generation == 0)
-        atomic_fetch_add_explicit(&client->generation, 1, memory_order_acq_rel);
-      client->payload.worker_index = worker_id;
-      client->payload.connect_time = get_realtime_ms();
-      client->payload.state = CLIENT_STATE_CONNECTING;
-
-      /* Copy client address string (format: "IP:port", "[IPv6]:port", or
-       * "localhost" for Unix socket clients) */
-      strncpy(client->payload.client_addr, client_addr_str, sizeof(client->payload.client_addr) - 1);
-      client->payload.client_addr[sizeof(client->payload.client_addr) - 1] = '\0';
-
-      /* Generate unique client ID: "IP:port-workerN-seqM"
-       * Use real client IP (not X-Forwarded-For) + port + worker index +
-       * sequence counter */
-      uint64_t seq = 0;
-      if (worker_id >= 0 && worker_id < STATUS_MAX_WORKERS) {
-        seq = status_shared->worker_stats[worker_id].client_id_counter++;
-      }
-      snprintf(client->payload.client_id, sizeof(client->payload.client_id), "%s-worker%d-seq%llu", client_addr_str,
-               worker_id, (unsigned long long)seq);
-
-      /* Copy service URL */
-      if (service_url) {
-        strncpy(client->payload.service_url, service_url, sizeof(client->payload.service_url) - 1);
-        client->payload.service_url[sizeof(client->payload.service_url) - 1] = '\0';
-      }
-
-      atomic_store_explicit(&client->active, 1, memory_order_release);
-      status_index = i;
-      break;
-    }
+    status_index = i;
+    break;
   }
+  unlock_client_admission(owner_pid);
 
   if (status_index < 0) {
     logger(LOG_ERROR, "No free client slots in status tracking");
     return -1;
   }
+
+  client_stats_t *client = &status_shared->clients[status_index];
+  reset_client_payload(client);
+  uint32_t generation = atomic_fetch_add_explicit(&client->generation, 1, memory_order_acq_rel) + 1;
+  if (generation == 0)
+    atomic_fetch_add_explicit(&client->generation, 1, memory_order_acq_rel);
+  client->payload.worker_index = worker_id;
+  client->payload.connect_time = get_realtime_ms();
+  client->payload.state = CLIENT_STATE_CONNECTING;
+
+  /* Copy client address string (format: "IP:port", "[IPv6]:port", or
+   * "localhost" for Unix socket clients) */
+  strncpy(client->payload.client_addr, client_addr_str, sizeof(client->payload.client_addr) - 1);
+  client->payload.client_addr[sizeof(client->payload.client_addr) - 1] = '\0';
+
+  /* Generate unique client ID: "IP:port-workerN-seqM"
+   * Use real client IP (not X-Forwarded-For) + port + worker index +
+   * sequence counter */
+  uint64_t seq = 0;
+  if (worker_id >= 0 && worker_id < STATUS_MAX_WORKERS)
+    seq = status_shared->worker_stats[worker_id].client_id_counter++;
+  snprintf(client->payload.client_id, sizeof(client->payload.client_id), "%s-worker%d-seq%llu", client_addr_str,
+           worker_id, (unsigned long long)seq);
+
+  /* Copy service URL */
+  if (service_url) {
+    strncpy(client->payload.service_url, service_url, sizeof(client->payload.service_url) - 1);
+    client->payload.service_url[sizeof(client->payload.service_url) - 1] = '\0';
+  }
+
+  atomic_store_explicit(&client->active, 1, memory_order_release);
 
   /* Trigger event notification for new client */
   status_trigger_event(STATUS_EVENT_SSE_UPDATE);
@@ -517,6 +542,10 @@ int status_reap_worker(pid_t dead_pid, int worker_index) {
     atomic_store_explicit(&client->owner_pid, 0, memory_order_seq_cst);
     reclaimed++;
   }
+
+  uint32_t expected_admission_owner = dead_owner;
+  atomic_compare_exchange_strong_explicit(&status_shared->client_admission_owner_pid, &expected_admission_owner, 0,
+                                          memory_order_release, memory_order_relaxed);
 
   if (worker_index >= 0 && worker_index < STATUS_MAX_WORKERS &&
       status_shared->worker_stats[worker_index].worker_pid == dead_pid) {

--- a/src/status.c
+++ b/src/status.c
@@ -512,7 +512,6 @@ void status_unregister_client(int status_index) {
 
   if (client_worker_index >= 0 && client_worker_index < STATUS_MAX_WORKERS) {
     status_shared->client_bytes_cumulative[client_worker_index] += bytes_sent;
-    status_shared->worker_stats[client_worker_index].client_bytes_cumulative += bytes_sent;
   }
 
   reset_client_payload(client);
@@ -863,7 +862,9 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
     uint64_t w_ctrl_used = w_ctrl_total > w_ctrl_free ? w_ctrl_total - w_ctrl_free : 0;
     uint32_t w_active = worker_active_clients[i];
     uint64_t w_bandwidth = worker_bandwidth_sum[i];
-    uint64_t w_total_bytes = ws->client_bytes_cumulative + worker_active_bytes[i];
+    /* The shared shard also includes bytes from clients reclaimed after a
+     * worker crash, while worker_stats can be reset during reaping. */
+    uint64_t w_total_bytes = status_shared->client_bytes_cumulative[i] + worker_active_bytes[i];
 
     if (append_sse_data(
             buffer, buffer_capacity, &len,

--- a/src/status.c
+++ b/src/status.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -40,10 +41,30 @@ static int log_event_send_fd = -1;
 static int control_event_recv_fd = -1;
 static int control_event_send_fd = -1;
 
+static int append_sse_data(char *buffer, size_t buffer_capacity, size_t *buffer_length, const char *format, ...)
+    __attribute__((format(printf, 4, 5)));
+
 static void set_fd_nonblocking(int fd) {
   int flags = fcntl(fd, F_GETFL, 0);
   if (flags >= 0)
     fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+static int append_sse_data(char *buffer, size_t buffer_capacity, size_t *buffer_length, const char *format, ...) {
+  if (*buffer_length >= buffer_capacity)
+    return -1;
+
+  size_t remaining_capacity = buffer_capacity - *buffer_length;
+  va_list arguments;
+  va_start(arguments, format);
+  int formatted_length = vsnprintf(buffer + *buffer_length, remaining_capacity, format, arguments);
+  va_end(arguments);
+
+  if (formatted_length < 0 || (size_t)formatted_length >= remaining_capacity)
+    return -1;
+
+  *buffer_length += (size_t)formatted_length;
+  return 0;
 }
 
 static void reset_client_payload(client_stats_t *client) {
@@ -84,9 +105,9 @@ static int snapshot_client(const client_stats_t *client, client_stats_payload_t 
     uint32_t generation_before = atomic_load_explicit(&client->generation, memory_order_acquire);
     *owner_pid = atomic_load_explicit(&client->owner_pid, memory_order_relaxed);
     memcpy(snapshot, &client->payload, sizeof(*snapshot));
-    atomic_thread_fence(memory_order_acquire);
-    uint32_t version_after = atomic_load_explicit(&client->data_version, memory_order_relaxed);
-    uint32_t generation_after = atomic_load_explicit(&client->generation, memory_order_relaxed);
+    atomic_thread_fence(memory_order_acq_rel);
+    uint32_t version_after = atomic_load_explicit(&client->data_version, memory_order_acquire);
+    uint32_t generation_after = atomic_load_explicit(&client->generation, memory_order_acquire);
     if (version_before == version_after && !(version_after & 1U) && generation_before == generation_after &&
         atomic_load_explicit(&client->active, memory_order_acquire)) {
       if (generation)
@@ -732,12 +753,14 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
   int64_t current_time = get_realtime_ms();
   int64_t uptime_ms = current_time - status_shared->server_start_time;
 
-  int len = snprintf(buffer, buffer_capacity,
-                     "data: "
-                     "{\"serverStartTime\":%lld,\"uptimeMs\":%lld,\"currentLogLevel\":%d,"
-                     "\"version\":\"" VERSION "\",\"maxClients\":%d,\"clients\":[",
-                     (long long)status_shared->server_start_time, (long long)uptime_ms,
-                     status_shared->current_log_level, config.maxclients);
+  size_t len = 0;
+  if (append_sse_data(buffer, buffer_capacity, &len,
+                      "data: "
+                      "{\"serverStartTime\":%lld,\"uptimeMs\":%lld,\"currentLogLevel\":%d,"
+                      "\"version\":\"" VERSION "\",\"maxClients\":%d,\"clients\":[",
+                      (long long)status_shared->server_start_time, (long long)uptime_ms,
+                      status_shared->current_log_level, config.maxclients) < 0)
+    return 0;
 
   /* Add client data (only real media streams: have a service_url) */
   int first_client = 1;
@@ -745,8 +768,8 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
     client_stats_payload_t client;
     uint32_t owner_pid = 0;
     if (snapshot_client(&status_shared->clients[i], &client, &owner_pid, NULL) && client.service_url[0] != '\0') {
-      if (!first_client)
-        len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",");
+      if (!first_client && append_sse_data(buffer, buffer_capacity, &len, ",") < 0)
+        return 0;
       first_client = 0;
 
       int64_t duration_ms = current_time - client.connect_time;
@@ -755,17 +778,19 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
       char escaped_client_id[256];
       json_escape_string_to_buffer(client.client_id, escaped_client_id, sizeof(escaped_client_id));
 
-      len += snprintf(buffer + len, buffer_capacity - (size_t)len,
-                      "{\"clientId\":\"%s\",\"workerPid\":%d,\"durationMs\":%lld,"
-                      "\"clientAddr\":\"%s\","
-                      "\"serviceUrl\":\"%s\",\"state\":%d,\"bytesSent\":%llu,"
-                      "\"currentBandwidth\":%u,\"queueBytes\":%zu,"
-                      "\"queueLimitBytes\":%zu,\"queueBytesHighwater\":%zu,"
-                      "\"droppedBytes\":%llu,\"slow\":%d}",
-                      escaped_client_id, (int)owner_pid, (long long)duration_ms, client.client_addr, client.service_url,
-                      (int)client.state, (unsigned long long)client.bytes_sent, client.current_bandwidth,
-                      client.queue_bytes, client.queue_limit_bytes, client.queue_bytes_highwater,
-                      (unsigned long long)client.dropped_bytes, client.slow_active);
+      if (append_sse_data(buffer, buffer_capacity, &len,
+                          "{\"clientId\":\"%s\",\"workerPid\":%d,\"durationMs\":%lld,"
+                          "\"clientAddr\":\"%s\","
+                          "\"serviceUrl\":\"%s\",\"state\":%d,\"bytesSent\":%llu,"
+                          "\"currentBandwidth\":%u,\"queueBytes\":%zu,"
+                          "\"queueLimitBytes\":%zu,\"queueBytesHighwater\":%zu,"
+                          "\"droppedBytes\":%llu,\"slow\":%d}",
+                          escaped_client_id, (int)owner_pid, (long long)duration_ms, client.client_addr,
+                          client.service_url, (int)client.state, (unsigned long long)client.bytes_sent,
+                          client.current_bandwidth, client.queue_bytes, client.queue_limit_bytes,
+                          client.queue_bytes_highwater, (unsigned long long)client.dropped_bytes,
+                          client.slow_active) < 0)
+        return 0;
 
       streams_count++;
       total_bytes += client.bytes_sent;
@@ -786,17 +811,19 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
   uint64_t total_bytes_sent = total_bytes;
   for (i = 0; i < STATUS_MAX_WORKERS; i++)
     total_bytes_sent += status_shared->client_bytes_cumulative[i];
-  len += snprintf(buffer + len, buffer_capacity - (size_t)len,
-                  "],\"totalClients\":%d,\"totalBytesSent\":%llu,\"totalBandwidth\":%u", streams_count,
-                  (unsigned long long)total_bytes_sent, total_bw);
+  if (append_sse_data(buffer, buffer_capacity, &len,
+                      "],\"totalClients\":%d,\"totalBytesSent\":%llu,\"totalBandwidth\":%u", streams_count,
+                      (unsigned long long)total_bytes_sent, total_bw) < 0)
+    return 0;
 
   /* Add per-worker breakdown */
-  len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",\"workers\":[");
+  if (append_sse_data(buffer, buffer_capacity, &len, ",\"workers\":[") < 0)
+    return 0;
   int first_worker_entry = 1;
   for (i = 0; i < config.workers && i < STATUS_MAX_WORKERS; i++) {
     worker_stats_t *ws = &status_shared->worker_stats[i];
-    if (!first_worker_entry)
-      len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",");
+    if (!first_worker_entry && append_sse_data(buffer, buffer_capacity, &len, ",") < 0)
+      return 0;
     first_worker_entry = 0;
 
     uint64_t w_pool_total = ws->pool_total_buffers;
@@ -809,32 +836,34 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
     uint64_t w_bandwidth = worker_bandwidth_sum[i];
     uint64_t w_total_bytes = ws->client_bytes_cumulative + worker_active_bytes[i];
 
-    len +=
-        snprintf(buffer + len, buffer_capacity - (size_t)len,
-                 "{\"id\":%d,\"pid\":%d,\"activeClients\":%u,\"totalBandwidth\":%llu,"
-                 "\"totalBytes\":%llu,"
-                 "\"send\":{\"total\":%llu,\"completions\":%llu,\"copied\":%llu,"
-                 "\"eagain\":%llu,\"enobufs\":%llu,\"batch\":%llu},"
-                 "\"pool\":{\"total\":%llu,\"free\":%llu,\"used\":%llu,\"max\":%llu,"
-                 "\"expansions\":%llu,\"exhaustions\":%llu,\"shrinks\":%llu,"
-                 "\"utilization\":%.1f},"
-                 "\"controlPool\":{\"total\":%llu,\"free\":%llu,\"used\":%llu,\"max\":%"
-                 "llu,\"expansions\":%llu,\"exhaustions\":%llu,\"shrinks\":%llu,"
-                 "\"utilization\":%.1f}}",
-                 i, (int)ws->worker_pid, (unsigned int)w_active, (unsigned long long)w_bandwidth,
-                 (unsigned long long)w_total_bytes, (unsigned long long)ws->total_sends,
-                 (unsigned long long)ws->total_completions, (unsigned long long)ws->total_copied,
-                 (unsigned long long)ws->eagain_count, (unsigned long long)ws->enobufs_count,
-                 (unsigned long long)ws->batch_sends, (unsigned long long)w_pool_total, (unsigned long long)w_pool_free,
-                 (unsigned long long)w_pool_used, (unsigned long long)ws->pool_max_buffers,
-                 (unsigned long long)ws->pool_expansions, (unsigned long long)ws->pool_exhaustions,
-                 (unsigned long long)ws->pool_shrinks, w_pool_total > 0 ? (100.0 * w_pool_used / w_pool_total) : 0.0,
-                 (unsigned long long)w_ctrl_total, (unsigned long long)w_ctrl_free, (unsigned long long)w_ctrl_used,
-                 (unsigned long long)ws->control_pool_max_buffers, (unsigned long long)ws->control_pool_expansions,
-                 (unsigned long long)ws->control_pool_exhaustions, (unsigned long long)ws->control_pool_shrinks,
-                 w_ctrl_total > 0 ? (100.0 * w_ctrl_used / w_ctrl_total) : 0.0);
+    if (append_sse_data(
+            buffer, buffer_capacity, &len,
+            "{\"id\":%d,\"pid\":%d,\"activeClients\":%u,\"totalBandwidth\":%llu,"
+            "\"totalBytes\":%llu,"
+            "\"send\":{\"total\":%llu,\"completions\":%llu,\"copied\":%llu,"
+            "\"eagain\":%llu,\"enobufs\":%llu,\"batch\":%llu},"
+            "\"pool\":{\"total\":%llu,\"free\":%llu,\"used\":%llu,\"max\":%llu,"
+            "\"expansions\":%llu,\"exhaustions\":%llu,\"shrinks\":%llu,"
+            "\"utilization\":%.1f},"
+            "\"controlPool\":{\"total\":%llu,\"free\":%llu,\"used\":%llu,\"max\":%"
+            "llu,\"expansions\":%llu,\"exhaustions\":%llu,\"shrinks\":%llu,"
+            "\"utilization\":%.1f}}",
+            i, (int)ws->worker_pid, (unsigned int)w_active, (unsigned long long)w_bandwidth,
+            (unsigned long long)w_total_bytes, (unsigned long long)ws->total_sends,
+            (unsigned long long)ws->total_completions, (unsigned long long)ws->total_copied,
+            (unsigned long long)ws->eagain_count, (unsigned long long)ws->enobufs_count,
+            (unsigned long long)ws->batch_sends, (unsigned long long)w_pool_total, (unsigned long long)w_pool_free,
+            (unsigned long long)w_pool_used, (unsigned long long)ws->pool_max_buffers,
+            (unsigned long long)ws->pool_expansions, (unsigned long long)ws->pool_exhaustions,
+            (unsigned long long)ws->pool_shrinks, w_pool_total > 0 ? (100.0 * w_pool_used / w_pool_total) : 0.0,
+            (unsigned long long)w_ctrl_total, (unsigned long long)w_ctrl_free, (unsigned long long)w_ctrl_used,
+            (unsigned long long)ws->control_pool_max_buffers, (unsigned long long)ws->control_pool_expansions,
+            (unsigned long long)ws->control_pool_exhaustions, (unsigned long long)ws->control_pool_shrinks,
+            w_ctrl_total > 0 ? (100.0 * w_ctrl_used / w_ctrl_total) : 0.0) < 0)
+      return 0;
   }
-  len += snprintf(buffer + len, buffer_capacity - (size_t)len, "]");
+  if (append_sse_data(buffer, buffer_capacity, &len, "]") < 0)
+    return 0;
 
   uint32_t current_log_epoch = atomic_load_explicit(&status_shared->log_epoch, memory_order_acquire);
   uint32_t current_log_sequence = atomic_load_explicit(&status_shared->log_sequence, memory_order_acquire);
@@ -850,7 +879,8 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
   const char *logs_mode = full_logs ? "full" : (first_sequence ? "incremental" : "none");
 
   /* Add logs section */
-  len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",\"logsMode\":\"%s\",\"logs\":[", logs_mode);
+  if (append_sse_data(buffer, buffer_capacity, &len, ",\"logsMode\":\"%s\",\"logs\":[", logs_mode) < 0)
+    return 0;
 
   int first_log = 1;
   for (uint32_t sequence = first_sequence; sequence > 0 && sequence <= current_log_sequence; sequence++) {
@@ -863,30 +893,32 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
     char message[STATUS_LOG_ENTRY_LEN];
     memcpy(message, entry->message, sizeof(message));
     message[sizeof(message) - 1] = '\0';
-    atomic_thread_fence(memory_order_acquire);
-    if (atomic_load_explicit(&entry->sequence, memory_order_relaxed) != sequence)
+    atomic_thread_fence(memory_order_acq_rel);
+    if (atomic_load_explicit(&entry->sequence, memory_order_acquire) != sequence)
       continue;
 
-    if (!first_log)
-      len += snprintf(buffer + len, buffer_capacity - (size_t)len, ",");
+    if (!first_log && append_sse_data(buffer, buffer_capacity, &len, ",") < 0)
+      return 0;
     first_log = 0;
     char escaped[STATUS_LOG_ENTRY_LEN * 2];
     json_escape_string_to_buffer(message, escaped, sizeof(escaped));
     if (full_logs) {
-      len += snprintf(buffer + len, buffer_capacity - (size_t)len,
-                      "{\"timestamp\":%lld,\"levelName\":\"%s\",\"message\":\"%s\"}", (long long)timestamp,
-                      status_get_log_level_name(level), escaped);
+      if (append_sse_data(buffer, buffer_capacity, &len, "{\"timestamp\":%lld,\"levelName\":\"%s\",\"message\":\"%s\"}",
+                          (long long)timestamp, status_get_log_level_name(level), escaped) < 0)
+        return 0;
     } else {
-      len += snprintf(buffer + len, buffer_capacity - (size_t)len,
-                      "{\"timestamp\":%lld,\"level\":%d,\"levelName\":\"%s\",\"message\":\"%s\"}", (long long)timestamp,
-                      level, status_get_log_level_name(level), escaped);
+      if (append_sse_data(buffer, buffer_capacity, &len,
+                          "{\"timestamp\":%lld,\"level\":%d,\"levelName\":\"%s\",\"message\":\"%s\"}",
+                          (long long)timestamp, level, status_get_log_level_name(level), escaped) < 0)
+        return 0;
     }
   }
   sent_initial = 1;
   last_log_epoch = current_log_epoch;
   last_log_sequence = current_log_sequence;
 
-  len += snprintf(buffer + len, buffer_capacity - (size_t)len, "]}\n\n");
+  if (append_sse_data(buffer, buffer_capacity, &len, "]}\n\n") < 0)
+    return 0;
 
   /* Update output parameters */
   *p_sent_initial = sent_initial;
@@ -896,7 +928,7 @@ int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_init
   /* Update global bandwidth statistics */
   status_shared->total_bandwidth = total_bw;
 
-  return len;
+  return (int)len;
 }
 
 void handle_disconnect_client(connection_t *c) {

--- a/src/status.h
+++ b/src/status.h
@@ -145,7 +145,7 @@ typedef struct {
 /* Shared memory structure for status information */
 typedef struct {
   /* Global statistics */
-  _Atomic uint32_t client_admission_owner_pid; /* Worker PID holding the short client admission guard */
+  _Atomic uint32_t client_admission_owner_pid;          /* Worker PID holding the short client admission guard */
   uint64_t client_bytes_cumulative[STATUS_MAX_WORKERS]; /* Single-writer shard per worker index */
   uint32_t total_bandwidth;
   int64_t server_start_time; /* Server start time in milliseconds */

--- a/src/status.h
+++ b/src/status.h
@@ -3,6 +3,7 @@
 
 #include "configuration.h"
 #include "connection.h"
+#include <stdatomic.h>
 #include <stdint.h>
 #include <sys/types.h>
 
@@ -16,7 +17,7 @@ typedef enum {
 } status_event_type_t;
 
 /* Maximum number of workers for per-worker statistics */
-#define STATUS_MAX_WORKERS 32
+#define STATUS_MAX_WORKERS CONFIG_MAX_WORKERS
 
 /* Maximum number of log entries to keep in circular buffer */
 #define STATUS_MAX_LOG_ENTRIES 100
@@ -60,33 +61,42 @@ typedef enum {
   CLIENT_STATE_DISCONNECTED
 } client_state_type_t;
 
-/* Per-client statistics stored in shared memory */
+/* Per-client payload. Atomic slot lifecycle fields live in client_stats_t so
+ * this payload can be cleared safely without touching atomic objects. */
 typedef struct {
-  int active;                        /* 1 if slot is active, 0 if free */
-  char client_id[128];               /* Unique client ID: "IP:port-workerN-seqM" */
-  pid_t worker_pid;                  /* Actual worker thread/process PID */
-  int worker_index;                  /* Worker index (0-based, matches worker_id) */
-  int64_t connect_time;              /* Connection timestamp in milliseconds */
-  char client_addr[128];             /* Client address (IP:port format, IPv6 uses []:port) */
-  char service_url[256];             /* Service URL being accessed */
-  client_state_type_t state;         /* Current connection state */
-  uint64_t bytes_sent;               /* Total bytes sent to client */
-  uint32_t current_bandwidth;        /* Current bandwidth in bytes/sec */
-  volatile int disconnect_requested; /* Set to 1 when disconnect is requested from API */
-  size_t queue_bytes;                /* Current queued bytes */
-  uint32_t queue_buffers;            /* Current queued buffers */
-  size_t queue_limit_bytes;          /* Dynamic queue limit snapshot */
-  size_t queue_bytes_highwater;      /* Peak queued bytes */
-  uint32_t queue_buffers_highwater;  /* Peak queued buffers */
-  uint64_t dropped_packets;          /* Total dropped packets */
-  uint64_t dropped_bytes;            /* Total dropped bytes */
-  uint32_t backpressure_events;      /* Times upstream reads were paused due to client backpressure (TCP only) */
+  char client_id[128];              /* Unique client ID: "IP:port-workerN-seqM" */
+  int worker_index;                 /* Worker index (0-based, matches worker_id) */
+  int64_t connect_time;             /* Connection timestamp in milliseconds */
+  char client_addr[128];            /* Client address (IP:port format, IPv6 uses []:port) */
+  char service_url[256];            /* Service URL being accessed */
+  client_state_type_t state;        /* Current connection state */
+  uint64_t bytes_sent;              /* Total bytes sent to client */
+  uint32_t current_bandwidth;       /* Current bandwidth in bytes/sec */
+  size_t queue_bytes;               /* Current queued bytes */
+  uint32_t queue_buffers;           /* Current queued buffers */
+  size_t queue_limit_bytes;         /* Dynamic queue limit snapshot */
+  size_t queue_bytes_highwater;     /* Peak queued bytes */
+  uint32_t queue_buffers_highwater; /* Peak queued buffers */
+  uint64_t dropped_packets;         /* Total dropped packets */
+  uint64_t dropped_bytes;           /* Total dropped bytes */
+  uint32_t backpressure_events;     /* Times upstream reads were paused due to client backpressure (TCP only) */
   int slow_active;
+} client_stats_payload_t;
+
+/* Per-client statistics stored in shared memory. owner_pid is also the
+ * reservation token: it is released only after every other field is reset. */
+typedef struct {
+  _Atomic uint32_t owner_pid;            /* 0 if free, otherwise owning worker PID */
+  _Atomic uint32_t active;               /* 1 once payload is fully published */
+  _Atomic uint32_t disconnect_requested; /* Set by status API, consumed by owner */
+  _Atomic uint32_t data_version;         /* Odd while payload statistics are being updated */
+  client_stats_payload_t payload;
 } client_stats_t;
 
 /* Log entry structure for circular buffer */
 typedef struct {
-  int64_t timestamp; /* Timestamp in milliseconds */
+  _Atomic uint32_t sequence; /* 0 while invalid/writing, otherwise published sequence */
+  int64_t timestamp;         /* Timestamp in milliseconds */
   loglevel_t level;
   char message[STATUS_LOG_ENTRY_LEN];
 } log_entry_t;
@@ -134,9 +144,8 @@ typedef struct {
 /* Shared memory structure for status information */
 typedef struct {
   /* Global statistics */
-  int total_clients;
-  uint64_t total_bytes_sent_cumulative; /* Bytes sent to clients that have
-                                           disconnected */
+  _Atomic uint32_t total_clients;
+  uint64_t client_bytes_cumulative[STATUS_MAX_WORKERS]; /* Single-writer shard per worker index */
   uint32_t total_bandwidth;
   int64_t server_start_time; /* Server start time in milliseconds */
 
@@ -155,17 +164,15 @@ typedef struct {
   int worker_notification_pipes[STATUS_MAX_WORKERS];         /* Write ends of worker
                                                                 pipes, -1 if inactive */
 
-  /* Log circular buffer */
-  pthread_mutex_t log_mutex; /* Mutex to protect log buffer writes */
-  int log_write_index;
-  int log_count;
+  /* Supervisor-owned log circular buffer */
+  _Atomic uint32_t log_epoch;
+  _Atomic uint32_t log_sequence;
   log_entry_t log_entries[STATUS_MAX_LOG_ENTRIES];
 
   /* Per-worker statistics (lock-free, each worker writes to its own slot) */
   worker_stats_t worker_stats[STATUS_MAX_WORKERS]; /* Per-worker statistics */
 
   /* Per-client statistics array */
-  pthread_mutex_t clients_mutex; /* Mutex to protect client slot allocation */
   client_stats_t clients[STATUS_MAX_CLIENTS];
 } status_shared_t;
 
@@ -185,11 +192,20 @@ int status_init(void);
  */
 void status_cleanup(void);
 
+/* Close supervisor-only status descriptors in a newly forked worker. */
+void status_worker_init(void);
+
+/* Drain worker log/control datagrams in the supervisor. */
+void status_supervisor_drain_logs(void);
+
+/* Reclaim every client slot owned by a worker confirmed dead by waitpid(). */
+int status_reap_worker(pid_t dead_pid, int worker_index);
+
 /**
  * Register a new streaming client connection in shared memory
  * Only called for media streaming clients, not for status/API requests
  * Called after routing determines the connection is for a media service
- * Allocates a free slot in the clients array under mutex protection
+ * Atomically reserves and publishes a free slot in the clients array
  * @param client_addr_str Client address string (format: "IP:port",
  * "[IPv6]:port", or "localhost" for Unix socket clients)
  * @param service_url Service URL string (e.g., HTTP request path)
@@ -301,12 +317,12 @@ const char *status_get_log_level_name(loglevel_t level);
  * @param buffer Output buffer
  * @param buffer_capacity Buffer size
  * @param p_sent_initial Pointer to sent_initial flag (in/out)
- * @param p_last_write_index Pointer to last write index (in/out)
- * @param p_last_log_count Pointer to last log count (in/out)
+ * @param p_last_log_epoch Pointer to last observed log epoch (in/out)
+ * @param p_last_log_sequence Pointer to last observed log sequence (in/out)
  * @return Number of bytes written to buffer
  */
-int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_initial, int *p_last_write_index,
-                          int *p_last_log_count);
+int status_build_sse_json(char *buffer, size_t buffer_capacity, int *p_sent_initial, uint32_t *p_last_log_epoch,
+                          uint32_t *p_last_log_sequence);
 
 /**
  * Initialize SSE connection for a client

--- a/src/status.h
+++ b/src/status.h
@@ -113,10 +113,6 @@ typedef struct {
   /* Client ID generation counter */
   uint64_t client_id_counter; /* Incremented for each new client registration */
 
-  /* Client traffic statistics */
-  uint64_t client_bytes_cumulative; /* Bytes sent to clients that have
-                                       disconnected */
-
   /* Zero-copy send statistics */
   uint64_t total_sends;       /* Total number of sendmsg() calls */
   uint64_t total_completions; /* Total MSG_ZEROCOPY completions */

--- a/src/status.h
+++ b/src/status.h
@@ -145,6 +145,7 @@ typedef struct {
 /* Shared memory structure for status information */
 typedef struct {
   /* Global statistics */
+  _Atomic uint32_t client_admission_owner_pid; /* Worker PID holding the short client admission guard */
   uint64_t client_bytes_cumulative[STATUS_MAX_WORKERS]; /* Single-writer shard per worker index */
   uint32_t total_bandwidth;
   int64_t server_start_time; /* Server start time in milliseconds */

--- a/src/status.h
+++ b/src/status.h
@@ -8,7 +8,7 @@
 #include <sys/types.h>
 
 /* Maximum number of clients we can track in shared memory */
-#define STATUS_MAX_CLIENTS 256
+#define STATUS_MAX_CLIENTS CONFIG_MAX_CLIENTS
 
 /* Event types for worker notification */
 typedef enum {
@@ -88,7 +88,8 @@ typedef struct {
 typedef struct {
   _Atomic uint32_t owner_pid;            /* 0 if free, otherwise owning worker PID */
   _Atomic uint32_t active;               /* 1 once payload is fully published */
-  _Atomic uint32_t disconnect_requested; /* Set by status API, consumed by owner */
+  _Atomic uint32_t generation;           /* Incremented whenever the slot is reused */
+  _Atomic uint32_t disconnect_requested; /* Requested generation, 0 if none */
   _Atomic uint32_t data_version;         /* Odd while payload statistics are being updated */
   client_stats_payload_t payload;
 } client_stats_t;
@@ -144,7 +145,6 @@ typedef struct {
 /* Shared memory structure for status information */
 typedef struct {
   /* Global statistics */
-  _Atomic uint32_t total_clients;
   uint64_t client_bytes_cumulative[STATUS_MAX_WORKERS]; /* Single-writer shard per worker index */
   uint32_t total_bandwidth;
   int64_t server_start_time; /* Server start time in milliseconds */

--- a/src/supervisor.c
+++ b/src/supervisor.c
@@ -34,11 +34,12 @@ typedef struct {
   int64_t restart_times[MAX_RESTARTS_IN_WINDOW]; /* Recent restart timestamps */
   int restart_count;                             /* Number of restarts in current window */
   int rate_limited;                              /* 1 if currently rate limited, 0 otherwise */
+  int retiring;                                  /* 1 when removed by a worker-count reduction */
 } worker_info_t;
 
 /* Supervisor state */
-static worker_info_t *workers = NULL;
-static int num_workers = 0;
+static worker_info_t workers[STATUS_MAX_WORKERS];
+static int desired_workers = 0;
 static volatile sig_atomic_t supervisor_stop_flag = 0;
 static volatile sig_atomic_t supervisor_reload_flag = 0;
 static volatile sig_atomic_t supervisor_restart_workers_flag = 0;
@@ -48,7 +49,6 @@ static void supervisor_signal_handler(int signum);
 static void supervisor_sighup_handler(int signum);
 static void supervisor_sigusr1_handler(int signum);
 static int spawn_worker(int worker_idx);
-static void cleanup_workers(void);
 static void restore_reload_snapshot(config_t *old_config, service_t **old_services, bindaddr_t **old_bind_addresses,
                                     m3u_cache_t *old_m3u_cache, epg_cache_t *old_epg_cache);
 static void free_reload_snapshot(config_t *old_config, service_t *old_services, bindaddr_t *old_bind_addresses,
@@ -139,6 +139,7 @@ static int spawn_worker(int worker_idx) {
 
     /* Set worker ID */
     worker_id = worker_idx;
+    status_worker_init();
 
     /* Run worker business logic */
     int result = run_worker();
@@ -150,6 +151,7 @@ static int spawn_worker(int worker_idx) {
   /* Parent: record worker info */
   workers[worker_idx].pid = pid;
   workers[worker_idx].worker_id = worker_idx;
+  workers[worker_idx].retiring = 0;
 
   logger(LOG_INFO, "Spawned worker %d with pid %d", worker_idx, (int)pid);
 
@@ -162,12 +164,11 @@ static int spawn_worker(int worker_idx) {
  * @param reason Log message describing why the signal is being sent
  */
 static void broadcast_signal_to_workers(int signum, const char *reason) {
-  logger(LOG_INFO, "%s, sending %s to %d workers", reason,
+  logger(LOG_INFO, "%s, sending %s to tracked workers", reason,
          signum == SIGTERM  ? "SIGTERM"
          : signum == SIGHUP ? "SIGHUP"
-                            : "signal",
-         num_workers);
-  for (int i = 0; i < num_workers; i++) {
+                            : "signal");
+  for (int i = 0; i < STATUS_MAX_WORKERS; i++) {
     if (workers[i].pid > 0) {
       kill(workers[i].pid, signum);
     }
@@ -179,7 +180,7 @@ static void broadcast_signal_to_workers(int signum, const char *reason) {
  * @return worker index, or -1 if not found
  */
 static int find_worker_by_pid(pid_t pid) {
-  for (int i = 0; i < num_workers; i++) {
+  for (int i = 0; i < STATUS_MAX_WORKERS; i++) {
     if (workers[i].pid == pid) {
       return i;
     }
@@ -187,15 +188,13 @@ static int find_worker_by_pid(pid_t pid) {
   return -1;
 }
 
-/**
- * Clean up worker array
- */
-static void cleanup_workers(void) {
-  if (workers) {
-    free(workers);
-    workers = NULL;
+static int count_running_workers(void) {
+  int count = 0;
+  for (int i = 0; i < STATUS_MAX_WORKERS; i++) {
+    if (workers[i].pid > 0)
+      count++;
   }
-  num_workers = 0;
+  return count;
 }
 
 static void restore_reload_snapshot(config_t *old_config, service_t **old_services, bindaddr_t **old_bind_addresses,
@@ -230,19 +229,16 @@ static void free_reload_snapshot(config_t *old_config, service_t *old_services, 
 int supervisor_run(void) {
   int i;
 
-  num_workers = config.workers;
-  workers = calloc(num_workers, sizeof(worker_info_t));
-  if (!workers) {
-    logger(LOG_FATAL, "Failed to allocate worker array");
-    return -1;
-  }
+  desired_workers = config.workers;
 
   /* Initialize worker info */
-  for (i = 0; i < num_workers; i++) {
+  memset(workers, 0, sizeof(workers));
+  for (i = 0; i < STATUS_MAX_WORKERS; i++) {
     workers[i].pid = 0;
     workers[i].worker_id = i;
     workers[i].restart_count = 0;
     workers[i].rate_limited = 0;
+    workers[i].retiring = 0;
     for (int j = 0; j < MAX_RESTARTS_IN_WINDOW; j++) {
       workers[i].restart_times[j] = 0;
     }
@@ -253,13 +249,12 @@ int supervisor_run(void) {
   }
 
   if (unix_socket_listeners_replace(bind_addresses) < 0) {
-    cleanup_workers();
     status_cleanup();
     return -1;
   }
 
   /* Spawn all workers */
-  for (i = 0; i < num_workers; i++) {
+  for (i = 0; i < desired_workers; i++) {
     if (spawn_worker(i) < 0) {
       logger(LOG_ERROR, "Failed to spawn worker %d", i);
     }
@@ -301,6 +296,8 @@ int supervisor_run(void) {
     int status;
     pid_t pid;
 
+    status_supervisor_drain_logs();
+
     /* Non-blocking wait for any child */
     while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
       int worker_idx = find_worker_by_pid(pid);
@@ -309,6 +306,10 @@ int supervisor_run(void) {
         continue;
       }
 
+      /* Reclaim shared status state before this worker index can be reused. */
+      status_reap_worker(pid, worker_idx);
+      workers[worker_idx].pid = 0;
+
       /* Log exit reason */
       if (WIFEXITED(status)) {
         logger(LOG_WARN, "Worker %d (pid %d) exited with status %d", worker_idx, (int)pid, WEXITSTATUS(status));
@@ -316,10 +317,8 @@ int supervisor_run(void) {
         logger(LOG_WARN, "Worker %d (pid %d) killed by signal %d", worker_idx, (int)pid, WTERMSIG(status));
       }
 
-      workers[worker_idx].pid = 0;
-
-      /* Restart if not stopping */
-      if (!supervisor_stop_flag) {
+      /* Restart only worker indexes still desired by the current config. */
+      if (!supervisor_stop_flag && worker_idx < desired_workers && !workers[worker_idx].retiring) {
         if (restart_allowed(&workers[worker_idx])) {
           record_restart(&workers[worker_idx]);
           workers[worker_idx].rate_limited = 0;
@@ -336,8 +335,8 @@ int supervisor_run(void) {
     }
 
     /* Check for rate-limited workers that can now be restarted */
-    for (i = 0; i < num_workers; i++) {
-      if (workers[i].rate_limited && workers[i].pid == 0 && !supervisor_stop_flag) {
+    for (i = 0; i < desired_workers; i++) {
+      if (workers[i].rate_limited && workers[i].pid == 0 && !workers[i].retiring && !supervisor_stop_flag) {
         if (restart_allowed(&workers[i])) {
           record_restart(&workers[i]);
           workers[i].rate_limited = 0;
@@ -405,53 +404,37 @@ int supervisor_run(void) {
           continue;
         }
 
-        /* Handle worker count changes */
-        if (config.workers > num_workers) {
+        /* Handle worker count changes without dropping tracking records for
+         * workers that have not reached waitpid() yet. */
+        int previous_desired = desired_workers;
+        desired_workers = config.workers;
+        if (desired_workers > previous_desired) {
+          for (i = previous_desired; i < desired_workers; i++)
+            workers[i].retiring = 0;
+
           if (bind_changed) {
             broadcast_signal_to_workers(SIGTERM, "Bind addresses changed");
           } else {
             broadcast_signal_to_workers(SIGHUP, "Forwarding config reload");
           }
 
-          /* Need to spawn more workers */
-          int new_count = config.workers;
-          worker_info_t *new_workers = realloc(workers, new_count * sizeof(worker_info_t));
-          if (new_workers) {
-            workers = new_workers;
-            /* Initialize new worker slots */
-            for (i = num_workers; i < new_count; i++) {
-              workers[i].pid = 0;
-              workers[i].worker_id = i;
-              workers[i].restart_count = 0;
-              workers[i].rate_limited = 0;
-              for (int j = 0; j < MAX_RESTARTS_IN_WINDOW; j++) {
-                workers[i].restart_times[j] = 0;
-              }
-              /* Spawn new worker - it inherits new config automatically */
+          for (i = previous_desired; i < desired_workers; i++) {
+            if (workers[i].pid == 0) {
               logger(LOG_INFO, "Spawning new worker %d", i);
-              if (spawn_worker(i) < 0) {
+              if (spawn_worker(i) < 0)
                 logger(LOG_ERROR, "Failed to spawn new worker %d", i);
-              }
             }
-            num_workers = new_count;
-          } else {
-            logger(LOG_ERROR, "Failed to allocate memory for new workers");
           }
-        } else if (config.workers < num_workers) {
+        } else if (desired_workers < previous_desired) {
           /* Need to terminate excess workers */
-          logger(LOG_INFO, "Reducing worker count from %d to %d", num_workers, config.workers);
-          for (i = config.workers; i < num_workers; i++) {
+          logger(LOG_INFO, "Reducing worker count from %d to %d", previous_desired, desired_workers);
+          for (i = desired_workers; i < previous_desired; i++) {
+            workers[i].retiring = 1;
+            workers[i].rate_limited = 0;
             if (workers[i].pid > 0) {
               logger(LOG_INFO, "Sending SIGTERM to excess worker %d (pid %d)", i, (int)workers[i].pid);
               kill(workers[i].pid, SIGTERM);
             }
-          }
-          /* Update num_workers - excess workers will be reaped normally */
-          num_workers = config.workers;
-          /* Shrink array */
-          worker_info_t *new_workers = realloc(workers, num_workers * sizeof(worker_info_t));
-          if (new_workers) {
-            workers = new_workers;
           }
 
           if (bind_changed) {
@@ -479,6 +462,8 @@ int supervisor_run(void) {
       broadcast_signal_to_workers(SIGTERM, "Received SIGUSR1, restarting workers");
     }
 
+    status_supervisor_drain_logs();
+
     /* Sleep before next check */
     usleep(100000); /* 100ms */
   }
@@ -486,7 +471,7 @@ int supervisor_run(void) {
   broadcast_signal_to_workers(SIGTERM, "Received stop signal, shutting down");
 
   /* Wait for all workers to exit with timeout */
-  int remaining = num_workers;
+  int remaining = count_running_workers();
   int timeout_count = 0;
   const int max_timeout = 50; /* 5 seconds (50 * 100ms) */
 
@@ -497,6 +482,7 @@ int supervisor_run(void) {
     if (pid > 0) {
       int worker_idx = find_worker_by_pid(pid);
       if (worker_idx >= 0) {
+        status_reap_worker(pid, worker_idx);
         workers[worker_idx].pid = 0;
         remaining--;
         logger(LOG_INFO, "Worker %d exited", worker_idx);
@@ -509,15 +495,18 @@ int supervisor_run(void) {
       /* No more children or error */
       break;
     }
+    status_supervisor_drain_logs();
   }
 
   /* Force kill any remaining workers */
   if (remaining > 0) {
     logger(LOG_WARN, "%d workers didn't exit gracefully, sending SIGKILL", remaining);
-    for (i = 0; i < num_workers; i++) {
+    for (i = 0; i < STATUS_MAX_WORKERS; i++) {
       if (workers[i].pid > 0) {
-        kill(workers[i].pid, SIGKILL);
-        waitpid(workers[i].pid, NULL, 0);
+        pid_t pid = workers[i].pid;
+        kill(pid, SIGKILL);
+        waitpid(pid, NULL, 0);
+        status_reap_worker(pid, i);
         workers[i].pid = 0;
       }
     }
@@ -527,9 +516,6 @@ int supervisor_run(void) {
 
   /* Close supervisor-owned Unix listeners and remove socket paths */
   unix_socket_listeners_cleanup();
-
-  /* Clean up worker array */
-  cleanup_workers();
 
   /* Clean up shared memory and other resources
    * Supervisor is now the last process, so it does final cleanup */

--- a/src/worker.c
+++ b/src/worker.c
@@ -326,10 +326,11 @@ int worker_run_event_loop(int *listen_sockets, int num_sockets, int notif_fd) {
             connection_t *next = c->next;
 
             /* Check if disconnect was requested for this client */
-            if (c->status_index >= 0 && status_shared->clients[c->status_index].active &&
-                status_shared->clients[c->status_index].disconnect_requested) {
-              logger(LOG_INFO, "Disconnect requested for client %s via API",
-                     status_shared->clients[c->status_index].client_addr);
+            if (c->status_index >= 0 &&
+                atomic_load_explicit(&status_shared->clients[c->status_index].active, memory_order_acquire) &&
+                atomic_load_explicit(&status_shared->clients[c->status_index].disconnect_requested,
+                                     memory_order_acquire)) {
+              logger(LOG_INFO, "Disconnect requested for status slot %d via API", c->status_index);
               worker_close_and_free_connection(c);
             }
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -326,10 +326,18 @@ int worker_run_event_loop(int *listen_sockets, int num_sockets, int notif_fd) {
             connection_t *next = c->next;
 
             /* Check if disconnect was requested for this client */
-            if (c->status_index >= 0 &&
-                atomic_load_explicit(&status_shared->clients[c->status_index].active, memory_order_acquire) &&
-                atomic_load_explicit(&status_shared->clients[c->status_index].disconnect_requested,
-                                     memory_order_acquire)) {
+            if (c->status_index >= 0) {
+              client_stats_t *status_client = &status_shared->clients[c->status_index];
+              uint32_t requested_generation =
+                  atomic_load_explicit(&status_client->disconnect_requested, memory_order_acquire);
+              uint32_t current_generation = atomic_load_explicit(&status_client->generation, memory_order_acquire);
+              int disconnect_matches_client = requested_generation != 0 && requested_generation == current_generation &&
+                                              atomic_load_explicit(&status_client->active, memory_order_acquire);
+              if (!disconnect_matches_client) {
+                c = next;
+                continue;
+              }
+
               logger(LOG_INFO, "Disconnect requested for status slot %d via API", c->status_index);
               worker_close_and_free_connection(c);
             }


### PR DESCRIPTION
## Summary

Reclaim shared status client slots when a worker exits, before its worker index is reused. Client ownership and counters now use lock-free 32-bit atomics, and cumulative traffic is sharded per worker.

Move status-page log writes to a supervisor-owned ring fed by a non-blocking Unix datagram socket. This removes process-shared mutexes that could remain locked after a worker crash while preserving the existing SSE full/incremental/clear contract.

Keep retiring workers tracked through `waitpid()` during worker-count reductions, enforce the 32-worker limit, and reject streams when status registration cannot reserve capacity.

## Root cause

Client slots were normally released only by worker-side connection cleanup. A worker killed by a signal could leave active slots and `total_clients` behind indefinitely. The process-shared status mutexes also had no portable owner-death recovery path on macOS.

## Validation

- Release CMake build
- Full E2E suite: 491 passed, 8 skipped
- Worker recovery E2E: 4 passed
- IPv6 E2E with `PytestRemovedIn10Warning` promoted to an error: 10 passed
- Ruff, clang-format dry-run, diff check, and both collect-only paths