### PR TITLE
feat(player): improve picture-in-picture controls

### DIFF
--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -56,6 +56,7 @@ interface PlayerControlsProps {
   isPiP?: boolean;
   isPiPSupported?: boolean;
   onPiPToggle?: () => void;
+  showMediaBadges?: boolean;
   // Sidebar controls
   showSidebar?: boolean;
   onToggleSidebar?: () => void;
@@ -63,6 +64,10 @@ interface PlayerControlsProps {
   activeSourceIndex?: number;
   onSourceChange?: (index: number) => void;
 }
+
+const COMPACT_BUTTON_CLASS = "[@container_video_(max-height:_320px)]:p-1 md:[@container_video_(max-height:_320px)]:p-1";
+const COMPACT_ICON_CLASS =
+  "[@container_video_(max-height:_320px)]:h-4 [@container_video_(max-height:_320px)]:w-4 md:[@container_video_(max-height:_320px)]:h-4 md:[@container_video_(max-height:_320px)]:w-4";
 
 export function PlayerControls({
   channel,
@@ -86,6 +91,7 @@ export function PlayerControls({
   isPiP = false,
   isPiPSupported = false,
   onPiPToggle,
+  showMediaBadges = true,
   showSidebar = true,
   onToggleSidebar,
   activeSourceIndex = 0,
@@ -231,11 +237,17 @@ export function PlayerControls({
       className={clsx(
         "flex w-full flex-col gap-1 bg-[linear-gradient(to_top,rgba(2,8,23,0.98)_0%,rgba(8,22,51,0.9)_46%,rgba(21,27,69,0.48)_72%,transparent_100%)] pt-4 pr-[max(0.375rem,env(safe-area-inset-right))] pb-1 pl-[max(0.375rem,env(safe-area-inset-left))] md:gap-2 md:pt-9 md:pb-3 md:pl-[max(0.75rem,env(safe-area-inset-left))]",
         showSidebar ? "md:pr-3" : "md:pr-[max(0.75rem,env(safe-area-inset-right))]",
+        "[@container_video_(max-height:_320px)]:gap-0.5 [@container_video_(max-height:_320px)]:pt-2 [@container_video_(max-height:_320px)]:pb-0.5 md:[@container_video_(max-height:_320px)]:gap-0.5 md:[@container_video_(max-height:_320px)]:pt-2 md:[@container_video_(max-height:_320px)]:pb-0.5 [@container_video_(max-height:_220px)]:pt-1 md:[@container_video_(max-height:_220px)]:pt-1",
       )}
     >
       {/* Program Info */}
       {currentProgram && (
-        <div className="flex min-w-0 items-center justify-between gap-1 text-xs leading-tight tracking-[0.01em] text-blue-50/80 md:gap-2 md:text-sm md:leading-normal">
+        <div
+          className={clsx(
+            "flex min-w-0 items-center justify-between gap-1 text-xs leading-tight tracking-[0.01em] text-blue-50/80 md:gap-2 md:text-sm md:leading-normal",
+            "md:[@container_video_(max-height:_320px)]:text-xs md:[@container_video_(max-height:_320px)]:leading-tight [@container_video_(max-height:_220px)]:hidden",
+          )}
+        >
           <div className="min-w-0 flex-1 truncate">
             <span className="font-medium text-blue-100">{formatTime(startTime)}</span>
             <span className="mx-1 text-blue-100/30 md:mx-2">|</span>
@@ -257,6 +269,7 @@ export function PlayerControls({
           aria-label={t("seekTo")}
           className={clsx(
             "group relative h-1.5 rounded-full bg-blue-50/15 shadow-[inset_0_1px_3px_rgba(0,0,0,0.45)] ring-1 ring-white/10 transition-[height,box-shadow] duration-150 md:h-2",
+            "[@container_video_(max-height:_320px)]:h-1 md:[@container_video_(max-height:_320px)]:h-1",
             isCatchupSupported
               ? "cursor-pointer hover:h-2 hover:shadow-[0_0_20px_rgba(59,130,246,0.16),inset_0_1px_3px_rgba(0,0,0,0.45)] md:hover:h-3"
               : "cursor-default",
@@ -302,17 +315,26 @@ export function PlayerControls({
       )}
 
       {/* Control Bar */}
-      <div className="flex min-h-10 min-w-0 items-center justify-between gap-0.5 md:min-h-14 md:gap-1">
+      <div
+        className={clsx(
+          "flex min-h-10 min-w-0 items-center justify-between gap-0.5 md:min-h-14 md:gap-1",
+          "[@container_video_(max-height:_320px)]:min-h-8 md:[@container_video_(max-height:_320px)]:min-h-8",
+        )}
+      >
         {/* Left Controls */}
         <div className="flex min-w-0 flex-1 items-center gap-0 sm:gap-1 md:gap-3">
           {/* Play/Pause */}
           <button
             type="button"
             onClick={onPlayPause}
-            className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1 md:p-2")}
+            className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1 md:p-2", COMPACT_BUTTON_CLASS)}
             title={isPlaying ? t("pause") : t("play")}
           >
-            {isPlaying ? <Pause className="h-4 w-4 md:h-7 md:w-7" /> : <Play className="h-4 w-4 md:h-7 md:w-7" />}
+            {isPlaying ? (
+              <Pause className={clsx("h-4 w-4 md:h-7 md:w-7", COMPACT_ICON_CLASS)} />
+            ) : (
+              <Play className={clsx("h-4 w-4 md:h-7 md:w-7", COMPACT_ICON_CLASS)} />
+            )}
           </button>
 
           {/* Volume */}
@@ -320,15 +342,15 @@ export function PlayerControls({
             <button
               type="button"
               onClick={onMuteToggle}
-              className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1 md:p-2")}
+              className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1 md:p-2", COMPACT_BUTTON_CLASS)}
               title={isMuted ? t("unmute") : t("mute")}
             >
               {isMuted || volume === 0 ? (
-                <VolumeX className="h-4 w-4 md:h-7 md:w-7" />
+                <VolumeX className={clsx("h-4 w-4 md:h-7 md:w-7", COMPACT_ICON_CLASS)} />
               ) : volume < 0.5 ? (
-                <Volume1 className="h-4 w-4 md:h-7 md:w-7" />
+                <Volume1 className={clsx("h-4 w-4 md:h-7 md:w-7", COMPACT_ICON_CLASS)} />
               ) : (
-                <Volume2 className="h-4 w-4 md:h-7 md:w-7" />
+                <Volume2 className={clsx("h-4 w-4 md:h-7 md:w-7", COMPACT_ICON_CLASS)} />
               )}
             </button>
 
@@ -368,14 +390,16 @@ export function PlayerControls({
             )}
           </div>
 
-          <div className="ml-1 mr-1 flex h-7 min-w-0 basis-0 flex-1 items-center overflow-hidden md:ml-2 md:mr-2 md:h-12">
-            <PlayerMediaBadges
-              mediaInfo={mediaInfo}
-              locale={locale}
-              renderState={renderState}
-              autoDeinterlace={autoDeinterlace}
-            />
-          </div>
+          {showMediaBadges && (
+            <div className="ml-1 mr-1 flex h-7 min-w-0 basis-0 flex-1 items-center overflow-hidden md:ml-2 md:mr-2 md:h-12">
+              <PlayerMediaBadges
+                mediaInfo={mediaInfo}
+                locale={locale}
+                renderState={renderState}
+                autoDeinterlace={autoDeinterlace}
+              />
+            </div>
+          )}
         </div>
 
         {/* Right Controls */}
@@ -450,13 +474,13 @@ export function PlayerControls({
           <button
             type="button"
             onClick={onFullscreen}
-            className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1 md:p-2")}
+            className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1 md:p-2", COMPACT_BUTTON_CLASS)}
             title={isFullscreen ? t("exitFullscreen") : t("fullscreen")}
           >
             {isFullscreen ? (
-              <Minimize className="h-4 w-4 md:h-6 md:w-6" />
+              <Minimize className={clsx("h-4 w-4 md:h-6 md:w-6", COMPACT_ICON_CLASS)} />
             ) : (
-              <Maximize className="h-4 w-4 md:h-6 md:w-6" />
+              <Maximize className={clsx("h-4 w-4 md:h-6 md:w-6", COMPACT_ICON_CLASS)} />
             )}
           </button>
 
@@ -465,10 +489,10 @@ export function PlayerControls({
             <button
               type="button"
               onClick={onPiPToggle}
-              className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1 md:p-2")}
+              className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "cursor-pointer p-1 md:p-2", COMPACT_BUTTON_CLASS)}
               title={t("pictureInPicture")}
             >
-              <PictureInPicture className="h-4 w-4 md:h-6 md:w-6" />
+              <PictureInPicture className={clsx("h-4 w-4 md:h-6 md:w-6", COMPACT_ICON_CLASS)} />
             </button>
           )}
 
@@ -477,13 +501,17 @@ export function PlayerControls({
             <button
               type="button"
               onClick={onToggleSidebar}
-              className={clsx(PLAYER_CONTROL_BUTTON_CLASS, "hidden cursor-pointer p-1.5 md:flex md:p-2")}
+              className={clsx(
+                PLAYER_CONTROL_BUTTON_CLASS,
+                "hidden cursor-pointer p-1.5 md:flex md:p-2",
+                COMPACT_BUTTON_CLASS,
+              )}
               title={showSidebar ? t("hideSidebar") : t("showSidebar")}
             >
               {showSidebar ? (
-                <PanelRightClose className="h-5 w-5 md:h-6 md:w-6" />
+                <PanelRightClose className={clsx("h-5 w-5 md:h-6 md:w-6", COMPACT_ICON_CLASS)} />
               ) : (
-                <PanelRightOpen className="h-5 w-5 md:h-6 md:w-6" />
+                <PanelRightOpen className={clsx("h-5 w-5 md:h-6 md:w-6", COMPACT_ICON_CLASS)} />
               )}
             </button>
           )}

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -202,25 +202,30 @@ function PlayerTopLeftOverlay({
     <div
       className={clsx(
         PLAYER_OVERLAY_SURFACE_CLASS,
-        "absolute top-4 left-4 z-10 max-w-[calc(100%-2rem)] rounded-xl px-2 py-1.5 transition-opacity duration-300 md:top-8 md:left-8 md:px-3 md:py-2",
+        "absolute top-4 left-4 z-10 max-w-[calc(100%-2rem)] rounded-xl px-2 py-1.5 transition-opacity duration-300 md:top-8 md:left-8 md:px-3 md:py-2 [@container_video_(max-height:_320px)]:top-2 [@container_video_(max-height:_320px)]:left-2 [@container_video_(max-height:_320px)]:rounded-lg [@container_video_(max-height:_320px)]:px-1.5 [@container_video_(max-height:_320px)]:py-1 md:[@container_video_(max-height:_320px)]:top-2 md:[@container_video_(max-height:_320px)]:left-2 md:[@container_video_(max-height:_320px)]:px-1.5 md:[@container_video_(max-height:_320px)]:py-1 [@container_video_(max-height:_220px)]:top-1 [@container_video_(max-height:_220px)]:left-1 md:[@container_video_(max-height:_220px)]:top-1 md:[@container_video_(max-height:_220px)]:left-1",
         visible ? "opacity-100" : "opacity-0 pointer-events-none",
       )}
     >
       <PlayerSelectedGlassLayers />
-      <div className="relative z-10 flex min-w-0 items-center gap-1.5 md:gap-2">
-        <span className="shrink-0 font-medium text-xs text-blue-50 tabular-nums drop-shadow-sm md:text-base">
+      <div className="relative z-10 flex min-w-0 items-center gap-1.5 md:gap-2 [@container_video_(max-height:_320px)]:gap-1 md:[@container_video_(max-height:_320px)]:gap-1">
+        <span className="shrink-0 font-medium text-xs text-blue-50 tabular-nums drop-shadow-sm md:text-base md:[@container_video_(max-height:_320px)]:text-xs">
           {time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
         </span>
         {loading && (
           <>
-            <span className="shrink-0 text-blue-100/35 text-xs md:text-sm" aria-hidden="true">
+            <span
+              className="shrink-0 text-blue-100/35 text-xs md:text-sm md:[@container_video_(max-height:_320px)]:text-xs"
+              aria-hidden="true"
+            >
               ·
             </span>
-            <div className="relative h-3 w-3 shrink-0 md:h-3.5 md:w-3.5">
+            <div className="relative h-3 w-3 shrink-0 md:h-3.5 md:w-3.5 md:[@container_video_(max-height:_320px)]:h-3 md:[@container_video_(max-height:_320px)]:w-3">
               <div className="absolute inset-0 rounded-full border border-blue-100/25" />
               <div className="absolute inset-0 animate-spin rounded-full border border-blue-200 border-t-transparent shadow-[0_0_8px_rgba(147,197,253,0.5)]" />
             </div>
-            <span className="min-w-0 truncate text-blue-50/70 text-xs md:text-sm">{loadingText}</span>
+            <span className="min-w-0 truncate text-blue-50/70 text-xs md:text-sm md:[@container_video_(max-height:_320px)]:text-xs">
+              {loadingText}
+            </span>
           </>
         )}
       </div>
@@ -1730,14 +1735,14 @@ export function VideoPlayer({
       {channel && (
         <div
           className={clsx(
-            "absolute top-4 right-4 md:top-8 md:right-8 z-10 flex flex-col gap-2 md:gap-3 items-end transition-opacity duration-300",
+            "absolute top-4 right-4 z-10 flex flex-col items-end gap-2 transition-opacity duration-300 md:top-8 md:right-8 md:gap-3 [@container_video_(max-height:_320px)]:top-2 [@container_video_(max-height:_320px)]:right-2 [@container_video_(max-height:_320px)]:gap-1 md:[@container_video_(max-height:_320px)]:top-2 md:[@container_video_(max-height:_320px)]:right-2 md:[@container_video_(max-height:_320px)]:gap-1 [@container_video_(max-height:_220px)]:top-1 [@container_video_(max-height:_220px)]:right-1 md:[@container_video_(max-height:_220px)]:top-1 md:[@container_video_(max-height:_220px)]:right-1",
             showControls ? "opacity-100" : "opacity-0 pointer-events-none",
           )}
         >
           <div
             className={clsx(
               PLAYER_OVERLAY_SURFACE_CLASS,
-              "relative flex max-w-[calc(100vw-2rem)] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-xl px-2 py-1.5 md:max-w-none md:gap-2 md:px-3 md:py-2",
+              "relative flex max-w-[calc(100vw-2rem)] flex-col items-center justify-center gap-1.5 overflow-hidden rounded-xl px-2 py-1.5 md:max-w-none md:gap-2 md:px-3 md:py-2 [@container_video_(max-height:_320px)]:gap-1 [@container_video_(max-height:_320px)]:rounded-lg [@container_video_(max-height:_320px)]:px-1.5 [@container_video_(max-height:_320px)]:py-1 md:[@container_video_(max-height:_320px)]:gap-1 md:[@container_video_(max-height:_320px)]:px-1.5 md:[@container_video_(max-height:_320px)]:py-1",
             )}
           >
             <PlayerSelectedGlassLayers />
@@ -1746,17 +1751,17 @@ export function VideoPlayer({
                 src={channel.logo}
                 alt={channel.name}
                 referrerPolicy="no-referrer"
-                className="relative z-10 h-8 w-20 object-contain drop-shadow-[0_0_14px_rgba(147,197,253,0.2)] md:h-14 md:w-36"
+                className="relative z-10 h-8 w-20 object-contain drop-shadow-[0_0_14px_rgba(147,197,253,0.2)] md:h-14 md:w-36 [@container_video_(max-height:_320px)]:h-6 [@container_video_(max-height:_320px)]:w-16 md:[@container_video_(max-height:_320px)]:h-6 md:[@container_video_(max-height:_320px)]:w-16 [@container_video_(max-height:_220px)]:hidden"
                 onError={(e) => {
                   (e.target as HTMLImageElement).style.display = "none";
                 }}
               />
             )}
             <div className="relative z-10 flex w-full min-w-0 items-center justify-center">
-              <div className="flex min-w-0 items-center gap-1.5 md:gap-2">
+              <div className="flex min-w-0 items-center gap-1.5 md:gap-2 [@container_video_(max-height:_320px)]:gap-1 md:[@container_video_(max-height:_320px)]:gap-1">
                 <span
                   className={clsx(
-                    "shrink-0 rounded-md px-1 py-0.5 font-semibold text-[10px] transition-[color,background-color,box-shadow,scale] duration-300 md:px-1.5 md:text-xs",
+                    "shrink-0 rounded-md px-1 py-0.5 font-semibold text-[10px] transition-[color,background-color,box-shadow,scale] duration-300 md:px-1.5 md:text-xs md:[@container_video_(max-height:_320px)]:px-1 md:[@container_video_(max-height:_320px)]:text-[10px]",
                     digitBuffer
                       ? "scale-110 bg-[linear-gradient(135deg,#3b82f6,#6366f1)] text-white shadow-[0_0_20px_rgba(59,130,246,0.45)] ring-2 ring-blue-200/40"
                       : "bg-blue-100/10 text-blue-50/65 ring-1 ring-blue-100/10",
@@ -1764,11 +1769,15 @@ export function VideoPlayer({
                 >
                   {digitBuffer || channel.id}
                 </span>
-                <h2 className="truncate font-bold text-white text-xs tracking-[0.01em] md:text-base">{channel.name}</h2>
+                <h2 className="truncate font-bold text-white text-xs tracking-[0.01em] md:text-base md:[@container_video_(max-height:_320px)]:text-xs">
+                  {channel.name}
+                </h2>
                 {channel.groups.length > 0 && (
                   <>
-                    <span className="hidden text-blue-100/35 text-xs sm:inline md:text-sm">·</span>
-                    <div className="hidden truncate text-blue-50/65 text-xs sm:block md:text-sm">
+                    <span className="hidden text-blue-100/35 text-xs sm:inline md:text-sm [@container_video_(max-height:_320px)]:hidden md:[@container_video_(max-height:_320px)]:hidden">
+                      ·
+                    </span>
+                    <div className="hidden truncate text-blue-50/65 text-xs sm:block md:text-sm [@container_video_(max-height:_320px)]:hidden md:[@container_video_(max-height:_320px)]:hidden">
                       {channel.groups.join(" / ")}
                     </div>
                   </>

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1885,6 +1885,7 @@ export function VideoPlayer({
             isPiP={isPiP}
             isPiPSupported={isPictureInPictureSupported()}
             onPiPToggle={handlePiPToggle}
+            showMediaBadges={!isDocumentPiP}
             activeSourceIndex={activeSourceIndex}
             onSourceChange={onSourceChange}
           />

--- a/web-ui/src/lib/document-picture-in-picture.ts
+++ b/web-ui/src/lib/document-picture-in-picture.ts
@@ -48,7 +48,7 @@ type DocumentPiPWindowSize = {
 };
 
 type DocumentPiPWindowOptions = DocumentPiPWindowSize & {
-  preferInitialWindowPlacement: true;
+  preferInitialWindowPlacement: false;
 };
 
 export function getDocumentPiPWindowOptions(playerElement: HTMLElement): DocumentPiPWindowOptions {
@@ -57,7 +57,7 @@ export function getDocumentPiPWindowOptions(playerElement: HTMLElement): Documen
   const width = Math.round(Math.min(Math.max(sourceWidth, DOCUMENT_PIP_MIN_WIDTH), DOCUMENT_PIP_MAX_WIDTH));
 
   return {
-    preferInitialWindowPlacement: true,
+    preferInitialWindowPlacement: false,
     width,
     height: Math.round(width / DOCUMENT_PIP_ASPECT_RATIO),
   };


### PR DESCRIPTION
## Summary

- allow Document Picture-in-Picture windows to reuse the user's previous placement and size
- hide media badges while rendering controls inside Document PiP
- compact player controls automatically when the player container height is small, including mobile, embedded, and PiP layouts
- tighten the top-left time/loading overlay and top-right channel overlay at small heights, including their edge spacing, typography, padding, and channel artwork

## Validation

- `pnpm exec biome check web-ui/src/components/player/player-controls.tsx web-ui/src/components/player/video-player.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm exec vite build web-ui`