### PR TITLE
feat(web-ui): add draggable player progress

### DIFF
--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -322,6 +322,8 @@ export function PlayerControls({
             isCatchupSupported
               ? "cursor-pointer hover:h-2 hover:shadow-[0_0_20px_rgba(59,130,246,0.16),inset_0_1px_3px_rgba(0,0,0,0.45)] md:hover:h-3"
               : "cursor-default",
+            isScrubbing &&
+              "h-2 [@container_video_(max-height:_320px)]:h-2 md:h-3 md:[@container_video_(max-height:_320px)]:h-2",
           )}
           onPointerDown={isCatchupSupported ? handlePointerDown : undefined}
           onPointerMove={isCatchupSupported ? handlePointerMove : undefined}

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -33,6 +33,8 @@ interface PlayerControlsProps {
   isLive: boolean;
   // Callback when user seeks to a new position
   onSeek: (seekTime: Date) => void;
+  // Keep the player controls visible while the user scrubs the timeline
+  onScrubbingChange: (isScrubbing: boolean) => void;
   // Locale for translations
   locale: Locale;
   // Current video playback time from video element (in seconds)
@@ -74,6 +76,7 @@ export function PlayerControls({
   currentProgram,
   isLive,
   onSeek,
+  onScrubbingChange,
   locale,
   currentTime,
   mediaInfo,
@@ -99,6 +102,8 @@ export function PlayerControls({
 }: PlayerControlsProps) {
   const t = usePlayerTranslation(locale);
   const progressBarRef = useRef<HTMLDivElement>(null);
+  const activePointerIdRef = useRef<number | null>(null);
+  const [scrubPosition, setScrubPosition] = useState<number | null>(null);
   const [hoverPosition, setHoverPosition] = useState<number | null>(null);
 
   // Check if any source on this channel supports catchup
@@ -181,56 +186,96 @@ export function PlayerControls({
     [startTime, duration, programTimeline],
   );
 
-  const handleSeek = useCallback(
-    (e: React.MouseEvent | React.TouchEvent) => {
-      // Only allow seeking if catchup is supported
-      if (!isCatchupSupported) return;
-      if (!progressBarRef.current) return;
+  const getPositionFromClientX = useCallback((clientX: number): number | null => {
+    const progressBar = progressBarRef.current;
+    if (!progressBar) return null;
 
-      const rect = progressBarRef.current.getBoundingClientRect();
-      let clientX: number;
-
-      if ("touches" in e) {
-        clientX = e.touches[0].clientX;
-      } else {
-        clientX = e.clientX;
-      }
-
-      const percentage = Math.min(Math.max(((clientX - rect.left) / rect.width) * 100, 0), 100);
-      const seekTime = getTimeAtPosition(percentage);
-      onSeek(seekTime);
-    },
-    [isCatchupSupported, getTimeAtPosition, onSeek],
-  );
-
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      handleSeek(e);
-    },
-    [handleSeek],
-  );
-
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      // Only show hover effects if catchup is supported
-      if (!isCatchupSupported) return;
-      if (!progressBarRef.current) return;
-
-      const rect = progressBarRef.current.getBoundingClientRect();
-      const percentage = Math.min(Math.max(((e.clientX - rect.left) / rect.width) * 100, 0), 100);
-      setHoverPosition(percentage);
-    },
-    [isCatchupSupported],
-  );
-
-  const handleMouseLeave = useCallback(() => {
-    setHoverPosition(null);
+    const rect = progressBar.getBoundingClientRect();
+    if (rect.width === 0) return null;
+    return Math.min(Math.max(((clientX - rect.left) / rect.width) * 100, 0), 100);
   }, []);
 
-  const hoverTime = useMemo(() => {
-    if (hoverPosition === null) return null;
-    return getTimeAtPosition(hoverPosition);
-  }, [hoverPosition, getTimeAtPosition]);
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!isCatchupSupported || !event.isPrimary || activePointerIdRef.current !== null) return;
+      if (event.pointerType === "mouse" && event.button !== 0) return;
+
+      const position = getPositionFromClientX(event.clientX);
+      if (position === null) return;
+
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      activePointerIdRef.current = event.pointerId;
+      setHoverPosition(null);
+      setScrubPosition(position);
+      onScrubbingChange(true);
+    },
+    [getPositionFromClientX, isCatchupSupported, onScrubbingChange],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!isCatchupSupported) return;
+
+      const position = getPositionFromClientX(event.clientX);
+      if (position === null) return;
+
+      if (activePointerIdRef.current === event.pointerId) {
+        event.preventDefault();
+        setScrubPosition(position);
+      } else if (activePointerIdRef.current === null && event.pointerType !== "touch") {
+        setHoverPosition(position);
+      }
+    },
+    [getPositionFromClientX, isCatchupSupported],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (activePointerIdRef.current !== event.pointerId) return;
+
+      event.preventDefault();
+      const position = getPositionFromClientX(event.clientX);
+      activePointerIdRef.current = null;
+      setScrubPosition(null);
+      onScrubbingChange(false);
+
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      if (position !== null) onSeek(getTimeAtPosition(position));
+    },
+    [getPositionFromClientX, getTimeAtPosition, onScrubbingChange, onSeek],
+  );
+
+  const cancelScrubbing = useCallback(
+    (pointerId: number) => {
+      if (activePointerIdRef.current !== pointerId) return;
+      activePointerIdRef.current = null;
+      setScrubPosition(null);
+      onScrubbingChange(false);
+    },
+    [onScrubbingChange],
+  );
+
+  const handlePointerCancel = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      cancelScrubbing(event.pointerId);
+    },
+    [cancelScrubbing],
+  );
+
+  const handlePointerLeave = useCallback(() => {
+    if (activePointerIdRef.current === null) setHoverPosition(null);
+  }, []);
+
+  const displayPosition = scrubPosition ?? progress;
+  const previewPosition = scrubPosition ?? hoverPosition;
+  const previewTime = useMemo(() => {
+    if (previewPosition === null) return null;
+    return getTimeAtPosition(previewPosition);
+  }, [previewPosition, getTimeAtPosition]);
+  const isScrubbing = scrubPosition !== null;
 
   return (
     <div
@@ -265,40 +310,47 @@ export function PlayerControls({
           tabIndex={isCatchupSupported ? 0 : -1}
           aria-valuemin={0}
           aria-valuemax={100}
-          aria-valuenow={Math.round(progress)}
+          aria-valuenow={Math.round(displayPosition)}
+          aria-valuetext={formatTime(getTimeAtPosition(displayPosition), true)}
           aria-label={t("seekTo")}
           className={clsx(
-            "group relative h-1.5 rounded-full bg-blue-50/15 shadow-[inset_0_1px_3px_rgba(0,0,0,0.45)] ring-1 ring-white/10 transition-[height,box-shadow] duration-150 md:h-2",
+            "group relative h-1.5 touch-none select-none rounded-full bg-blue-50/15 shadow-[inset_0_1px_3px_rgba(0,0,0,0.45)] ring-1 ring-white/10 transition-[height,box-shadow] duration-150 before:absolute before:-inset-y-3 before:inset-x-0 before:content-[''] md:h-2",
             "[@container_video_(max-height:_320px)]:h-1 md:[@container_video_(max-height:_320px)]:h-1",
             isCatchupSupported
               ? "cursor-pointer hover:h-2 hover:shadow-[0_0_20px_rgba(59,130,246,0.16),inset_0_1px_3px_rgba(0,0,0,0.45)] md:hover:h-3"
               : "cursor-default",
           )}
-          onMouseDown={isCatchupSupported ? handleMouseDown : undefined}
-          onMouseMove={isCatchupSupported ? handleMouseMove : undefined}
-          onMouseLeave={isCatchupSupported ? handleMouseLeave : undefined}
+          onPointerDown={isCatchupSupported ? handlePointerDown : undefined}
+          onPointerMove={isCatchupSupported ? handlePointerMove : undefined}
+          onPointerUp={isCatchupSupported ? handlePointerUp : undefined}
+          onPointerCancel={isCatchupSupported ? handlePointerCancel : undefined}
+          onLostPointerCapture={isCatchupSupported ? handlePointerCancel : undefined}
+          onPointerLeave={isCatchupSupported ? handlePointerLeave : undefined}
         >
           <div
-            className="absolute top-0 left-0 h-full rounded-full bg-[linear-gradient(90deg,#3b82f6_0%,#38bdf8_52%,#6366f1_100%)] shadow-[0_0_18px_rgba(59,130,246,0.4)] transition-[width] duration-150"
-            style={{ width: `${progress}%` }}
+            className={clsx(
+              "absolute top-0 left-0 h-full rounded-full bg-[linear-gradient(90deg,#3b82f6_0%,#38bdf8_52%,#6366f1_100%)] shadow-[0_0_18px_rgba(59,130,246,0.4)]",
+              !isScrubbing && "transition-[width] duration-150",
+            )}
+            style={{ width: `${displayPosition}%` }}
           />
 
-          {isCatchupSupported && hoverPosition !== null && (
+          {isCatchupSupported && previewPosition !== null && (
             <>
               <div
                 className="absolute top-0 h-full w-0.5 bg-blue-50/80 shadow-[0_0_8px_rgba(147,197,253,0.7)]"
-                style={{ left: `${hoverPosition}%` }}
+                style={{ left: `${previewPosition}%` }}
               />
-              {hoverTime && (
+              {previewTime && (
                 <div
                   className={clsx(
                     PLAYER_OVERLAY_SURFACE_CLASS,
-                    "absolute bottom-full mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg px-2.5 py-1 text-xs font-medium text-blue-50",
+                    "absolute bottom-full mb-4 -translate-x-1/2 whitespace-nowrap rounded-lg px-2.5 py-1 text-xs font-medium text-blue-50 md:mb-2",
                   )}
-                  style={{ left: `${hoverPosition}%` }}
+                  style={{ left: `clamp(2.5rem, ${previewPosition}%, calc(100% - 2.5rem))` }}
                 >
                   <PlayerSelectedGlassLayers />
-                  <span className="relative z-10">{formatTime(hoverTime, true)}</span>
+                  <span className="relative z-10">{formatTime(previewTime, true)}</span>
                 </div>
               )}
             </>
@@ -306,10 +358,13 @@ export function PlayerControls({
 
           <div
             className={clsx(
-              "absolute top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-blue-300 shadow-[0_0_16px_rgba(147,197,253,0.75)] transition-[left,width,height] duration-150 md:h-3 md:w-3",
-              isCatchupSupported && "group-hover:h-3 group-hover:w-3 md:group-hover:h-4 md:group-hover:w-4",
+              "absolute top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-blue-300 shadow-[0_0_16px_rgba(147,197,253,0.75)]",
+              isScrubbing ? "h-4 w-4" : "h-2.5 w-2.5 transition-[left,width,height] duration-150 md:h-3 md:w-3",
+              isCatchupSupported &&
+                !isScrubbing &&
+                "group-hover:h-3 group-hover:w-3 md:group-hover:h-4 md:group-hover:w-4",
             )}
-            style={{ left: `${progress}%` }}
+            style={{ left: `${displayPosition}%` }}
           />
         </div>
       )}

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -314,7 +314,9 @@ export function PlayerControls({
           aria-valuemin={0}
           aria-valuemax={100}
           aria-valuenow={Math.round(displayPosition)}
-          aria-valuetext={formatTime(getTimeAtPosition(displayPosition), true)}
+          aria-valuetext={
+            isScrubbing && previewGoesLive ? t("goLive") : formatTime(getTimeAtPosition(displayPosition), true)
+          }
           aria-label={t("seekTo")}
           className={clsx(
             "group relative h-1.5 touch-none select-none rounded-full bg-blue-50/15 shadow-[inset_0_1px_3px_rgba(0,0,0,0.45)] ring-1 ring-white/10 transition-[height,box-shadow] duration-150 before:absolute before:-inset-y-3 before:inset-x-0 before:content-[''] md:h-2",

--- a/web-ui/src/components/player/player-controls.tsx
+++ b/web-ui/src/components/player/player-controls.tsx
@@ -18,7 +18,7 @@ import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import type { Locale } from "../../lib/locale";
 import { createProgramTimeline, programProgressToWallClock } from "../../lib/program-timeline";
 import type { PlayerMediaInfo, PlayerRenderState } from "../../mpegts";
-import { mseToWallClock } from "../../mpegts/player/wall-clock";
+import { isNearLiveWallClock, type LiveSessionAnchor, mseToWallClock } from "../../mpegts/player/wall-clock";
 import type { Channel, EPGProgram } from "../../types/player";
 import { PLAYER_CONTROL_BUTTON_CLASS, PLAYER_OVERLAY_SURFACE_CLASS } from "./classnames";
 import { PlayerMediaBadges } from "./player-media-badges";
@@ -45,6 +45,7 @@ interface PlayerControlsProps {
   autoDeinterlace: boolean;
   // The absolute time of the last seek position (null for live mode)
   seekStartTime: Date;
+  liveSessionAnchor: LiveSessionAnchor | null;
   // Video element controls
   isPlaying: boolean;
   onPlayPause: () => void;
@@ -83,6 +84,7 @@ export function PlayerControls({
   renderState,
   autoDeinterlace,
   seekStartTime,
+  liveSessionAnchor,
   isPlaying,
   onPlayPause,
   volume,
@@ -275,6 +277,7 @@ export function PlayerControls({
     if (previewPosition === null) return null;
     return getTimeAtPosition(previewPosition);
   }, [previewPosition, getTimeAtPosition]);
+  const previewGoesLive = previewTime ? isNearLiveWallClock(previewTime, liveSessionAnchor, seekStartTime) : false;
   const isScrubbing = scrubPosition !== null;
 
   return (
@@ -350,7 +353,7 @@ export function PlayerControls({
                   style={{ left: `clamp(2.5rem, ${previewPosition}%, calc(100% - 2.5rem))` }}
                 >
                   <PlayerSelectedGlassLayers />
-                  <span className="relative z-10">{formatTime(previewTime, true)}</span>
+                  <span className="relative z-10">{previewGoesLive ? t("goLive") : formatTime(previewTime, true)}</span>
                 </div>
               )}
             </>

--- a/web-ui/src/components/player/settings-dropdown.tsx
+++ b/web-ui/src/components/player/settings-dropdown.tsx
@@ -41,11 +41,11 @@ function SettingsDropdownComponent({
   const t = usePlayerTranslation(locale);
 
   return (
-    <div>
+    <div className="size-8 [anchor-name:--player-settings-trigger] md:size-9">
       <button
         type="button"
         popoverTarget={SETTINGS_POPOVER_ID}
-        className="flex size-8 cursor-pointer items-center justify-center rounded-xl border border-transparent p-0 text-slate-500 transition-[color,background-color,border-color,box-shadow,transform] [anchor-name:--player-settings-trigger] motion-reduce:transition-none hover:border-blue-400/20 hover:bg-blue-400/10 hover:text-blue-700 hover:shadow-[0_0_18px_rgba(59,130,246,0.1)] motion-safe:active:scale-95 dark:text-slate-400 dark:hover:text-blue-200 md:size-9"
+        className="flex size-8 cursor-pointer items-center justify-center rounded-xl border border-transparent p-0 text-slate-500 transition-[color,background-color,border-color,box-shadow,transform] motion-reduce:transition-none hover:border-blue-400/20 hover:bg-blue-400/10 hover:text-blue-700 hover:shadow-[0_0_18px_rgba(59,130,246,0.1)] motion-safe:active:scale-95 dark:text-slate-400 dark:hover:text-blue-200 md:size-9"
         title={t("settings")}
       >
         <Settings className="h-5 w-5" />

--- a/web-ui/src/components/player/settings-dropdown.tsx
+++ b/web-ui/src/components/player/settings-dropdown.tsx
@@ -1,5 +1,5 @@
 import { Settings } from "lucide-react";
-import { memo, useEffect, useRef, useState } from "react";
+import { memo } from "react";
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import { LOCALE_OPTIONS, type Locale } from "../../lib/locale";
 import { THEME_LABEL_KEYS, THEME_MODES, type ThemeMode } from "../../types/ui";
@@ -24,6 +24,7 @@ const SETTING_SWITCH_CLASS = "min-h-6 gap-3 px-0.5";
 const SETTING_SWITCH_LABEL_CLASS = "flex-1 font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65";
 const SETTING_SWITCH_CONTROL_CLASS =
   "border-blue-900/10 bg-slate-200/75 shadow-inner data-[state=checked]:border-blue-300/35 data-[state=checked]:bg-blue-500 data-[state=checked]:shadow-[0_0_16px_rgba(59,130,246,0.24)] dark:border-blue-100/10 dark:bg-slate-800/80";
+const SETTINGS_POPOVER_ID = "player-settings-popover";
 
 function SettingsDropdownComponent({
   locale,
@@ -38,122 +39,109 @@ function SettingsDropdownComponent({
   onPictureEnhancementChange,
 }: SettingsDropdownProps) {
   const t = usePlayerTranslation(locale);
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [isOpen]);
 
   return (
-    <div className="relative" ref={dropdownRef}>
+    <div>
       <button
         type="button"
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex size-8 cursor-pointer items-center justify-center rounded-xl border border-transparent p-0 text-slate-500 transition-[color,background-color,border-color,box-shadow,transform] motion-reduce:transition-none hover:border-blue-400/20 hover:bg-blue-400/10 hover:text-blue-700 hover:shadow-[0_0_18px_rgba(59,130,246,0.1)] motion-safe:active:scale-95 dark:text-slate-400 dark:hover:text-blue-200 md:size-9"
+        popoverTarget={SETTINGS_POPOVER_ID}
+        className="flex size-8 cursor-pointer items-center justify-center rounded-xl border border-transparent p-0 text-slate-500 transition-[color,background-color,border-color,box-shadow,transform] [anchor-name:--player-settings-trigger] motion-reduce:transition-none hover:border-blue-400/20 hover:bg-blue-400/10 hover:text-blue-700 hover:shadow-[0_0_18px_rgba(59,130,246,0.1)] motion-safe:active:scale-95 dark:text-slate-400 dark:hover:text-blue-200 md:size-9"
         title={t("settings")}
       >
         <Settings className="h-5 w-5" />
       </button>
 
-      {isOpen && (
-        <div className="absolute top-full right-0 z-50 mt-1 w-52 max-w-[calc(100vw-1rem)] rounded-2xl border border-blue-900/12 bg-[linear-gradient(145deg,rgba(255,255,255,0.9),rgba(238,242,255,0.82))] shadow-[0_20px_55px_rgba(30,64,175,0.18),inset_0_1px_0_rgba(255,255,255,0.82)] backdrop-blur-2xl dark:border-blue-100/15 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.94),rgba(26,24,72,0.9))] dark:shadow-[0_22px_60px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]">
-          <div className="space-y-3.5 p-3">
-            {/* Language Select */}
-            <div>
-              <label htmlFor="player-settings-locale" className={SETTING_LABEL_CLASS}>
-                {t("language")}
-              </label>
-              <SelectBox
-                id="player-settings-locale"
-                value={locale}
-                onChange={(e) => onLocaleChange(e.target.value as Locale)}
-                containerClassName="w-full min-w-0"
-                aria-label={t("language")}
-              >
-                {LOCALE_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </SelectBox>
+      <div
+        id={SETTINGS_POPOVER_ID}
+        popover="auto"
+        className="fixed inset-auto m-0 mt-1 w-52 max-w-[calc(100vw-1rem)] rounded-2xl border border-blue-900/12 bg-[linear-gradient(145deg,rgba(255,255,255,0.9),rgba(238,242,255,0.82))] p-0 shadow-[0_20px_55px_rgba(30,64,175,0.18),inset_0_1px_0_rgba(255,255,255,0.82)] [position-anchor:--player-settings-trigger] [right:anchor(right)] [top:anchor(bottom)] backdrop-blur-2xl dark:border-blue-100/15 dark:bg-[linear-gradient(145deg,rgba(7,20,43,0.94),rgba(26,24,72,0.9))] dark:shadow-[0_22px_60px_rgba(1,7,24,0.62),inset_0_1px_0_rgba(255,255,255,0.08)]"
+      >
+        <div className="space-y-3.5 p-3">
+          {/* Language Select */}
+          <div>
+            <label htmlFor="player-settings-locale" className={SETTING_LABEL_CLASS}>
+              {t("language")}
+            </label>
+            <SelectBox
+              id="player-settings-locale"
+              value={locale}
+              onChange={(e) => onLocaleChange(e.target.value as Locale)}
+              containerClassName="w-full min-w-0"
+              aria-label={t("language")}
+            >
+              {LOCALE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </SelectBox>
+          </div>
+
+          {/* Theme Select */}
+          <div>
+            <label htmlFor="player-settings-theme" className={SETTING_LABEL_CLASS}>
+              {t("theme")}
+            </label>
+            <SelectBox
+              id="player-settings-theme"
+              value={theme}
+              onChange={(e) => onThemeChange(e.target.value as ThemeMode)}
+              containerClassName="w-full min-w-0"
+              aria-label={t("theme")}
+            >
+              {THEME_MODES.map((option) => (
+                <option key={option} value={option}>
+                  {t(THEME_LABEL_KEYS[option])}
+                </option>
+              ))}
+            </SelectBox>
+          </div>
+
+          {/* Seamless channel/source switch (dual-slot preload) */}
+          <LabeledSwitch
+            label={t("seamlessSwitch")}
+            checked={seamlessSwitch}
+            onCheckedChange={onSeamlessSwitchChange}
+            className={SETTING_SWITCH_CLASS}
+            labelClassName={SETTING_SWITCH_LABEL_CLASS}
+            switchClassName={SETTING_SWITCH_CONTROL_CLASS}
+          />
+
+          {/* Video processing group: deinterlace + picture enhancement.
+                Both only take effect for 1080p-and-below content, so the
+                resolution caveat is stated once as a shared group note. */}
+          <div className="space-y-3 border-blue-900/10 border-t pt-3.5 dark:border-blue-100/10">
+            <div className="px-0.5">
+              <span className="block font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">
+                {t("videoProcessing")}
+              </span>
+              <span className="mt-0.5 block text-[11px] text-slate-400 leading-4 dark:text-blue-50/35">
+                {t("resolutionLimitHint")}
+              </span>
             </div>
 
-            {/* Theme Select */}
-            <div>
-              <label htmlFor="player-settings-theme" className={SETTING_LABEL_CLASS}>
-                {t("theme")}
-              </label>
-              <SelectBox
-                id="player-settings-theme"
-                value={theme}
-                onChange={(e) => onThemeChange(e.target.value as ThemeMode)}
-                containerClassName="w-full min-w-0"
-                aria-label={t("theme")}
-              >
-                {THEME_MODES.map((option) => (
-                  <option key={option} value={option}>
-                    {t(THEME_LABEL_KEYS[option])}
-                  </option>
-                ))}
-              </SelectBox>
-            </div>
-
-            {/* Seamless channel/source switch (dual-slot preload) */}
+            {/* Automatic deinterlacing (heuristic detection, ≤1080 content only) */}
             <LabeledSwitch
-              label={t("seamlessSwitch")}
-              checked={seamlessSwitch}
-              onCheckedChange={onSeamlessSwitchChange}
+              label={t("deinterlace")}
+              checked={autoDeinterlace}
+              onCheckedChange={onAutoDeinterlaceChange}
               className={SETTING_SWITCH_CLASS}
               labelClassName={SETTING_SWITCH_LABEL_CLASS}
               switchClassName={SETTING_SWITCH_CONTROL_CLASS}
             />
 
-            {/* Video processing group: deinterlace + picture enhancement.
-                Both only take effect for 1080p-and-below content, so the
-                resolution caveat is stated once as a shared group note. */}
-            <div className="space-y-3 border-blue-900/10 border-t pt-3.5 dark:border-blue-100/10">
-              <div className="px-0.5">
-                <span className="block font-medium text-slate-600 text-xs leading-4 dark:text-blue-50/65">
-                  {t("videoProcessing")}
-                </span>
-                <span className="mt-0.5 block text-[11px] text-slate-400 leading-4 dark:text-blue-50/35">
-                  {t("resolutionLimitHint")}
-                </span>
-              </div>
-
-              {/* Automatic deinterlacing (heuristic detection, ≤1080 content only) */}
-              <LabeledSwitch
-                label={t("deinterlace")}
-                checked={autoDeinterlace}
-                onCheckedChange={onAutoDeinterlaceChange}
-                className={SETTING_SWITCH_CLASS}
-                labelClassName={SETTING_SWITCH_LABEL_CLASS}
-                switchClassName={SETTING_SWITCH_CONTROL_CLASS}
-              />
-
-              {/* Picture enhancement (WebGL post-processing inside the render gate) */}
-              <LabeledSwitch
-                label={t("pictureEnhancement")}
-                checked={pictureEnhancement}
-                onCheckedChange={onPictureEnhancementChange}
-                className={SETTING_SWITCH_CLASS}
-                labelClassName={SETTING_SWITCH_LABEL_CLASS}
-                switchClassName={SETTING_SWITCH_CONTROL_CLASS}
-              />
-            </div>
+            {/* Picture enhancement (WebGL post-processing inside the render gate) */}
+            <LabeledSwitch
+              label={t("pictureEnhancement")}
+              checked={pictureEnhancement}
+              onCheckedChange={onPictureEnhancementChange}
+              className={SETTING_SWITCH_CLASS}
+              labelClassName={SETTING_SWITCH_LABEL_CLASS}
+              switchClassName={SETTING_SWITCH_CONTROL_CLASS}
+            />
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -472,6 +472,18 @@ export function VideoPlayer({
     resetControlsTimer();
   }, [resetControlsTimer]);
 
+  const handleScrubbingChange = useCallback(
+    (isScrubbing: boolean) => {
+      if (hideControlsTimeoutRef.current) {
+        window.clearTimeout(hideControlsTimeoutRef.current);
+        hideControlsTimeoutRef.current = 0;
+      }
+      setShowControls(true);
+      if (!isScrubbing) resetControlsTimer();
+    },
+    [resetControlsTimer],
+  );
+
   const hideControlsImmediately = useCallback(() => {
     if (hideControlsTimeoutRef.current) {
       window.clearTimeout(hideControlsTimeoutRef.current);
@@ -1868,7 +1880,6 @@ export function VideoPlayer({
               ? "opacity-100"
               : "opacity-0 pointer-events-none has-focus-visible:opacity-100 has-focus-visible:pointer-events-auto",
           )}
-          onMouseEnter={showControlsImmediately}
         >
           <PlayerControls
             channel={channel}
@@ -1876,6 +1887,7 @@ export function VideoPlayer({
             currentProgram={currentProgram}
             isLive={isLive}
             onSeek={handleSeek}
+            onScrubbingChange={handleScrubbingChange}
             locale={locale}
             mediaInfo={slotMediaInfo[visibleSlotId]}
             renderState={slotRenderStates[visibleSlotId]}

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -1893,6 +1893,7 @@ export function VideoPlayer({
             renderState={slotRenderStates[visibleSlotId]}
             autoDeinterlace={autoDeinterlace}
             seekStartTime={streamStartTime}
+            liveSessionAnchor={liveSessionAnchor}
             isPlaying={isPlaying}
             onPlayPause={togglePlayPause}
             volume={volume}

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -189,6 +189,7 @@ function PlayerPage() {
   }, [currentChannel, activeSource, activeSourceIndex, streamStartTime, seekAtLiveEdge]);
 
   const handleVideoSeek = useCallback((seekTime: Date, goingLive: boolean) => {
+    setCurrentVideoTime(0);
     setSeekAtLiveEdge(goingLive);
     if (goingLive) {
       setStreamStartTime(new Date());


### PR DESCRIPTION
## Summary

Adds precise progress-bar scrubbing for desktop, touch, and pen input using Pointer Events and Pointer Capture. The player previews the target wall-clock time while dragging and performs a single seek on release, avoiding repeated catch-up stream reloads.

The controls remain visible during scrubbing, the touch target is enlarged without changing the visual track, and the preview stays within the timeline bounds. The settings menu now uses the native Popover API with CSS Anchor Positioning, removing manual open state and document-level outside-click handling.

## Validation

- `pnpm run lint:biome`
- `pnpm run type-check:tsc`
- `pnpm run web-ui:build`
- `git diff --check`

The generated `src/embedded_web_data.h` is intentionally excluded.