### PR TITLE
fix(player): improve viewport safe area handling

### DIFF
--- a/web-ui/player.html
+++ b/web-ui/player.html
@@ -36,7 +36,7 @@
     </script>
     <link href="/src/index.css" rel="stylesheet" />
   </head>
-  <body class="bg-background text-foreground antialiased">
+  <body class="overflow-hidden bg-background text-foreground antialiased">
     <div id="root"></div>
     <script type="module" src="/src/pages/player.tsx"></script>
   </body>

--- a/web-ui/player.html
+++ b/web-ui/player.html
@@ -15,13 +15,20 @@
     <link rel="apple-touch-icon" href="./assets/icon.png" />
     <script>
       (() => {
+        const root = document.documentElement;
+        const navigatorStandalone = navigator.standalone;
+        const isStandalone =
+          typeof navigatorStandalone === "boolean"
+            ? navigatorStandalone
+            : window.matchMedia("(display-mode: standalone)").matches;
+        root.classList.toggle("player-standalone", isStandalone);
+
         try {
           const storageKey = "player-theme";
           const stored = localStorage.getItem(storageKey);
           const theme = stored === "light" || stored === "dark" ? stored : "auto";
           const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
           const isDark = theme === "dark" || (theme === "auto" && prefersDark);
-          const root = document.documentElement;
           if (isDark) {
             root.classList.add("dark");
             root.style.colorScheme = "dark";

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -227,7 +227,12 @@ export function PlayerControls({
   }, [hoverPosition, getTimeAtPosition]);
 
   return (
-    <div className="flex w-full flex-col gap-1 bg-[linear-gradient(to_top,rgba(2,8,23,0.98)_0%,rgba(8,22,51,0.9)_46%,rgba(21,27,69,0.48)_72%,transparent_100%)] px-1.5 pt-4 pb-1 md:gap-2 md:px-3 md:pt-9 md:pb-3">
+    <div
+      className={clsx(
+        "flex w-full flex-col gap-1 bg-[linear-gradient(to_top,rgba(2,8,23,0.98)_0%,rgba(8,22,51,0.9)_46%,rgba(21,27,69,0.48)_72%,transparent_100%)] pt-4 pr-[max(0.375rem,env(safe-area-inset-right))] pb-1 pl-[max(0.375rem,env(safe-area-inset-left))] md:gap-2 md:pt-9 md:pb-3 md:pl-[max(0.75rem,env(safe-area-inset-left))]",
+        showSidebar ? "md:pr-3" : "md:pr-[max(0.75rem,env(safe-area-inset-right))]",
+      )}
+    >
       {/* Program Info */}
       {currentProgram && (
         <div className="flex min-w-0 items-center justify-between gap-1 text-xs leading-tight tracking-[0.01em] text-blue-50/80 md:gap-2 md:text-sm md:leading-normal">

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1674,8 +1674,9 @@ export function VideoPlayer({
       role="application"
       ref={playerSurfaceRef}
       className={clsx(
-        "dark @container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-[radial-gradient(circle_at_50%_35%,#102044_0%,#050b18_58%,#01030a_100%)]",
+        "dark @container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center",
         isDocumentPiP ? "h-screen min-h-screen aspect-auto" : "md:aspect-auto md:h-full",
+        isDocumentPiP && "player-surface-background",
         !showControls && "cursor-none",
       )}
       onPointerEnter={handlePointerHover}
@@ -1896,7 +1897,7 @@ export function VideoPlayer({
   return (
     <div
       className={clsx(
-        "relative w-full bg-[radial-gradient(circle_at_50%_35%,#102044_0%,#050b18_58%,#01030a_100%)] pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] md:h-full",
+        "player-surface-background relative w-full pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] md:h-full",
         showSidebar && "md:pr-0",
       )}
     >

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1896,7 +1896,7 @@ export function VideoPlayer({
   return (
     <div
       className={clsx(
-        "relative w-full bg-[radial-gradient(circle_at_50%_20%,#102044_0%,#050b18_52%,#01030a_100%)] pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] md:h-full",
+        "relative w-full bg-[radial-gradient(circle_at_50%_35%,#102044_0%,#050b18_58%,#01030a_100%)] pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] md:h-full",
         showSidebar && "md:pr-0",
       )}
     >

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1674,9 +1674,8 @@ export function VideoPlayer({
       role="application"
       ref={playerSurfaceRef}
       className={clsx(
-        "dark @container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center",
+        "dark @container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-[radial-gradient(circle_at_50%_35%,#102044_0%,#050b18_58%,#01030a_100%)]",
         isDocumentPiP ? "h-screen min-h-screen aspect-auto" : "md:aspect-auto md:h-full",
-        isDocumentPiP && "player-surface-background",
         !showControls && "cursor-none",
       )}
       onPointerEnter={handlePointerHover}
@@ -1897,7 +1896,7 @@ export function VideoPlayer({
   return (
     <div
       className={clsx(
-        "player-surface-background relative w-full pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] md:h-full",
+        "relative w-full bg-[radial-gradient(circle_at_50%_35%,#102044_0%,#050b18_58%,#01030a_100%)] pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] md:h-full",
         showSidebar && "md:pr-0",
       )}
     >

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1853,7 +1853,8 @@ export function VideoPlayer({
         <div
           role="toolbar"
           className={clsx(
-            "absolute bottom-0 left-0 right-0 z-10 transition-opacity duration-300",
+            "absolute bottom-0 left-[calc(0px_-_env(safe-area-inset-left))] right-[calc(0px_-_env(safe-area-inset-right))] z-10 transition-opacity duration-300",
+            showSidebar && "md:right-0",
             showControls
               ? "opacity-100"
               : "opacity-0 pointer-events-none has-focus-visible:opacity-100 has-focus-visible:pointer-events-auto",

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1893,7 +1893,12 @@ export function VideoPlayer({
   );
 
   return (
-    <div className="relative w-full bg-[radial-gradient(circle_at_50%_20%,#102044_0%,#050b18_52%,#01030a_100%)] pt-[env(safe-area-inset-top)] md:h-full">
+    <div
+      className={clsx(
+        "relative w-full bg-[radial-gradient(circle_at_50%_20%,#102044_0%,#050b18_52%,#01030a_100%)] pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] md:h-full",
+        showSidebar && "md:pr-0",
+      )}
+    >
       <div ref={playerDockRef} className="contents">
         {isDocumentPiP && (
           <div className="@container-size/video relative flex aspect-video w-full min-h-0 items-center justify-center bg-[radial-gradient(circle_at_center,#102044_0%,#050b18_62%,#01030a_100%)] px-4 text-center font-medium text-blue-50/65 text-sm md:aspect-auto md:h-full md:text-base">

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -126,3 +126,11 @@
     transition-duration: 0.01ms;
   }
 }
+
+.player-viewport-height {
+  height: 100dvh;
+}
+
+.player-standalone .player-viewport-height {
+  height: 100vh;
+}

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -41,7 +41,6 @@
 }
 
 :root {
-  --player-surface-background: radial-gradient(circle at 50% 35%, #102044 0%, #050b18 58%, #01030a 100%);
   --background: 226 44% 97%;
   --foreground: 229 36% 14%;
   --card: 0 0% 100%;
@@ -134,15 +133,4 @@
 
 .player-standalone .player-viewport-height {
   height: 100vh;
-}
-
-.player-surface-background {
-  background: var(--player-surface-background);
-}
-
-@media (orientation: portrait) {
-  html.player-surface-active,
-  html.player-surface-active body {
-    background: var(--player-surface-background);
-  }
 }

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -41,6 +41,7 @@
 }
 
 :root {
+  --player-surface-background: radial-gradient(circle at 50% 35%, #102044 0%, #050b18 58%, #01030a 100%);
   --background: 226 44% 97%;
   --foreground: 229 36% 14%;
   --card: 0 0% 100%;
@@ -136,5 +137,12 @@
 }
 
 .player-surface-background {
-  background: radial-gradient(circle at 50% 35%, #102044 0%, #050b18 58%, #01030a 100%);
+  background: var(--player-surface-background);
+}
+
+@media (orientation: portrait) {
+  html.player-surface-active,
+  html.player-surface-active body {
+    background: var(--player-surface-background);
+  }
 }

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -134,3 +134,7 @@
 .player-standalone .player-viewport-height {
   height: 100vh;
 }
+
+.player-surface-background {
+  background: radial-gradient(circle at 50% 35%, #102044 0%, #050b18 58%, #01030a 100%);
+}

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -464,7 +464,7 @@ function PlayerPage() {
   const mainContent = (
     <div
       ref={pageContainerRef}
-      className="flex h-dvh flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(59,130,246,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_88%_10%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
+      className="flex h-dvh flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(59,130,246,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] [@media(display-mode:standalone)]:h-screen dark:bg-[radial-gradient(circle_at_88%_10%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
     >
       <title>{t("title")}</title>
 
@@ -501,7 +501,7 @@ function PlayerPage() {
         {/* Sidebar - Mobile: always visible (below video, hidden in fullscreen), Desktop: toggle-able side panel (visible in fullscreen) */}
         <div
           className={clsx(
-            "flex w-full flex-1 flex-col overflow-hidden border-blue-950/10 border-t bg-white/68 shadow-[-14px_0_40px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-blue-100/10 dark:bg-[linear-gradient(160deg,rgba(5,13,32,0.96),rgba(17,16,49,0.92))] dark:shadow-[-18px_0_48px_rgba(1,7,24,0.28)] md:w-80 md:flex-initial md:border-t-0 md:border-l",
+            "flex w-full flex-1 flex-col overflow-hidden border-blue-950/10 border-t bg-white/68 pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] shadow-[-14px_0_40px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-blue-100/10 dark:bg-[linear-gradient(160deg,rgba(5,13,32,0.96),rgba(17,16,49,0.92))] dark:shadow-[-18px_0_48px_rgba(1,7,24,0.28)] md:w-80 md:flex-initial md:border-t-0 md:border-l md:pt-[env(safe-area-inset-top)] md:pl-0",
             (showSidebar || isMobile) && !(isFullscreen && isMobile) ? "" : "hidden",
           )}
         >
@@ -561,9 +561,9 @@ function PlayerPage() {
     const playlistErrorHints = [t("playlistErrorHintReachable"), t("playlistErrorHintFormat")];
 
     return (
-      <div className="min-h-dvh bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.16),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.13),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]">
+      <div className="h-dvh overflow-y-auto bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.16),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] [@media(display-mode:standalone)]:h-screen dark:bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.13),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]">
         <title>{t("title")}</title>
-        <div className="mx-auto flex min-h-dvh w-[calc(100%-2rem)] max-w-5xl items-center py-8 sm:w-[calc(100%-3rem)]">
+        <div className="mx-auto flex min-h-full w-[calc(100%-2rem)] max-w-5xl items-center py-8 sm:w-[calc(100%-3rem)]">
           <Card className="min-w-0 w-full overflow-hidden rounded-3xl border-blue-900/10 bg-white/72 shadow-[0_28px_80px_rgba(30,64,175,0.16),inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-2xl dark:border-blue-100/12 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.9),rgba(26,24,72,0.82))] dark:shadow-[0_30px_90px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
             <div className="grid min-w-0 md:grid-cols-[minmax(0,1fr)_18rem]">
               <div className="min-w-0 p-6 sm:p-8 md:p-10">
@@ -646,7 +646,7 @@ function PlayerPage() {
       {isLoading && (
         <div
           className={clsx(
-            "fixed inset-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
+            "fixed top-0 left-0 z-50 flex h-dvh w-full items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] [@media(display-mode:standalone)]:h-screen dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
             isRevealing && "animate-zoom-fade-out",
           )}
         >

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -577,7 +577,7 @@ function PlayerPage() {
         {isLoading && (
           <div
             className={clsx(
-              "absolute inset-x-0 top-0 bottom-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] [@media(orientation:portrait)]:top-[env(safe-area-inset-top)] [@media(orientation:portrait)]:pt-4 dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
+              "absolute inset-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
               isRevealing && "animate-zoom-fade-out",
             )}
           >

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -460,200 +460,198 @@ function PlayerPage() {
     handlePictureEnhancementChange,
   ]);
 
-  // Main UI content
-  const mainContent = (
-    <div
-      ref={pageContainerRef}
-      className="player-viewport-height relative flex flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(59,130,246,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_88%_10%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
-    >
-      <title>{t("title")}</title>
-
-      {/* Main Content */}
-      <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
-        {/* Video Player - Mobile: fixed aspect ratio at top, Desktop: fills left side */}
-        <div className="w-full sticky md:static md:flex-1 shrink-0">
-          <VideoPlayer
-            channel={currentChannel}
-            segments={playbackSegments}
-            playMode={playMode}
-            onError={handleVideoError}
-            locale={locale}
-            currentProgram={currentVideoProgram}
-            onSeek={handleVideoSeek}
-            onStreamStartTimeChange={setStreamStartTime}
-            streamStartTime={streamStartTime}
-            currentVideoTime={currentVideoTime}
-            onCurrentVideoTimeChange={handleCurrentVideoTimeChange}
-            onChannelNavigate={handleChannelNavigate}
-            showSidebar={showSidebar}
-            onToggleSidebar={handleToggleSidebar}
-            isFullscreen={isFullscreen}
-            onFullscreenToggle={handleFullscreenToggle}
-            seamlessSwitch={seamlessSwitch}
-            autoDeinterlace={autoDeinterlace}
-            pictureEnhancement={pictureEnhancement}
-            activeSourceIndex={activeSourceIndex}
-            onSourceChange={handleSourceChange}
-            onPlaybackStarted={handlePlaybackStarted}
-          />
-        </div>
-
-        {/* Sidebar - Mobile: always visible (below video, hidden in fullscreen), Desktop: toggle-able side panel (visible in fullscreen) */}
-        <div
-          className={clsx(
-            "flex w-full flex-1 flex-col overflow-hidden border-blue-950/10 border-t bg-white/68 pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] shadow-[-14px_0_40px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-blue-100/10 dark:bg-[linear-gradient(160deg,rgba(5,13,32,0.96),rgba(17,16,49,0.92))] dark:shadow-[-18px_0_48px_rgba(1,7,24,0.28)] md:w-80 md:flex-initial md:border-t-0 md:border-l md:pt-[env(safe-area-inset-top)] md:pl-0",
-            (showSidebar || isMobile) && !(isFullscreen && isMobile) ? "" : "hidden",
-          )}
-        >
-          {/* Sidebar Tabs */}
-          <div className="flex shrink-0 items-center border-blue-950/10 border-b bg-white/44 shadow-[0_8px_24px_rgba(30,64,175,0.045)] backdrop-blur-xl dark:border-blue-100/10 dark:bg-[linear-gradient(90deg,#1a2035,#292643)]">
-            {(["channels", "epg"] as const).map((view) => (
-              <button
-                type="button"
-                key={view}
-                onClick={() => {
-                  (view === "channels" ? channelListNextScrollBehaviorRef : epgViewNextScrollBehaviorRef).current =
-                    "instant";
-                  setSidebarView(view);
-                }}
-                className={clsx(
-                  "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap border-b-2 px-3 py-2 text-center font-semibold text-xs leading-5 tracking-[0.01em] transition-[color,background-color,border-color,box-shadow] md:px-4 md:py-3 md:text-sm",
-                  sidebarView === view
-                    ? "border-blue-500 bg-[linear-gradient(to_top,rgba(59,130,246,0.12),transparent)] text-blue-700 shadow-[inset_0_-1px_0_rgba(59,130,246,0.18)] dark:border-blue-300 dark:text-blue-200"
-                    : "cursor-pointer border-transparent text-slate-500 hover:bg-blue-400/5 hover:text-blue-700 dark:text-slate-400 dark:hover:text-blue-100",
-                )}
-              >
-                {view === "channels" ? `${t("channels")} (${metadata?.channels.length || 0})` : t("programGuide")}
-              </button>
-            ))}
-          </div>
-
-          {/* Sidebar Content */}
-          <div className="flex-1 overflow-hidden">
-            <Activity mode={sidebarView === "channels" ? "visible" : "hidden"}>
-              <ChannelList
-                channels={metadata?.channels}
-                groups={metadata?.groups}
-                currentChannel={currentChannel}
-                onChannelSelect={selectChannel}
-                locale={locale}
-                settingsSlot={settingsSlot}
-                epgData={epgData}
-              />
-            </Activity>
-            <Activity mode={sidebarView === "epg" ? "visible" : "hidden"}>
-              <EPGView
-                channelId={currentChannel ? getEPGChannelId(currentChannel, epgData) : null}
-                epgData={epgData}
-                onProgramSelect={handleProgramSelect}
-                locale={locale}
-                supportsCatchup={!!currentChannel?.sources.some((s) => s.catchup && s.catchupSource)}
-                currentPlayingProgram={currentVideoProgram}
-              />
-            </Activity>
-          </div>
-        </div>
-      </div>
-
-      {/* Loading overlay shares the player viewport to avoid iOS standalone fixed-position gaps. */}
-      {isLoading && (
-        <div
-          className={clsx(
-            "absolute inset-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
-            isRevealing && "animate-zoom-fade-out",
-          )}
-        >
-          <div className="text-center space-y-4">
-            {/* Loading spinner */}
-            <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-blue-950/10 border-t-blue-500 border-r-indigo-500 shadow-[0_0_28px_rgba(59,130,246,0.22)] dark:border-blue-100/10 dark:border-t-blue-300 dark:border-r-indigo-400" />
-          </div>
-        </div>
-      )}
-    </div>
-  );
-
-  if (error && !metadata) {
-    const playlistErrorHints = [t("playlistErrorHintReachable"), t("playlistErrorHintFormat")];
-
+  const hasPlaylistLoadError = error !== null && !metadata;
+  if (!hasPlaylistLoadError) {
     return (
-      <div className="player-viewport-height overflow-y-auto bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.16),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.13),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]">
+      <div
+        ref={pageContainerRef}
+        className="player-viewport-height relative flex flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(59,130,246,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_88%_10%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
+      >
         <title>{t("title")}</title>
-        <div className="mx-auto flex min-h-full w-[calc(100%-2rem)] max-w-5xl items-center py-8 sm:w-[calc(100%-3rem)]">
-          <Card className="min-w-0 w-full overflow-hidden rounded-3xl border-blue-900/10 bg-white/72 shadow-[0_28px_80px_rgba(30,64,175,0.16),inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-2xl dark:border-blue-100/12 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.9),rgba(26,24,72,0.82))] dark:shadow-[0_30px_90px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
-            <div className="grid min-w-0 md:grid-cols-[minmax(0,1fr)_18rem]">
-              <div className="min-w-0 p-6 sm:p-8 md:p-10">
-                <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-2xl border border-rose-300/20 bg-[linear-gradient(145deg,rgba(251,113,133,0.16),rgba(99,102,241,0.12))] text-rose-500 shadow-[0_12px_28px_rgba(225,29,72,0.12)] dark:text-rose-300">
-                  <AlertTriangle className="h-6 w-6" aria-hidden="true" />
-                </div>
 
-                <div className="font-semibold text-blue-700 text-sm dark:text-blue-200">{t("playlistLoadEyebrow")}</div>
-                <h1 className="mt-2 text-balance font-semibold text-2xl text-foreground leading-tight tracking-tight sm:text-3xl">
-                  {t("playlistLoadTitle")}
-                </h1>
-                <p className="mt-3 max-w-2xl text-pretty break-words text-sm leading-6 text-muted-foreground sm:text-base">
-                  {t("playlistLoadDescription")}
-                </p>
+        {/* Main Content */}
+        <div className="flex flex-col md:flex-row flex-1 overflow-hidden">
+          {/* Video Player - Mobile: fixed aspect ratio at top, Desktop: fills left side */}
+          <div className="w-full sticky md:static md:flex-1 shrink-0">
+            <VideoPlayer
+              channel={currentChannel}
+              segments={playbackSegments}
+              playMode={playMode}
+              onError={handleVideoError}
+              locale={locale}
+              currentProgram={currentVideoProgram}
+              onSeek={handleVideoSeek}
+              onStreamStartTimeChange={setStreamStartTime}
+              streamStartTime={streamStartTime}
+              currentVideoTime={currentVideoTime}
+              onCurrentVideoTimeChange={handleCurrentVideoTimeChange}
+              onChannelNavigate={handleChannelNavigate}
+              showSidebar={showSidebar}
+              onToggleSidebar={handleToggleSidebar}
+              isFullscreen={isFullscreen}
+              onFullscreenToggle={handleFullscreenToggle}
+              seamlessSwitch={seamlessSwitch}
+              autoDeinterlace={autoDeinterlace}
+              pictureEnhancement={pictureEnhancement}
+              activeSourceIndex={activeSourceIndex}
+              onSourceChange={handleSourceChange}
+              onPlaybackStarted={handlePlaybackStarted}
+            />
+          </div>
 
-                <div className="mt-6 min-w-0 rounded-2xl border border-blue-900/10 bg-blue-50/45 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] dark:border-blue-100/10 dark:bg-blue-300/6">
-                  <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                    <ListChecks className="h-4 w-4 text-blue-600 dark:text-blue-300" aria-hidden="true" />
-                    {t("playlistErrorChecklist")}
-                  </div>
-                  <ul className="mt-3 space-y-2 text-sm leading-5 text-muted-foreground">
-                    {playlistErrorHints.map((hint) => (
-                      <li key={hint} className="flex min-w-0 gap-2">
-                        <span
-                          className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.45)]"
-                          aria-hidden="true"
-                        />
-                        <span className="min-w-0 break-words">{hint}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-
-                <div className="mt-6 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={loadPlaylist}
-                    className="w-full gap-2 rounded-xl border-primary/20 bg-[linear-gradient(135deg,#0e7490,#4338ca)] text-white shadow-[0_10px_28px_rgba(37,99,235,0.24)] transition-[color,background-color,border-color] hover:border-primary/30 hover:bg-[linear-gradient(135deg,#0e7490,#4338ca)] hover:text-white sm:w-auto"
-                  >
-                    <RefreshCw className="h-4 w-4" aria-hidden="true" />
-                    {t("retry")}
-                  </Button>
-                  <a
-                    href={getM3UIntegrationGuideUrl(locale)}
-                    target="_blank"
-                    rel="noreferrer"
-                    className={buttonVariants({
-                      variant: "outline",
-                      className:
-                        "w-full gap-2 rounded-xl border-blue-900/12 bg-white/55 text-blue-800 shadow-sm hover:bg-blue-50 dark:border-blue-100/15 dark:bg-slate-950/35 dark:text-blue-100 dark:hover:bg-blue-300/10 sm:w-auto",
-                    })}
-                  >
-                    {t("m3uIntegrationGuide")}
-                    <ExternalLink className="h-4 w-4" aria-hidden="true" />
-                  </a>
-                </div>
-              </div>
-
-              <div className="min-w-0 border-blue-900/10 border-t bg-[linear-gradient(145deg,rgba(224,242,254,0.42),rgba(238,242,255,0.58))] p-6 dark:border-blue-100/10 dark:bg-[linear-gradient(145deg,rgba(8,47,73,0.22),rgba(30,27,75,0.3))] md:border-t-0 md:border-l md:p-8">
-                <div className="text-sm font-semibold text-foreground">{t("playlistEndpoint")}</div>
-                <div className="mt-3 break-all rounded-xl border border-blue-900/10 bg-white/55 px-3 py-2 font-mono text-foreground text-sm leading-5 shadow-inner dark:border-blue-100/10 dark:bg-slate-950/42">
-                  {buildAppPath("/playlist.m3u")}
-                </div>
-                <div className="mt-6 text-sm font-semibold text-foreground">{t("technicalDetails")}</div>
-                <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">{error}</p>
-              </div>
+          {/* Sidebar - Mobile: always visible (below video, hidden in fullscreen), Desktop: toggle-able side panel (visible in fullscreen) */}
+          <div
+            className={clsx(
+              "flex w-full flex-1 flex-col overflow-hidden border-blue-950/10 border-t bg-white/68 pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] shadow-[-14px_0_40px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-blue-100/10 dark:bg-[linear-gradient(160deg,rgba(5,13,32,0.96),rgba(17,16,49,0.92))] dark:shadow-[-18px_0_48px_rgba(1,7,24,0.28)] md:w-80 md:flex-initial md:border-t-0 md:border-l md:pt-[env(safe-area-inset-top)] md:pl-0",
+              (showSidebar || isMobile) && !(isFullscreen && isMobile) ? "" : "hidden",
+            )}
+          >
+            {/* Sidebar Tabs */}
+            <div className="flex shrink-0 items-center border-blue-950/10 border-b bg-white/44 shadow-[0_8px_24px_rgba(30,64,175,0.045)] backdrop-blur-xl dark:border-blue-100/10 dark:bg-[linear-gradient(90deg,#1a2035,#292643)]">
+              {(["channels", "epg"] as const).map((view) => (
+                <button
+                  type="button"
+                  key={view}
+                  onClick={() => {
+                    (view === "channels" ? channelListNextScrollBehaviorRef : epgViewNextScrollBehaviorRef).current =
+                      "instant";
+                    setSidebarView(view);
+                  }}
+                  className={clsx(
+                    "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap border-b-2 px-3 py-2 text-center font-semibold text-xs leading-5 tracking-[0.01em] transition-[color,background-color,border-color,box-shadow] md:px-4 md:py-3 md:text-sm",
+                    sidebarView === view
+                      ? "border-blue-500 bg-[linear-gradient(to_top,rgba(59,130,246,0.12),transparent)] text-blue-700 shadow-[inset_0_-1px_0_rgba(59,130,246,0.18)] dark:border-blue-300 dark:text-blue-200"
+                      : "cursor-pointer border-transparent text-slate-500 hover:bg-blue-400/5 hover:text-blue-700 dark:text-slate-400 dark:hover:text-blue-100",
+                  )}
+                >
+                  {view === "channels" ? `${t("channels")} (${metadata?.channels.length || 0})` : t("programGuide")}
+                </button>
+              ))}
             </div>
-          </Card>
+
+            {/* Sidebar Content */}
+            <div className="flex-1 overflow-hidden">
+              <Activity mode={sidebarView === "channels" ? "visible" : "hidden"}>
+                <ChannelList
+                  channels={metadata?.channels}
+                  groups={metadata?.groups}
+                  currentChannel={currentChannel}
+                  onChannelSelect={selectChannel}
+                  locale={locale}
+                  settingsSlot={settingsSlot}
+                  epgData={epgData}
+                />
+              </Activity>
+              <Activity mode={sidebarView === "epg" ? "visible" : "hidden"}>
+                <EPGView
+                  channelId={currentChannel ? getEPGChannelId(currentChannel, epgData) : null}
+                  epgData={epgData}
+                  onProgramSelect={handleProgramSelect}
+                  locale={locale}
+                  supportsCatchup={!!currentChannel?.sources.some((s) => s.catchup && s.catchupSource)}
+                  currentPlayingProgram={currentVideoProgram}
+                />
+              </Activity>
+            </div>
+          </div>
         </div>
+
+        {/* Loading overlay shares the player viewport to avoid iOS standalone fixed-position gaps. */}
+        {isLoading && (
+          <div
+            className={clsx(
+              "absolute inset-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
+              isRevealing && "animate-zoom-fade-out",
+            )}
+          >
+            <div className="text-center space-y-4">
+              {/* Loading spinner */}
+              <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-blue-950/10 border-t-blue-500 border-r-indigo-500 shadow-[0_0_28px_rgba(59,130,246,0.22)] dark:border-blue-100/10 dark:border-t-blue-300 dark:border-r-indigo-400" />
+            </div>
+          </div>
+        )}
       </div>
     );
   }
 
-  return mainContent;
+  const playlistErrorHints = [t("playlistErrorHintReachable"), t("playlistErrorHintFormat")];
+
+  return (
+    <div className="player-viewport-height overflow-y-auto bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.16),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.13),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]">
+      <title>{t("title")}</title>
+      <div className="mx-auto flex min-h-full w-[calc(100%-2rem)] max-w-5xl items-center py-8 sm:w-[calc(100%-3rem)]">
+        <Card className="min-w-0 w-full overflow-hidden rounded-3xl border-blue-900/10 bg-white/72 shadow-[0_28px_80px_rgba(30,64,175,0.16),inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-2xl dark:border-blue-100/12 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.9),rgba(26,24,72,0.82))] dark:shadow-[0_30px_90px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
+          <div className="grid min-w-0 md:grid-cols-[minmax(0,1fr)_18rem]">
+            <div className="min-w-0 p-6 sm:p-8 md:p-10">
+              <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-2xl border border-rose-300/20 bg-[linear-gradient(145deg,rgba(251,113,133,0.16),rgba(99,102,241,0.12))] text-rose-500 shadow-[0_12px_28px_rgba(225,29,72,0.12)] dark:text-rose-300">
+                <AlertTriangle className="h-6 w-6" aria-hidden="true" />
+              </div>
+
+              <div className="font-semibold text-blue-700 text-sm dark:text-blue-200">{t("playlistLoadEyebrow")}</div>
+              <h1 className="mt-2 text-balance font-semibold text-2xl text-foreground leading-tight tracking-tight sm:text-3xl">
+                {t("playlistLoadTitle")}
+              </h1>
+              <p className="mt-3 max-w-2xl text-pretty break-words text-sm leading-6 text-muted-foreground sm:text-base">
+                {t("playlistLoadDescription")}
+              </p>
+
+              <div className="mt-6 min-w-0 rounded-2xl border border-blue-900/10 bg-blue-50/45 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] dark:border-blue-100/10 dark:bg-blue-300/6">
+                <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                  <ListChecks className="h-4 w-4 text-blue-600 dark:text-blue-300" aria-hidden="true" />
+                  {t("playlistErrorChecklist")}
+                </div>
+                <ul className="mt-3 space-y-2 text-sm leading-5 text-muted-foreground">
+                  {playlistErrorHints.map((hint) => (
+                    <li key={hint} className="flex min-w-0 gap-2">
+                      <span
+                        className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.45)]"
+                        aria-hidden="true"
+                      />
+                      <span className="min-w-0 break-words">{hint}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="mt-6 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={loadPlaylist}
+                  className="w-full gap-2 rounded-xl border-primary/20 bg-[linear-gradient(135deg,#0e7490,#4338ca)] text-white shadow-[0_10px_28px_rgba(37,99,235,0.24)] transition-[color,background-color,border-color] hover:border-primary/30 hover:bg-[linear-gradient(135deg,#0e7490,#4338ca)] hover:text-white sm:w-auto"
+                >
+                  <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                  {t("retry")}
+                </Button>
+                <a
+                  href={getM3UIntegrationGuideUrl(locale)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={buttonVariants({
+                    variant: "outline",
+                    className:
+                      "w-full gap-2 rounded-xl border-blue-900/12 bg-white/55 text-blue-800 shadow-sm hover:bg-blue-50 dark:border-blue-100/15 dark:bg-slate-950/35 dark:text-blue-100 dark:hover:bg-blue-300/10 sm:w-auto",
+                  })}
+                >
+                  {t("m3uIntegrationGuide")}
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                </a>
+              </div>
+            </div>
+
+            <div className="min-w-0 border-blue-900/10 border-t bg-[linear-gradient(145deg,rgba(224,242,254,0.42),rgba(238,242,255,0.58))] p-6 dark:border-blue-100/10 dark:bg-[linear-gradient(145deg,rgba(8,47,73,0.22),rgba(30,27,75,0.3))] md:border-t-0 md:border-l md:p-8">
+              <div className="text-sm font-semibold text-foreground">{t("playlistEndpoint")}</div>
+              <div className="mt-3 break-all rounded-xl border border-blue-900/10 bg-white/55 px-3 py-2 font-mono text-foreground text-sm leading-5 shadow-inner dark:border-blue-100/10 dark:bg-slate-950/42">
+                {buildAppPath("/playlist.m3u")}
+              </div>
+              <div className="mt-6 text-sm font-semibold text-foreground">{t("technicalDetails")}</div>
+              <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">{error}</p>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
 }
 
 // Mount the app

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -1,6 +1,16 @@
 import { clsx } from "clsx";
 import { AlertTriangle, ExternalLink, ListChecks, RefreshCw } from "lucide-react";
-import { Activity, StrictMode, startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Activity,
+  StrictMode,
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createRoot } from "react-dom/client";
 import {
   ChannelList,
@@ -99,6 +109,14 @@ function PlayerPage() {
   const [pictureEnhancement, setPictureEnhancement] = useState(() => getPictureEnhancement());
   const pageContainerRef = useRef<HTMLDivElement>(null);
   const isSimulatedFullscreenRef = useRef(false);
+  const hasPlaylistLoadError = Boolean(error && !metadata);
+
+  useLayoutEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("player-surface-active", !isLoading && !hasPlaylistLoadError);
+
+    return () => root.classList.remove("player-surface-active");
+  }, [hasPlaylistLoadError, isLoading]);
 
   // Track stream start time - the absolute time position when current stream started
   // For live mode: null (no seeking)
@@ -476,7 +494,6 @@ function PlayerPage() {
     handlePictureEnhancementChange,
   ]);
 
-  const hasPlaylistLoadError = Boolean(error && !metadata);
   if (!hasPlaylistLoadError) {
     return (
       <div

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -460,7 +460,7 @@ function PlayerPage() {
     handlePictureEnhancementChange,
   ]);
 
-  const hasPlaylistLoadError = error !== null && !metadata;
+  const hasPlaylistLoadError = Boolean(error && !metadata);
   if (!hasPlaylistLoadError) {
     return (
       <div

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -70,10 +70,10 @@ function shouldInsetSidebarRight(): boolean {
   const { angle, type } = screen.orientation;
   if (!type.startsWith("landscape")) return true;
 
-  // On naturally portrait screens, 90° puts the device top on the right and
-  // 270° puts it on the left. Preserve the inset for other angles, including
-  // naturally landscape devices.
-  return angle !== 270;
+  // At 90°, the sidebar's right edge is on the device-bottom side and may
+  // overlap the smaller system area. Preserve the inset at 270° and for other
+  // angles, including naturally landscape devices.
+  return angle !== 90;
 }
 
 function PlayerPage() {

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -1,16 +1,6 @@
 import { clsx } from "clsx";
 import { AlertTriangle, ExternalLink, ListChecks, RefreshCw } from "lucide-react";
-import {
-  Activity,
-  StrictMode,
-  startTransition,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { Activity, StrictMode, startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
   ChannelList,
@@ -109,14 +99,6 @@ function PlayerPage() {
   const [pictureEnhancement, setPictureEnhancement] = useState(() => getPictureEnhancement());
   const pageContainerRef = useRef<HTMLDivElement>(null);
   const isSimulatedFullscreenRef = useRef(false);
-  const hasPlaylistLoadError = Boolean(error && !metadata);
-
-  useLayoutEffect(() => {
-    const root = document.documentElement;
-    root.classList.toggle("player-surface-active", !isLoading && !hasPlaylistLoadError);
-
-    return () => root.classList.remove("player-surface-active");
-  }, [hasPlaylistLoadError, isLoading]);
 
   // Track stream start time - the absolute time position when current stream started
   // For live mode: null (no seeking)
@@ -494,6 +476,7 @@ function PlayerPage() {
     handlePictureEnhancementChange,
   ]);
 
+  const hasPlaylistLoadError = Boolean(error && !metadata);
   if (!hasPlaylistLoadError) {
     return (
       <div

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -464,7 +464,7 @@ function PlayerPage() {
   const mainContent = (
     <div
       ref={pageContainerRef}
-      className="player-viewport-height flex flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(59,130,246,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_88%_10%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
+      className="player-viewport-height relative flex flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(59,130,246,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_88%_10%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
     >
       <title>{t("title")}</title>
 
@@ -554,6 +554,21 @@ function PlayerPage() {
           </div>
         </div>
       </div>
+
+      {/* Loading overlay shares the player viewport to avoid iOS standalone fixed-position gaps. */}
+      {isLoading && (
+        <div
+          className={clsx(
+            "absolute inset-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
+            isRevealing && "animate-zoom-fade-out",
+          )}
+        >
+          <div className="text-center space-y-4">
+            {/* Loading spinner */}
+            <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-blue-950/10 border-t-blue-500 border-r-indigo-500 shadow-[0_0_28px_rgba(59,130,246,0.22)] dark:border-blue-100/10 dark:border-t-blue-300 dark:border-r-indigo-400" />
+          </div>
+        </div>
+      )}
     </div>
   );
 
@@ -638,26 +653,7 @@ function PlayerPage() {
     );
   }
 
-  return (
-    <>
-      {/* Main content rendered below (will be revealed) */}
-      {mainContent}
-      {/* Loading overlay */}
-      {isLoading && (
-        <div
-          className={clsx(
-            "player-viewport-height fixed top-0 left-0 z-50 flex w-full items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
-            isRevealing && "animate-zoom-fade-out",
-          )}
-        >
-          <div className="text-center space-y-4">
-            {/* Loading spinner */}
-            <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-blue-950/10 border-t-blue-500 border-r-indigo-500 shadow-[0_0_28px_rgba(59,130,246,0.22)] dark:border-blue-100/10 dark:border-t-blue-300 dark:border-r-indigo-400" />
-          </div>
-        </div>
-      )}
-    </>
-  );
+  return mainContent;
 }
 
 // Mount the app

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -464,7 +464,7 @@ function PlayerPage() {
   const mainContent = (
     <div
       ref={pageContainerRef}
-      className="flex h-dvh flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(59,130,246,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] [@media(display-mode:standalone)]:h-screen dark:bg-[radial-gradient(circle_at_88%_10%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
+      className="player-viewport-height flex flex-col bg-[radial-gradient(circle_at_92%_8%,rgba(59,130,246,0.15),transparent_28%),radial-gradient(circle_at_72%_92%,rgba(99,102,241,0.13),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_88%_10%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_70%_88%,rgba(99,102,241,0.12),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]"
     >
       <title>{t("title")}</title>
 
@@ -561,7 +561,7 @@ function PlayerPage() {
     const playlistErrorHints = [t("playlistErrorHintReachable"), t("playlistErrorHintFormat")];
 
     return (
-      <div className="h-dvh overflow-y-auto bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.16),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] [@media(display-mode:standalone)]:h-screen dark:bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.13),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]">
+      <div className="player-viewport-height overflow-y-auto bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.16),transparent_32%),linear-gradient(145deg,#f8fbff,#edf2ff)] dark:bg-[radial-gradient(circle_at_18%_14%,rgba(59,130,246,0.1),transparent_30%),radial-gradient(circle_at_84%_82%,rgba(99,102,241,0.13),transparent_34%),linear-gradient(145deg,#050b18,#090d24)]">
         <title>{t("title")}</title>
         <div className="mx-auto flex min-h-full w-[calc(100%-2rem)] max-w-5xl items-center py-8 sm:w-[calc(100%-3rem)]">
           <Card className="min-w-0 w-full overflow-hidden rounded-3xl border-blue-900/10 bg-white/72 shadow-[0_28px_80px_rgba(30,64,175,0.16),inset_0_1px_0_rgba(255,255,255,0.85)] backdrop-blur-2xl dark:border-blue-100/12 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.9),rgba(26,24,72,0.82))] dark:shadow-[0_30px_90px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
@@ -646,7 +646,7 @@ function PlayerPage() {
       {isLoading && (
         <div
           className={clsx(
-            "fixed top-0 left-0 z-50 flex h-dvh w-full items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] [@media(display-mode:standalone)]:h-screen dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
+            "player-viewport-height fixed top-0 left-0 z-50 flex w-full items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
             isRevealing && "animate-zoom-fade-out",
           )}
         >

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -67,14 +67,12 @@ function unlockScreenOrientation(): void {
 }
 
 function shouldInsetSidebarRight(): boolean {
-  if (!("standalone" in navigator)) return true;
-
   const { angle, type } = screen.orientation;
   if (!type.startsWith("landscape")) return true;
 
-  // On naturally portrait iPhones, Safari reports 90° with the notch on the
-  // right and 270° with the notch on the left. Preserve the inset for other
-  // angles, including naturally landscape iPads.
+  // On naturally portrait screens, 90° puts the device top on the right and
+  // 270° puts it on the left. Preserve the inset for other angles, including
+  // naturally landscape devices.
   return angle !== 270;
 }
 

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -66,6 +66,18 @@ function unlockScreenOrientation(): void {
   }
 }
 
+function shouldInsetSidebarRight(): boolean {
+  if (!("standalone" in navigator)) return true;
+
+  const { angle, type } = screen.orientation;
+  if (!type.startsWith("landscape")) return true;
+
+  // On naturally portrait iPhones, Safari reports 90° with the notch on the
+  // right and 270° with the notch on the left. Preserve the inset for other
+  // angles, including naturally landscape iPads.
+  return angle !== 270;
+}
+
 function PlayerPage() {
   const { locale, setLocale } = useLocale("player-locale");
   const { theme, setTheme } = useTheme("player-theme");
@@ -83,6 +95,7 @@ function PlayerPage() {
   const [sidebarView, setSidebarView] = useState<"channels" | "epg">("channels");
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
+  const [insetSidebarRight, setInsetSidebarRight] = useState(shouldInsetSidebarRight);
   const [seamlessSwitch, setSeamlessSwitch] = useState(() => getSeamlessSwitch());
   const [autoDeinterlace, setAutoDeinterlace] = useState(() => getAutoDeinterlace());
   const [pictureEnhancement, setPictureEnhancement] = useState(() => getPictureEnhancement());
@@ -124,15 +137,20 @@ function PlayerPage() {
     };
   }, []);
 
-  // Track mobile/desktop state
+  // Track responsive layout and which physical edge is on the sidebar's right.
   useEffect(() => {
-    const handleResize = () => {
-      startTransition(() => setIsMobile(window.innerWidth < 768));
+    const handleViewportChange = () => {
+      startTransition(() => {
+        setIsMobile(window.innerWidth < 768);
+        setInsetSidebarRight(shouldInsetSidebarRight());
+      });
     };
 
-    window.addEventListener("resize", handleResize);
+    window.addEventListener("resize", handleViewportChange);
+    screen.orientation.addEventListener("change", handleViewportChange);
     return () => {
-      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("resize", handleViewportChange);
+      screen.orientation.removeEventListener("change", handleViewportChange);
     };
   }, []);
 
@@ -502,7 +520,8 @@ function PlayerPage() {
           {/* Sidebar - Mobile: always visible (below video, hidden in fullscreen), Desktop: toggle-able side panel (visible in fullscreen) */}
           <div
             className={clsx(
-              "flex w-full flex-1 flex-col overflow-hidden border-blue-950/10 border-t bg-white/68 pr-[env(safe-area-inset-right)] pl-[env(safe-area-inset-left)] shadow-[-14px_0_40px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-blue-100/10 dark:bg-[linear-gradient(160deg,rgba(5,13,32,0.96),rgba(17,16,49,0.92))] dark:shadow-[-18px_0_48px_rgba(1,7,24,0.28)] md:w-80 md:flex-initial md:border-t-0 md:border-l md:pt-[env(safe-area-inset-top)] md:pl-0",
+              "flex w-full flex-1 flex-col overflow-hidden border-blue-950/10 border-t bg-white/68 pl-[env(safe-area-inset-left)] shadow-[-14px_0_40px_rgba(30,64,175,0.06)] backdrop-blur-2xl dark:border-blue-100/10 dark:bg-[linear-gradient(160deg,rgba(5,13,32,0.96),rgba(17,16,49,0.92))] dark:shadow-[-18px_0_48px_rgba(1,7,24,0.28)] md:w-80 md:flex-initial md:border-t-0 md:border-l md:pt-[env(safe-area-inset-top)] md:pl-0",
+              insetSidebarRight && "pr-[env(safe-area-inset-right)]",
               (showSidebar || isMobile) && !(isFullscreen && isMobile) ? "" : "hidden",
             )}
           >

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -577,7 +577,7 @@ function PlayerPage() {
         {isLoading && (
           <div
             className={clsx(
-              "absolute inset-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
+              "absolute inset-x-0 top-0 bottom-0 z-50 flex items-center justify-center bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),transparent_28%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.14),transparent_35%),linear-gradient(145deg,#f8fbff,#edf2ff)] pt-[max(1rem,env(safe-area-inset-top))] pr-[max(1rem,env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] pl-[max(1rem,env(safe-area-inset-left))] [@media(orientation:portrait)]:top-[env(safe-area-inset-top)] [@media(orientation:portrait)]:pt-4 dark:bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.11),transparent_30%),radial-gradient(circle_at_65%_60%,rgba(99,102,241,0.12),transparent_38%),linear-gradient(145deg,#050b18,#090d24)]",
               isRevealing && "animate-zoom-fade-out",
             )}
           >


### PR DESCRIPTION
## Summary

Improve the web player's viewport and safe-area behavior on devices with display cutouts.

The player now uses `100vh` in standalone mode and `100dvh` in browser mode, while locking body scrolling. On platforms that expose `navigator.standalone`, that value is authoritative so iOS does not depend on its unreliable `display-mode` media query. Other platforms fall back to `matchMedia("(display-mode: standalone)")`. Detection runs synchronously before the stylesheet and React app load to avoid an incorrect first layout.

The loading overlay lives inside the main player viewport as an absolutely positioned full-page layer and retains its own four-sided safe-area padding.

On naturally portrait devices in landscape, the sidebar removes its right inset at 90°, when that edge is on the device-bottom side and may safely overlap the smaller system area. At 270° the right inset is retained to protect content from the device-top cutout side. Portrait and naturally landscape devices keep the existing right inset behavior. Mobile portrait keeps the bottom safe area inside the sidebar's scrollable content so the sidebar background extends beneath it.

When the player owns a horizontal screen edge, its surface background continues through that safe-area strip and the controls toolbar extends its bottom gradient over it. The controls content applies matching inset padding, so buttons, metadata, and the progress bar remain in the safe content region. In split layouts with a visible sidebar, the gradient does not extend into the sidebar-owned right edge.

The player does not add special handling for the portrait top safe area. The standalone playlist error page remains a normal vertically scrollable page and does not apply special safe-area padding. Player controls retain their existing bottom spacing without extra Home Indicator compensation.

## Validation

- `pnpm exec biome check web-ui/src/pages/player.tsx web-ui/src/components/player/video-player.tsx web-ui/src/index.css`
- `pnpm exec vite build web-ui --outDir /tmp/rtp2httpd-web-ui-safe-area-build --emptyOutDir`
- `git diff --check`