### PR TITLE
feat(player): add EPG-aware Media Session controls

### DIFF
--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -374,7 +374,7 @@ export function PlayerControls({
             )}
           </div>
 
-          <div className="ml-1.5 flex h-7 min-w-0 basis-0 flex-1 items-center overflow-hidden md:ml-2 md:h-12">
+          <div className="ml-1 mr-1 flex h-7 min-w-0 basis-0 flex-1 items-center overflow-hidden md:ml-2 md:mr-2 md:h-12">
             <PlayerMediaBadges
               mediaInfo={mediaInfo}
               locale={locale}
@@ -388,7 +388,7 @@ export function PlayerControls({
         <div className="flex shrink-0 items-center gap-0 sm:gap-0.5 md:gap-2">
           {/* Live/Catchup Indicator & Go Live Button */}
           {isLive ? (
-            <span className="flex items-center gap-1 whitespace-nowrap p-1 text-[11px] font-semibold tracking-wide text-white md:gap-1.5 md:p-2 md:text-sm">
+            <span className="flex items-center gap-1 whitespace-nowrap text-[11px] font-semibold tracking-wide text-white md:gap-1.5 md:text-sm">
               <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-rose-400 shadow-[0_0_12px_rgba(251,113,133,0.85)] md:h-2 md:w-2" />
               {t("live")}
             </span>

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -16,7 +16,9 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import type { Locale } from "../../lib/locale";
+import { createProgramTimeline, programProgressToWallClock } from "../../lib/program-timeline";
 import type { PlayerMediaInfo, PlayerRenderState } from "../../mpegts";
+import { mseToWallClock } from "../../mpegts/player/wall-clock";
 import type { Channel, EPGProgram } from "../../types/player";
 import { PLAYER_CONTROL_BUTTON_CLASS, PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
 import { PlayerMediaBadges } from "./player-media-badges";
@@ -95,34 +97,54 @@ export function PlayerControls({
   // Check if any source on this channel supports catchup
   const isCatchupSupported = channel.sources.some((s) => s.catchup && s.catchupSource);
 
-  const { startTime, endTime, duration } = useMemo(() => {
-    if (!currentProgram) {
-      // No EPG data: use 3-hour rewind window
-      const now = new Date();
-      const threeHoursAgo = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+  const programTimeline = useMemo(
+    () => (currentProgram ? createProgramTimeline(currentProgram, seekStartTime, currentTime) : null),
+    [currentProgram, seekStartTime, currentTime],
+  );
+
+  const fallbackRange = useMemo(() => {
+    if (currentProgram) return null;
+    const endTime = new Date();
+    return {
+      startTime: new Date(endTime.getTime() - 3 * 60 * 60 * 1000),
+      endTime,
+      duration: 3 * 60 * 60,
+    };
+  }, [currentProgram]);
+
+  const { startTime, endTime, duration, elapsedTime, progress } = useMemo(() => {
+    if (programTimeline) {
       return {
-        startTime: threeHoursAgo,
-        endTime: now,
-        duration: 3 * 60 * 60,
+        startTime: programTimeline.startTime,
+        endTime: programTimeline.endTime,
+        duration: programTimeline.durationSeconds,
+        elapsedTime: programTimeline.positionSeconds,
+        progress: programTimeline.progress * 100,
       };
     }
 
-    const startTime = currentProgram.start;
-    const endTime = currentProgram.end;
-    const duration = (endTime.getTime() - startTime.getTime()) / 1000;
+    if (fallbackRange) {
+      const playheadTime = mseToWallClock(currentTime, seekStartTime);
+      const elapsedTime = (playheadTime.getTime() - fallbackRange.startTime.getTime()) / 1000;
+      return {
+        ...fallbackRange,
+        elapsedTime,
+        progress: Math.min(100, Math.max(0, (elapsedTime / fallbackRange.duration) * 100)),
+      };
+    }
 
-    return { startTime, endTime, duration };
-  }, [currentProgram]);
+    if (currentProgram) {
+      return {
+        startTime: currentProgram.start,
+        endTime: currentProgram.end,
+        duration: 0,
+        elapsedTime: 0,
+        progress: 0,
+      };
+    }
 
-  const elapsedTime = useMemo(() => {
-    const currentAbsoluteTime = new Date(seekStartTime.getTime() + currentTime * 1000);
-    return (currentAbsoluteTime.getTime() - startTime.getTime()) / 1000;
-  }, [startTime, seekStartTime, currentTime]);
-
-  const progress = useMemo(() => {
-    if (duration === 0) return 0;
-    return Math.min(Math.max((elapsedTime / duration) * 100, 0), 100);
-  }, [duration, elapsedTime]);
+    return { startTime: seekStartTime, endTime: seekStartTime, duration: 0, elapsedTime: 0, progress: 0 };
+  }, [currentProgram, currentTime, fallbackRange, programTimeline, seekStartTime]);
 
   const formatTime = useCallback((date: Date, withSeconds = false) => {
     return date.toLocaleTimeString([], {
@@ -145,10 +167,11 @@ export function PlayerControls({
 
   const getTimeAtPosition = useCallback(
     (percentage: number): Date => {
+      if (programTimeline) return programProgressToWallClock(programTimeline, percentage / 100);
       const timestamp = startTime.getTime() + (duration * 1000 * percentage) / 100;
       return new Date(timestamp);
     },
-    [startTime, duration],
+    [startTime, duration, programTimeline],
   );
 
   const handleSeek = useCallback(

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -7,6 +7,7 @@ import {
   useEffect,
   useEffectEvent,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -23,6 +24,7 @@ import {
 import type { Locale } from "../../lib/locale";
 import { buildCatchupSegments } from "../../lib/m3u-parser";
 import { getMuted, getVolume, saveMuted, saveVolume } from "../../lib/player-storage";
+import { createProgramTimeline, programPositionToWallClock } from "../../lib/program-timeline";
 import {
   createPlayer,
   defaultConfig,
@@ -38,6 +40,7 @@ import {
   goLiveTargetMse,
   isNearLiveWallClock,
   type LiveSessionAnchor,
+  mseToWallClock,
   wallClockToMse,
 } from "../../mpegts/player/wall-clock";
 import mp2WasmUrl from "../../mpegts/wasm/minimp3/mp2_decoder.wasm?url";
@@ -104,6 +107,18 @@ function isInterruptedPlayError(err: unknown): boolean {
 
 function ignoreInterruptedPlayError(err: unknown): void {
   if (!isInterruptedPlayError(err)) throw err;
+}
+
+function setMediaSessionAction(
+  mediaSession: MediaSession,
+  action: MediaSessionAction,
+  handler: MediaSessionActionHandler | null,
+): void {
+  try {
+    mediaSession.setActionHandler(action, handler);
+  } catch {
+    // Some browsers expose Media Session but do not implement every action.
+  }
 }
 
 function decodeRequestUrl(url: string): string {
@@ -236,6 +251,13 @@ export function VideoPlayer({
   onPlaybackStarted,
 }: VideoPlayerProps) {
   const t = usePlayerTranslation(locale);
+  const programTimeline = useMemo(
+    () => (currentProgram ? createProgramTimeline(currentProgram, streamStartTime, currentVideoTime) : null),
+    [currentProgram, streamStartTime, currentVideoTime],
+  );
+  const canSeekProgramInMediaSession = Boolean(
+    programTimeline && channel?.sources.some((source) => source.catchup && source.catchupSource),
+  );
 
   const playerDockRef = useRef<HTMLDivElement>(null);
   const playerSurfaceRef = useRef<HTMLDivElement>(null);
@@ -319,6 +341,7 @@ export function VideoPlayer({
   const userPausedRef = useRef(false);
   /** Reset wall-clock calibration after each new segment load. */
   const wallClockCalibratedRef = useRef(false);
+  const mediaSessionPositionUpdatedAtRef = useRef(0);
 
   // Digit input state
   const [digitBuffer, setDigitBuffer] = useState("");
@@ -634,7 +657,7 @@ export function VideoPlayer({
     }
     const source = channel?.sources[activeSourceIndex];
     if (source?.catchupSource) {
-      const seekTime = new Date(streamStartTime.getTime() + currentVideoTime * 1000);
+      const seekTime = mseToWallClock(currentVideoTime, streamStartTime);
       return buildCatchupSegments(source, seekTime);
     }
     return segments;
@@ -712,7 +735,7 @@ export function VideoPlayer({
         if (playMode === "live") {
           onSeek(new Date(), true);
         } else {
-          onSeek(new Date(streamStartTime.getTime() + currentVideoTime * 1000), false);
+          onSeek(mseToWallClock(currentVideoTime, streamStartTime), false);
         }
       }
       if (playMode === "catchup") {
@@ -762,7 +785,7 @@ export function VideoPlayer({
   const handleSeekNeeded = useEffectEvent((seconds: number) => {
     const video = getActiveVideo();
     shouldAutoPlayRef.current = !video?.paused;
-    const seekTime = new Date(streamStartTime.getTime() + seconds * 1000);
+    const seekTime = mseToWallClock(seconds, streamStartTime);
     onSeek?.(seekTime, isNearLiveWallClock(seekTime, liveSessionAnchor, streamStartTime));
   });
 
@@ -866,6 +889,67 @@ export function VideoPlayer({
     }
   });
 
+  const updateMediaSessionPosition = useEffectEvent((force = false) => {
+    if (!("mediaSession" in navigator) || !navigator.mediaSession.setPositionState) return;
+
+    if (!channel) {
+      navigator.mediaSession.setPositionState({});
+      return;
+    }
+
+    const now = Date.now();
+    if (!force && now - mediaSessionPositionUpdatedAtRef.current < 1000) return;
+
+    const video = getActiveVideo();
+    if (!video) return;
+    mediaSessionPositionUpdatedAtRef.current = now;
+
+    const timeline = currentProgram ? createProgramTimeline(currentProgram, streamStartTime, video.currentTime) : null;
+    const supportsCatchup = channel.sources.some((source) => source.catchup && source.catchupSource);
+
+    try {
+      if (timeline && supportsCatchup) {
+        navigator.mediaSession.setPositionState({
+          duration: timeline.durationSeconds,
+          position: timeline.positionSeconds,
+          playbackRate: video.playbackRate || 1,
+        });
+      } else {
+        navigator.mediaSession.setPositionState({
+          duration: Infinity,
+          position: Math.max(0, video.currentTime),
+          playbackRate: video.playbackRate || 1,
+        });
+      }
+    } catch {
+      // Older implementations may reject Infinity even though it represents live media.
+      navigator.mediaSession.setPositionState({});
+    }
+  });
+
+  const handleMediaSessionPlay = useEffectEvent(() => {
+    userPausedRef.current = false;
+    getActiveVideo()?.play()?.catch(ignoreInterruptedPlayError);
+  });
+
+  const handleMediaSessionPause = useEffectEvent(() => {
+    userPausedRef.current = true;
+    getActiveVideo()?.pause();
+  });
+
+  const handleMediaSessionSeekBackward = useEffectEvent((details: MediaSessionActionDetails) => {
+    handleRelativeSeek(-(details.seekOffset ?? 5));
+  });
+
+  const handleMediaSessionSeekForward = useEffectEvent((details: MediaSessionActionDetails) => {
+    handleRelativeSeek(details.seekOffset ?? 5);
+  });
+
+  const handleMediaSessionSeekTo = useEffectEvent((details: MediaSessionActionDetails) => {
+    if (!programTimeline || details.seekTime === undefined) return;
+    handleSeek(programPositionToWallClock(programTimeline, details.seekTime));
+  });
+
   // Media Session: lock screen / control center metadata (esp. useful during PiP playback)
   useEffect(() => {
     if (!("mediaSession" in navigator)) return;
@@ -883,26 +967,50 @@ export function VideoPlayer({
 
   useEffect(() => {
     if (!("mediaSession" in navigator)) return;
-    navigator.mediaSession.playbackState = isPlaying ? "playing" : "paused";
-  }, [isPlaying]);
+    navigator.mediaSession.playbackState = channel ? (isPlaying ? "playing" : "paused") : "none";
+  }, [channel, isPlaying]);
 
-  // Media Session action handlers (lock screen / control center play & pause)
+  // Media Session action handlers (lock screen / control center playback and EPG timeline seeking)
   useEffect(() => {
     if (!("mediaSession" in navigator)) return;
-    const videoForActiveSlot = () => (activeSlotIdRef.current === "a" ? slotAVideoRef : slotBVideoRef).current;
-    navigator.mediaSession.setActionHandler("play", () => {
-      userPausedRef.current = false;
-      videoForActiveSlot()?.play()?.catch(ignoreInterruptedPlayError);
-    });
-    navigator.mediaSession.setActionHandler("pause", () => {
-      userPausedRef.current = true;
-      videoForActiveSlot()?.pause();
-    });
+    const mediaSession = navigator.mediaSession;
+    setMediaSessionAction(mediaSession, "play", handleMediaSessionPlay);
+    setMediaSessionAction(mediaSession, "pause", handleMediaSessionPause);
+    setMediaSessionAction(
+      mediaSession,
+      "seekbackward",
+      canSeekProgramInMediaSession ? handleMediaSessionSeekBackward : null,
+    );
+    setMediaSessionAction(
+      mediaSession,
+      "seekforward",
+      canSeekProgramInMediaSession ? handleMediaSessionSeekForward : null,
+    );
+    setMediaSessionAction(mediaSession, "seekto", canSeekProgramInMediaSession ? handleMediaSessionSeekTo : null);
     return () => {
-      navigator.mediaSession.setActionHandler("play", null);
-      navigator.mediaSession.setActionHandler("pause", null);
+      setMediaSessionAction(mediaSession, "play", null);
+      setMediaSessionAction(mediaSession, "pause", null);
+      setMediaSessionAction(mediaSession, "seekbackward", null);
+      setMediaSessionAction(mediaSession, "seekforward", null);
+      setMediaSessionAction(mediaSession, "seekto", null);
     };
-  }, []);
+  }, [canSeekProgramInMediaSession]);
+
+  // These reactive values intentionally trigger the Effect Event, which reads their latest values without capturing them.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: synchronize Media Session immediately on timeline/slot state changes
+  useEffect(() => {
+    updateMediaSessionPosition(true);
+  }, [channel, currentProgram, playMode, activeSourceIndex, visibleSlotId, isPlaying]);
+
+  useEffect(
+    () => () => {
+      if (!("mediaSession" in navigator) || !navigator.mediaSession.setPositionState) return;
+      navigator.mediaSession.metadata = null;
+      navigator.mediaSession.playbackState = "none";
+      navigator.mediaSession.setPositionState({});
+    },
+    [],
+  );
 
   // Load segments whenever they change (channel/source switch, seek, retry — all go through here)
   const handleLoadSegments = useEffectEvent((newSegments: PlayerSegment[]) => {
@@ -1100,13 +1208,19 @@ export function VideoPlayer({
     const video = slotVideoRef(slotId).current;
     if (!video) return;
     onCurrentVideoTimeChange(video.currentTime);
+    updateMediaSessionPosition();
+  });
+
+  const handleVideoTimelineChange = useEffectEvent((slotId: SlotId) => {
+    if (slotId !== getActiveSlotId()) return;
+    updateMediaSessionPosition(true);
   });
 
   const handleVideoEnded = useEffectEvent((slotId: SlotId) => {
     if (slotId !== getActiveSlotId()) return;
     const video = slotVideoRef(slotId).current;
     if (onSeek && video?.duration) {
-      const seekTime = new Date(streamStartTime.getTime() + video.duration * 1000);
+      const seekTime = mseToWallClock(video.duration, streamStartTime);
       onSeek(seekTime, isNearLiveWallClock(seekTime, liveSessionAnchor, streamStartTime));
     }
   });
@@ -1137,7 +1251,7 @@ export function VideoPlayer({
     // Media element died in background (MediaSource closed / decode error).
     // Note: video.paused may still report false in this state.
     const mediaDead = video.error !== null;
-    const behindLiveMs = Date.now() - (streamStartTime.getTime() + currentVideoTime * 1000);
+    const behindLiveMs = Date.now() - mseToWallClock(currentVideoTime, streamStartTime).getTime();
     // Beyond this lag a live-edge reload beats letting live-sync chase at 2x
     // for tens of seconds; tied to the sync config rather than a magic 10s.
     const staleLiveMs = (defaultConfig.liveSyncMaxLatency + 5) * 1000;
@@ -1154,7 +1268,7 @@ export function VideoPlayer({
       // Catchup: rebuild the stream at the current position
       console.log("Reloading at current position after background suspension");
       shouldAutoPlayRef.current = true;
-      const seekTime = new Date(streamStartTime.getTime() + currentVideoTime * 1000);
+      const seekTime = mseToWallClock(currentVideoTime, streamStartTime);
       onSeek?.(seekTime, isNearLiveWallClock(seekTime, liveSessionAnchor, streamStartTime));
       return;
     }
@@ -1314,6 +1428,8 @@ export function VideoPlayer({
         ["playing", (event) => handleVideoPlaying(slotId, event.timeStamp)],
         ["pause", () => handleVideoPause(slotId)],
         ["timeupdate", () => handleVideoTimeUpdate(slotId)],
+        ["seeked", () => handleVideoTimelineChange(slotId)],
+        ["ratechange", () => handleVideoTimelineChange(slotId)],
         ["ended", () => handleVideoEnded(slotId)],
         ["enterpictureinpicture", () => handleVideoEnterPiP(slotId)],
         ["leavepictureinpicture", () => handleVideoLeavePiP()],

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -111,11 +111,11 @@ function ignoreInterruptedPlayError(err: unknown): void {
 
 function setMediaSessionAction(
   mediaSession: MediaSession,
-  action: MediaSessionAction,
+  action: MediaSessionAction | "enterpictureinpicture",
   handler: MediaSessionActionHandler | null,
 ): void {
   try {
-    mediaSession.setActionHandler(action, handler);
+    mediaSession.setActionHandler(action as MediaSessionAction, handler);
   } catch {
     // Some browsers expose Media Session but do not implement every action.
   }
@@ -258,6 +258,7 @@ export function VideoPlayer({
   const canSeekProgramInMediaSession = Boolean(
     programTimeline && channel?.sources.some((source) => source.catchup && source.catchupSource),
   );
+  const canNavigateChannelsInMediaSession = Boolean(channel && onChannelNavigate);
 
   const playerDockRef = useRef<HTMLDivElement>(null);
   const playerSurfaceRef = useRef<HTMLDivElement>(null);
@@ -950,6 +951,14 @@ export function VideoPlayer({
     handleSeek(programPositionToWallClock(programTimeline, details.seekTime));
   });
 
+  const handleMediaSessionPreviousTrack = useEffectEvent(() => {
+    onChannelNavigate?.("prev");
+  });
+
+  const handleMediaSessionNextTrack = useEffectEvent(() => {
+    onChannelNavigate?.("next");
+  });
+
   // Media Session: lock screen / control center metadata (esp. useful during PiP playback)
   useEffect(() => {
     if (!("mediaSession" in navigator)) return;
@@ -969,32 +978,6 @@ export function VideoPlayer({
     if (!("mediaSession" in navigator)) return;
     navigator.mediaSession.playbackState = channel ? (isPlaying ? "playing" : "paused") : "none";
   }, [channel, isPlaying]);
-
-  // Media Session action handlers (lock screen / control center playback and EPG timeline seeking)
-  useEffect(() => {
-    if (!("mediaSession" in navigator)) return;
-    const mediaSession = navigator.mediaSession;
-    setMediaSessionAction(mediaSession, "play", handleMediaSessionPlay);
-    setMediaSessionAction(mediaSession, "pause", handleMediaSessionPause);
-    setMediaSessionAction(
-      mediaSession,
-      "seekbackward",
-      canSeekProgramInMediaSession ? handleMediaSessionSeekBackward : null,
-    );
-    setMediaSessionAction(
-      mediaSession,
-      "seekforward",
-      canSeekProgramInMediaSession ? handleMediaSessionSeekForward : null,
-    );
-    setMediaSessionAction(mediaSession, "seekto", canSeekProgramInMediaSession ? handleMediaSessionSeekTo : null);
-    return () => {
-      setMediaSessionAction(mediaSession, "play", null);
-      setMediaSessionAction(mediaSession, "pause", null);
-      setMediaSessionAction(mediaSession, "seekbackward", null);
-      setMediaSessionAction(mediaSession, "seekforward", null);
-      setMediaSessionAction(mediaSession, "seekto", null);
-    };
-  }, [canSeekProgramInMediaSession]);
 
   // These reactive values intentionally trigger the Effect Event, which reads their latest values without capturing them.
   // biome-ignore lint/correctness/useExhaustiveDependencies: synchronize Media Session immediately on timeline/slot state changes
@@ -1541,17 +1524,15 @@ export function VideoPlayer({
     await video.requestPictureInPicture();
   });
 
-  const handlePiPToggle = useEffectEvent(async () => {
+  const enterPictureInPicture = useEffectEvent(async () => {
+    if (isAnyPictureInPictureActive()) return;
+
     const video = getActiveVideo();
     if (!video) return;
 
     let openedDocumentPiPWindow: Window | null = null;
 
     try {
-      if (await exitPictureInPicture()) {
-        return;
-      }
-
       const documentPictureInPicture = getDocumentPictureInPicture();
       if (documentPictureInPicture) {
         const playerElement = playerSurfaceRef.current;
@@ -1590,6 +1571,59 @@ export function VideoPlayer({
       console.error("Picture-in-Picture error:", err);
     }
   });
+
+  const handlePiPToggle = useEffectEvent(async () => {
+    if (await exitPictureInPicture()) return;
+    await enterPictureInPicture();
+  });
+
+  const handleMediaSessionEnterPictureInPicture = useEffectEvent(() => {
+    void enterPictureInPicture();
+  });
+
+  // Media Session action handlers (lock screen / control center playback, navigation, seeking, and PiP)
+  useEffect(() => {
+    if (!("mediaSession" in navigator)) return;
+    const mediaSession = navigator.mediaSession;
+    setMediaSessionAction(mediaSession, "play", handleMediaSessionPlay);
+    setMediaSessionAction(mediaSession, "pause", handleMediaSessionPause);
+    setMediaSessionAction(
+      mediaSession,
+      "previoustrack",
+      canNavigateChannelsInMediaSession ? handleMediaSessionPreviousTrack : null,
+    );
+    setMediaSessionAction(
+      mediaSession,
+      "nexttrack",
+      canNavigateChannelsInMediaSession ? handleMediaSessionNextTrack : null,
+    );
+    setMediaSessionAction(
+      mediaSession,
+      "seekbackward",
+      canSeekProgramInMediaSession ? handleMediaSessionSeekBackward : null,
+    );
+    setMediaSessionAction(
+      mediaSession,
+      "seekforward",
+      canSeekProgramInMediaSession ? handleMediaSessionSeekForward : null,
+    );
+    setMediaSessionAction(mediaSession, "seekto", canSeekProgramInMediaSession ? handleMediaSessionSeekTo : null);
+    setMediaSessionAction(
+      mediaSession,
+      "enterpictureinpicture",
+      isPictureInPictureSupported() ? handleMediaSessionEnterPictureInPicture : null,
+    );
+    return () => {
+      setMediaSessionAction(mediaSession, "play", null);
+      setMediaSessionAction(mediaSession, "pause", null);
+      setMediaSessionAction(mediaSession, "previoustrack", null);
+      setMediaSessionAction(mediaSession, "nexttrack", null);
+      setMediaSessionAction(mediaSession, "seekbackward", null);
+      setMediaSessionAction(mediaSession, "seekforward", null);
+      setMediaSessionAction(mediaSession, "seekto", null);
+      setMediaSessionAction(mediaSession, "enterpictureinpicture", null);
+    };
+  }, [canNavigateChannelsInMediaSession, canSeekProgramInMediaSession]);
 
   const handleUserInteraction = useEffectEvent(() => {
     const video = getActiveVideo();

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -893,7 +893,7 @@ export function VideoPlayer({
     if (!("mediaSession" in navigator) || !navigator.mediaSession.setPositionState) return;
 
     if (!channel) {
-      navigator.mediaSession.setPositionState({});
+      navigator.mediaSession.setPositionState();
       return;
     }
 
@@ -923,7 +923,7 @@ export function VideoPlayer({
       }
     } catch {
       // Older implementations may reject Infinity even though it represents live media.
-      navigator.mediaSession.setPositionState({});
+      navigator.mediaSession.setPositionState();
     }
   });
 
@@ -1007,7 +1007,7 @@ export function VideoPlayer({
       if (!("mediaSession" in navigator) || !navigator.mediaSession.setPositionState) return;
       navigator.mediaSession.metadata = null;
       navigator.mediaSession.playbackState = "none";
-      navigator.mediaSession.setPositionState({});
+      navigator.mediaSession.setPositionState();
     },
     [],
   );

--- a/web-ui/src/lib/program-timeline.ts
+++ b/web-ui/src/lib/program-timeline.ts
@@ -1,0 +1,46 @@
+import { mseToWallClock } from "../mpegts/player/wall-clock";
+import type { EPGProgram } from "../types/player";
+
+export interface ProgramTimeline {
+  startTime: Date;
+  endTime: Date;
+  playheadTime: Date;
+  durationSeconds: number;
+  positionSeconds: number;
+  progress: number;
+}
+
+export function createProgramTimeline(
+  program: Pick<EPGProgram, "start" | "end">,
+  streamOrigin: Date,
+  mediaTime: number,
+): ProgramTimeline | null {
+  const durationSeconds = (program.end.getTime() - program.start.getTime()) / 1000;
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) return null;
+
+  const playheadTime = mseToWallClock(mediaTime, streamOrigin);
+  if (!Number.isFinite(playheadTime.getTime())) return null;
+  const unclampedPosition = (playheadTime.getTime() - program.start.getTime()) / 1000;
+  const positionSeconds = Math.min(durationSeconds, Math.max(0, unclampedPosition));
+
+  return {
+    startTime: program.start,
+    endTime: program.end,
+    playheadTime,
+    durationSeconds,
+    positionSeconds,
+    progress: positionSeconds / durationSeconds,
+  };
+}
+
+export function programPositionToWallClock(timeline: ProgramTimeline, positionSeconds: number): Date {
+  const clampedPosition = Number.isFinite(positionSeconds)
+    ? Math.min(timeline.durationSeconds, Math.max(0, positionSeconds))
+    : 0;
+  return new Date(timeline.startTime.getTime() + clampedPosition * 1000);
+}
+
+export function programProgressToWallClock(timeline: ProgramTimeline, progress: number): Date {
+  const clampedProgress = Number.isFinite(progress) ? Math.min(1, Math.max(0, progress)) : 0;
+  return programPositionToWallClock(timeline, timeline.durationSeconds * clampedProgress);
+}

--- a/web-ui/src/mpegts/player/mpegts-player.ts
+++ b/web-ui/src/mpegts/player/mpegts-player.ts
@@ -147,7 +147,9 @@ export function createMpegtsPlayer(
         sourceMode = "hls";
         hlsLive = msg.live;
         updateLiveState();
-        if (!msg.live) {
+        if (msg.live) {
+          mse?.setDuration(Infinity);
+        } else {
           mse?.setDuration(msg.totalDuration);
           hlsVodThrottleEnabled = true;
           updateFetchBackpressure();
@@ -369,6 +371,9 @@ export function createMpegtsPlayer(
   /** Create (or recreate) MSE and attach to video element. */
   function initMSE(): void {
     mse = createMSE(video, config);
+    if (sourceMode === "continuous-live-ts") {
+      mse.setDuration(Infinity);
+    }
 
     mse.open(() => {
       if (pendingSegments) {

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -33,7 +33,7 @@ import {
 } from "../lib/player-storage";
 import { buildAppPath } from "../lib/url";
 import type { PlayerSegment } from "../mpegts";
-import { NEAR_LIVE_EDGE_MS } from "../mpegts/player/wall-clock";
+import { mseToWallClock, NEAR_LIVE_EDGE_MS } from "../mpegts/player/wall-clock";
 import type { Channel, M3UMetadata } from "../types/player";
 
 function getM3UIntegrationGuideUrl(locale: Locale) {
@@ -164,7 +164,7 @@ function PlayerPage() {
         setStreamStartTime(new Date());
       } else {
         // Preserve current playback position when switching source in catchup mode
-        setStreamStartTime(new Date(streamStartTime.getTime() + currentVideoTime * 1000));
+        setStreamStartTime(mseToWallClock(currentVideoTime, streamStartTime));
       }
       setActiveSourceIndex(sourceIndex);
     },
@@ -318,7 +318,7 @@ function PlayerPage() {
     if (!epgChannelId) return null;
 
     // Calculate absolute time based on stream start + current video position
-    const absoluteTime = new Date(streamStartTime.getTime() + currentVideoTime * 1000);
+    const absoluteTime = mseToWallClock(currentVideoTime, streamStartTime);
     return getCurrentProgram(epgChannelId, epgData, absoluteTime);
   }, [currentChannel, epgData, streamStartTime, currentVideoTime]);
 


### PR DESCRIPTION
## Summary

Make the web player’s Media Session representation match its wall-clock and EPG semantics while keeping MSE on its internal media timeline. Expand system media controls with EPG-aware seeking, channel navigation, and browser-initiated Picture-in-Picture.

## Behavior

Channels with valid EPG data and catchup support expose the current program as a finite Media Session timeline. Seek-to maps back to wall-clock time, while seek forward and backward reuse the keyboard relative-seek path and honor the user agent offset with a five-second fallback. Channels without EPG or catchup remain live-only and expose no seek actions.

Previous-track and next-track actions switch to the previous and next IPTV channels using the existing channel navigation behavior, including wrapping at the ends of the list.

The enter-picture-in-picture action uses the same active-slot-aware PiP implementation as the player UI. This lets Chrome’s global media controls request Video or Document PiP and provides the entry point Chrome uses for automatic PiP when the browser considers the page eligible. Automatic PiP remains user-agent and permission dependent; registering the action does not force PiP merely because the user switches tabs.

Live HLS and continuous TS sources explicitly use an infinite MSE duration. Safari-compatible position-state cleanup avoids passing an empty dictionary when live position state is unsupported.

The existing 30-second minimum catchup duration remains scoped to catchup URL creation, so buffered seeks three to thirty seconds behind live continue to work unchanged.

## Validation

- `pnpm run type-check:tsc`
- `pnpm run lint:biome`
- `pnpm exec vite build web-ui`
- `git diff --check`