### PR TITLE
fix(web-player): improve TS bitrate reporting

### DIFF
--- a/web-ui/src/playback-engine/demux/pat-pmt-pes.ts
+++ b/web-ui/src/playback-engine/demux/pat-pmt-pes.ts
@@ -25,40 +25,10 @@ interface PIDToStreamTypeMap {
   [pid: number]: StreamType;
 }
 
-const MAXIMUM_BITRATE_DESCRIPTOR_TAG = 0x0e;
-const MAXIMUM_BITRATE_UNIT_BITS_PER_SECOND = 50 * 8;
-
-/** Read the largest ISO/IEC 13818-1 maximum_bitrate_descriptor in a descriptor loop. */
-export function parseMaximumBitrateDescriptor(data: Uint8Array, start: number, length: number): number | undefined {
-  const end = Math.min(data.byteLength, start + length);
-  let maximumBitrate: number | undefined;
-
-  for (let offset = start; offset + 2 <= end; ) {
-    const tag = data[offset];
-    const descriptorLength = data[offset + 1];
-    const descriptorEnd = offset + 2 + descriptorLength;
-    if (descriptorEnd > end) break;
-
-    if (tag === MAXIMUM_BITRATE_DESCRIPTOR_TAG && descriptorLength >= 3) {
-      const encodedValue = ((data[offset + 2] & 0x3f) << 16) | (data[offset + 3] << 8) | data[offset + 4];
-      const bitsPerSecond = encodedValue * MAXIMUM_BITRATE_UNIT_BITS_PER_SECOND;
-      if (bitsPerSecond > 0) {
-        maximumBitrate = Math.max(maximumBitrate ?? 0, bitsPerSecond);
-      }
-    }
-
-    offset = descriptorEnd;
-  }
-
-  return maximumBitrate;
-}
-
 export class PMT {
   program_number!: number;
   version_number!: number;
   pcr_pid!: number;
-  program_maximum_bitrate: number | undefined;
-  elementary_maximum_bitrates: Record<number, number> = {};
   // pid -> stream_type
   pid_stream_type: PIDToStreamTypeMap = {};
 

--- a/web-ui/src/playback-engine/demux/pat-pmt-pes.ts
+++ b/web-ui/src/playback-engine/demux/pat-pmt-pes.ts
@@ -25,10 +25,40 @@ interface PIDToStreamTypeMap {
   [pid: number]: StreamType;
 }
 
+const MAXIMUM_BITRATE_DESCRIPTOR_TAG = 0x0e;
+const MAXIMUM_BITRATE_UNIT_BITS_PER_SECOND = 50 * 8;
+
+/** Read the largest ISO/IEC 13818-1 maximum_bitrate_descriptor in a descriptor loop. */
+export function parseMaximumBitrateDescriptor(data: Uint8Array, start: number, length: number): number | undefined {
+  const end = Math.min(data.byteLength, start + length);
+  let maximumBitrate: number | undefined;
+
+  for (let offset = start; offset + 2 <= end; ) {
+    const tag = data[offset];
+    const descriptorLength = data[offset + 1];
+    const descriptorEnd = offset + 2 + descriptorLength;
+    if (descriptorEnd > end) break;
+
+    if (tag === MAXIMUM_BITRATE_DESCRIPTOR_TAG && descriptorLength >= 3) {
+      const encodedValue = ((data[offset + 2] & 0x3f) << 16) | (data[offset + 3] << 8) | data[offset + 4];
+      const bitsPerSecond = encodedValue * MAXIMUM_BITRATE_UNIT_BITS_PER_SECOND;
+      if (bitsPerSecond > 0) {
+        maximumBitrate = Math.max(maximumBitrate ?? 0, bitsPerSecond);
+      }
+    }
+
+    offset = descriptorEnd;
+  }
+
+  return maximumBitrate;
+}
+
 export class PMT {
   program_number!: number;
   version_number!: number;
   pcr_pid!: number;
+  program_maximum_bitrate: number | undefined;
+  elementary_maximum_bitrates: Record<number, number> = {};
   // pid -> stream_type
   pid_stream_type: PIDToStreamTypeMap = {};
 

--- a/web-ui/src/playback-engine/demux/ts-demuxer.ts
+++ b/web-ui/src/playback-engine/demux/ts-demuxer.ts
@@ -26,6 +26,7 @@ import {
   type PIDToSliceQueues,
   PMT,
   type ProgramToPMTMap,
+  parseMaximumBitrateDescriptor,
   SectionData,
   SliceQueue,
   StreamType,
@@ -115,6 +116,9 @@ export type OnErrorCallback = (type: DemuxErrorDetail, info: string) => void;
 export type OnTrackMetadataCallback = (type: string, metadata: unknown) => void;
 export type OnDataAvailableCallback = (audioTrack: unknown, videoTrack: unknown, force?: boolean) => void;
 export type OnTrackDiscontinuityCallback = (track: "audio" | "video") => void;
+export type OnMaximumBitrateCallback = (bitsPerSecond: number) => void;
+/** Reports the 90 kHz PCR base and byte position from the PMT-declared PCR PID. */
+export type OnPcrCallback = (pcrBase: number, bytePosition: number, discontinuity: boolean) => void;
 
 class TSDemuxer {
   private readonly TAG: string = "TSDemuxer";
@@ -123,6 +127,8 @@ class TSDemuxer {
   public onTrackMetadata: OnTrackMetadataCallback | null = null;
   public onDataAvailable: OnDataAvailableCallback | null = null;
   public onTrackDiscontinuity: OnTrackDiscontinuityCallback | null = null;
+  public onMaximumBitrate: OnMaximumBitrateCallback | null = null;
+  public onPcr: OnPcrCallback | null = null;
   /** Software audio decode support (MP2) */
   public onRawAudioData: ((frame: { codec: "mp2"; data: Uint8Array; pts: number }) => void) | null = null;
 
@@ -228,6 +234,8 @@ class TSDemuxer {
     this.onTrackMetadata = null;
     this.onDataAvailable = null;
     this.onTrackDiscontinuity = null;
+    this.onMaximumBitrate = null;
+    this.onPcr = null;
     this.onRawAudioData = null;
     this.soft_decode_audio_codec_ = null;
   }
@@ -485,7 +493,10 @@ class TSDemuxer {
           const PCR_flag = (data[5] & 0x10) >>> 4;
           if (PCR_flag) {
             // track PCR base for pts/dts wraparound detection
-            this.getPcrBase(data);
+            const pcrBase = this.getPcrBase(data);
+            if (is_pcr_pid) {
+              this.onPcr?.(pcrBase, file_position, adaptation_field_info.discontinuity_indicator === 1);
+            }
           }
         }
         if (adaptation_field_control === 0x02 || 5 + adaptation_field_length === 188) {
@@ -903,6 +914,7 @@ class TSDemuxer {
 
     pmt.pcr_pid = ((data[8] & 0x1f) << 8) | data[9];
     const program_info_length = ((data[10] & 0x0f) << 8) | data[11];
+    pmt.program_maximum_bitrate = parseMaximumBitrateDescriptor(data, 12, program_info_length);
 
     const info_start_index = 12 + program_info_length;
     const info_bytes = section_length - 9 - program_info_length - 4;
@@ -913,6 +925,10 @@ class TSDemuxer {
       const ES_info_length = ((data[i + 3] & 0x0f) << 8) | data[i + 4];
 
       pmt.pid_stream_type[elementary_PID] = stream_type;
+      const elementaryMaximumBitrate = parseMaximumBitrateDescriptor(data, i + 5, ES_info_length);
+      if (elementaryMaximumBitrate !== undefined) {
+        pmt.elementary_maximum_bitrates[elementary_PID] = elementaryMaximumBitrate;
+      }
 
       const already_has_video = pmt.common_pids.h264 || pmt.common_pids.h265;
       const already_has_audio =
@@ -969,6 +985,14 @@ class TSDemuxer {
         Log.v(this.TAG, `Parsed first PMT: ${JSON.stringify(pmt)}`);
       }
       this.pmt_ = pmt;
+      const elementaryMaximumBitrate = Object.values(pmt.elementary_maximum_bitrates).reduce(
+        (sum, bitsPerSecond) => sum + bitsPerSecond,
+        0,
+      );
+      const maximumBitrate = pmt.program_maximum_bitrate ?? elementaryMaximumBitrate;
+      if (maximumBitrate > 0) {
+        this.onMaximumBitrate?.(maximumBitrate);
+      }
       if (pmt.common_pids.h264 || pmt.common_pids.h265) {
         this.has_video_ = true;
       }

--- a/web-ui/src/playback-engine/demux/ts-demuxer.ts
+++ b/web-ui/src/playback-engine/demux/ts-demuxer.ts
@@ -26,7 +26,6 @@ import {
   type PIDToSliceQueues,
   PMT,
   type ProgramToPMTMap,
-  parseMaximumBitrateDescriptor,
   SectionData,
   SliceQueue,
   StreamType,
@@ -116,7 +115,6 @@ export type OnErrorCallback = (type: DemuxErrorDetail, info: string) => void;
 export type OnTrackMetadataCallback = (type: string, metadata: unknown) => void;
 export type OnDataAvailableCallback = (audioTrack: unknown, videoTrack: unknown, force?: boolean) => void;
 export type OnTrackDiscontinuityCallback = (track: "audio" | "video") => void;
-export type OnMaximumBitrateCallback = (bitsPerSecond: number) => void;
 /** Reports the 90 kHz PCR base and byte position from the PMT-declared PCR PID. */
 export type OnPcrCallback = (pcrBase: number, bytePosition: number, discontinuity: boolean) => void;
 
@@ -127,7 +125,6 @@ class TSDemuxer {
   public onTrackMetadata: OnTrackMetadataCallback | null = null;
   public onDataAvailable: OnDataAvailableCallback | null = null;
   public onTrackDiscontinuity: OnTrackDiscontinuityCallback | null = null;
-  public onMaximumBitrate: OnMaximumBitrateCallback | null = null;
   public onPcr: OnPcrCallback | null = null;
   /** Software audio decode support (MP2) */
   public onRawAudioData: ((frame: { codec: "mp2"; data: Uint8Array; pts: number }) => void) | null = null;
@@ -234,7 +231,6 @@ class TSDemuxer {
     this.onTrackMetadata = null;
     this.onDataAvailable = null;
     this.onTrackDiscontinuity = null;
-    this.onMaximumBitrate = null;
     this.onPcr = null;
     this.onRawAudioData = null;
     this.soft_decode_audio_codec_ = null;
@@ -914,7 +910,6 @@ class TSDemuxer {
 
     pmt.pcr_pid = ((data[8] & 0x1f) << 8) | data[9];
     const program_info_length = ((data[10] & 0x0f) << 8) | data[11];
-    pmt.program_maximum_bitrate = parseMaximumBitrateDescriptor(data, 12, program_info_length);
 
     const info_start_index = 12 + program_info_length;
     const info_bytes = section_length - 9 - program_info_length - 4;
@@ -925,10 +920,6 @@ class TSDemuxer {
       const ES_info_length = ((data[i + 3] & 0x0f) << 8) | data[i + 4];
 
       pmt.pid_stream_type[elementary_PID] = stream_type;
-      const elementaryMaximumBitrate = parseMaximumBitrateDescriptor(data, i + 5, ES_info_length);
-      if (elementaryMaximumBitrate !== undefined) {
-        pmt.elementary_maximum_bitrates[elementary_PID] = elementaryMaximumBitrate;
-      }
 
       const already_has_video = pmt.common_pids.h264 || pmt.common_pids.h265;
       const already_has_audio =
@@ -985,14 +976,6 @@ class TSDemuxer {
         Log.v(this.TAG, `Parsed first PMT: ${JSON.stringify(pmt)}`);
       }
       this.pmt_ = pmt;
-      const elementaryMaximumBitrate = Object.values(pmt.elementary_maximum_bitrates).reduce(
-        (sum, bitsPerSecond) => sum + bitsPerSecond,
-        0,
-      );
-      const maximumBitrate = pmt.program_maximum_bitrate ?? elementaryMaximumBitrate;
-      if (maximumBitrate > 0) {
-        this.onMaximumBitrate?.(maximumBitrate);
-      }
       if (pmt.common_pids.h264 || pmt.common_pids.h265) {
         this.has_video_ = true;
       }

--- a/web-ui/src/playback-engine/worker/pipeline.ts
+++ b/web-ui/src/playback-engine/worker/pipeline.ts
@@ -68,9 +68,9 @@ const CANCELLED = Symbol("cancelled");
 type SourceMode = "continuous-live-ts" | "static-ts-list" | "hls";
 const PCR_TIMESCALE = 90000;
 const BITRATE_MEDIA_WINDOW_MS = 5000;
-const BITRATE_STABLE_AFTER_MS = 2000;
+const BITRATE_STABLE_AFTER_MS = 500;
 const BITRATE_UPDATE_INTERVAL_MS = 1000;
-const BITRATE_MINIMUM_SAMPLES = 3;
+const BITRATE_MINIMUM_SAMPLES = 2;
 const SEGMENT_BITRATE_SAMPLE_COUNT = 5;
 
 type MediaInfoVideo = NonNullable<PlayerMediaInfo["video"]>;
@@ -809,13 +809,6 @@ class Pipeline {
       }
       this._workerAudioDecoder?.reset();
       this._resetAudioTiming();
-    };
-    demuxer.onMaximumBitrate = (bitsPerSecond) => {
-      if (this._sourceMode === "hls" && this._advertisedBitrate !== undefined) return;
-      this._advertisedBitrate = bitsPerSecond;
-      if (!this._measuredBitrateStable) {
-        this._mergeMediaInfo({ bitrate: { bitsPerSecond, source: "advertised" } });
-      }
     };
     demuxer.onPcr = (pcrBase, bytePosition, discontinuity) => {
       this._recordTsPcr(pcrBase, bytePosition, discontinuity);

--- a/web-ui/src/playback-engine/worker/pipeline.ts
+++ b/web-ui/src/playback-engine/worker/pipeline.ts
@@ -160,7 +160,7 @@ class Pipeline {
   private _tsBitrateSamples: Array<{ pcrBase: number; bytePosition: number }> = [];
   private _segmentBitrateSamples: number[] = [];
   private _currentSegmentBytes = 0;
-  private _lastBitrateUpdateTimestamp = 0;
+  private _lastBitrateUpdatePcr = 0;
   private _measuredBitrateStable = false;
 
   private _workerAudioDecoder: WorkerAudioDecoder | null = null;
@@ -272,7 +272,7 @@ class Pipeline {
     this._tsBitrateSamples = [];
     this._segmentBitrateSamples = [];
     this._currentSegmentBytes = 0;
-    this._lastBitrateUpdateTimestamp = 0;
+    this._lastBitrateUpdatePcr = 0;
     this._measuredBitrateStable = false;
     // A new generation must clear the previous stream's badges immediately.
     this._callbacks.onMediaInfo({});
@@ -282,7 +282,7 @@ class Pipeline {
     this._tsBitrateSamples = [];
     this._segmentBitrateSamples = [];
     this._currentSegmentBytes = 0;
-    this._lastBitrateUpdateTimestamp = 0;
+    this._lastBitrateUpdatePcr = 0;
     this._measuredBitrateStable = false;
     this._replaceBitrate(
       this._advertisedBitrate ? { bitsPerSecond: this._advertisedBitrate, source: "advertised" } : undefined,
@@ -317,6 +317,7 @@ class Pipeline {
         (pcrBase <= previousSample.pcrBase || bytePosition <= previousSample.bytePosition))
     ) {
       this._tsBitrateSamples = [];
+      this._lastBitrateUpdatePcr = 0;
     }
 
     this._tsBitrateSamples.push({ pcrBase, bytePosition });
@@ -332,9 +333,9 @@ class Pipeline {
     const elapsedMediaMilliseconds = (elapsedPcr * 1000) / PCR_TIMESCALE;
     const estimateStable =
       elapsedMediaMilliseconds >= BITRATE_STABLE_AFTER_MS && this._tsBitrateSamples.length >= BITRATE_MINIMUM_SAMPLES;
-    const timestamp = performance.now();
     const updateTooSoon =
-      this._lastBitrateUpdateTimestamp > 0 && timestamp - this._lastBitrateUpdateTimestamp < BITRATE_UPDATE_INTERVAL_MS;
+      this._lastBitrateUpdatePcr > 0 &&
+      ((pcrBase - this._lastBitrateUpdatePcr) * 1000) / PCR_TIMESCALE < BITRATE_UPDATE_INTERVAL_MS;
     if (!estimateStable || updateTooSoon) return;
 
     const totalBytes = lastSample.bytePosition - firstSample.bytePosition;
@@ -343,7 +344,7 @@ class Pipeline {
     const bitsPerSecond = Math.round((totalBytes * 8 * PCR_TIMESCALE) / elapsedPcr / 1000) * 1000;
     if (!Number.isFinite(bitsPerSecond) || bitsPerSecond <= 0) return;
 
-    this._lastBitrateUpdateTimestamp = timestamp;
+    this._lastBitrateUpdatePcr = pcrBase;
     this._measuredBitrateStable = true;
     this._replaceBitrate({ bitsPerSecond, source: "measured" });
   }

--- a/web-ui/src/playback-engine/worker/pipeline.ts
+++ b/web-ui/src/playback-engine/worker/pipeline.ts
@@ -66,7 +66,8 @@ const HLS_URL_RE = /\.m3u8?($|\?)/i;
 /** Sentinel rejection value for intentionally cancelled segment loads. */
 const CANCELLED = Symbol("cancelled");
 type SourceMode = "continuous-live-ts" | "static-ts-list" | "hls";
-const BITRATE_WINDOW_MS = 5000;
+const PCR_TIMESCALE = 90000;
+const BITRATE_MEDIA_WINDOW_MS = 5000;
 const BITRATE_STABLE_AFTER_MS = 2000;
 const BITRATE_UPDATE_INTERVAL_MS = 1000;
 const BITRATE_MINIMUM_SAMPLES = 3;
@@ -156,7 +157,7 @@ class Pipeline {
   private _hasActualAudioInfo = false;
   private _advertisedBitrate: number | undefined;
   private _lastHlsInfo: HlsInfo | undefined;
-  private _bitrateSamples: Array<{ timestamp: number; bytes: number }> = [];
+  private _tsBitrateSamples: Array<{ pcrBase: number; bytePosition: number }> = [];
   private _segmentBitrateSamples: number[] = [];
   private _currentSegmentBytes = 0;
   private _lastBitrateUpdateTimestamp = 0;
@@ -268,7 +269,7 @@ class Pipeline {
     this._hasActualAudioInfo = false;
     this._advertisedBitrate = undefined;
     this._lastHlsInfo = undefined;
-    this._bitrateSamples = [];
+    this._tsBitrateSamples = [];
     this._segmentBitrateSamples = [];
     this._currentSegmentBytes = 0;
     this._lastBitrateUpdateTimestamp = 0;
@@ -278,7 +279,7 @@ class Pipeline {
   }
 
   private _resetBitrateMeasurement(): void {
-    this._bitrateSamples = [];
+    this._tsBitrateSamples = [];
     this._segmentBitrateSamples = [];
     this._currentSegmentBytes = 0;
     this._lastBitrateUpdateTimestamp = 0;
@@ -300,29 +301,46 @@ class Pipeline {
   private _recordInputBytes(bytes: number): void {
     if (bytes <= 0) return;
 
+    // Segmented fMP4 has no PCR, so retain the complete-segment fallback.
     if (this._sourceMode !== "continuous-live-ts") {
       this._currentSegmentBytes += bytes;
-      return;
+    }
+  }
+
+  private _recordTsPcr(pcrBase: number, bytePosition: number, discontinuity: boolean): void {
+    if (this._sourceMode === "hls" || !Number.isFinite(pcrBase) || !Number.isFinite(bytePosition)) return;
+
+    const previousSample = this._tsBitrateSamples.at(-1);
+    if (
+      discontinuity ||
+      (previousSample !== undefined &&
+        (pcrBase <= previousSample.pcrBase || bytePosition <= previousSample.bytePosition))
+    ) {
+      this._tsBitrateSamples = [];
     }
 
-    const timestamp = performance.now();
-    this._bitrateSamples.push({ timestamp, bytes });
-    const windowStart = timestamp - BITRATE_WINDOW_MS;
-    while (this._bitrateSamples.length > 0 && this._bitrateSamples[0].timestamp < windowStart) {
-      this._bitrateSamples.shift();
+    this._tsBitrateSamples.push({ pcrBase, bytePosition });
+    const windowStart = pcrBase - (BITRATE_MEDIA_WINDOW_MS * PCR_TIMESCALE) / 1000;
+    while (this._tsBitrateSamples.length > 1 && this._tsBitrateSamples[1].pcrBase <= windowStart) {
+      this._tsBitrateSamples.shift();
     }
 
-    const firstSample = this._bitrateSamples[0];
-    if (!firstSample) return;
-    const elapsedMilliseconds = timestamp - firstSample.timestamp;
+    const firstSample = this._tsBitrateSamples[0];
+    const lastSample = this._tsBitrateSamples.at(-1);
+    if (!firstSample || !lastSample) return;
+    const elapsedPcr = lastSample.pcrBase - firstSample.pcrBase;
+    const elapsedMediaMilliseconds = (elapsedPcr * 1000) / PCR_TIMESCALE;
     const estimateStable =
-      elapsedMilliseconds >= BITRATE_STABLE_AFTER_MS && this._bitrateSamples.length >= BITRATE_MINIMUM_SAMPLES;
-    if (!estimateStable || timestamp - this._lastBitrateUpdateTimestamp < BITRATE_UPDATE_INTERVAL_MS) return;
+      elapsedMediaMilliseconds >= BITRATE_STABLE_AFTER_MS && this._tsBitrateSamples.length >= BITRATE_MINIMUM_SAMPLES;
+    const timestamp = performance.now();
+    const updateTooSoon =
+      this._lastBitrateUpdateTimestamp > 0 && timestamp - this._lastBitrateUpdateTimestamp < BITRATE_UPDATE_INTERVAL_MS;
+    if (!estimateStable || updateTooSoon) return;
 
-    // The first sample establishes the window's time baseline; only bytes that
-    // arrived after that point belong to the measured interval.
-    const totalBytes = this._bitrateSamples.slice(1).reduce((sum, sample) => sum + sample.bytes, 0);
-    const bitsPerSecond = Math.round((totalBytes * 8 * 1000) / elapsedMilliseconds / 1000) * 1000;
+    const totalBytes = lastSample.bytePosition - firstSample.bytePosition;
+    // PCR advances with the media timeline, so server-side delivery bursts do
+    // not inflate this transport-stream bitrate as wall-clock sampling would.
+    const bitsPerSecond = Math.round((totalBytes * 8 * PCR_TIMESCALE) / elapsedPcr / 1000) * 1000;
     if (!Number.isFinite(bitsPerSecond) || bitsPerSecond <= 0) return;
 
     this._lastBitrateUpdateTimestamp = timestamp;
@@ -587,7 +605,7 @@ class Pipeline {
         this._currentSegmentBytes = 0;
         await this._loadSegment(meta);
         if (this._runId !== runId) return;
-        if (this._sourceMode !== "continuous-live-ts") {
+        if (this._sourceMode === "hls" || this._fmp4Mode) {
           this._publishSegmentBitrate(meta.duration);
         }
 
@@ -791,6 +809,16 @@ class Pipeline {
       }
       this._workerAudioDecoder?.reset();
       this._resetAudioTiming();
+    };
+    demuxer.onMaximumBitrate = (bitsPerSecond) => {
+      if (this._sourceMode === "hls" && this._advertisedBitrate !== undefined) return;
+      this._advertisedBitrate = bitsPerSecond;
+      if (!this._measuredBitrateStable) {
+        this._mergeMediaInfo({ bitrate: { bitsPerSecond, source: "advertised" } });
+      }
+    };
+    demuxer.onPcr = (pcrBase, bytePosition, discontinuity) => {
+      this._recordTsPcr(pcrBase, bytePosition, discontinuity);
     };
 
     // Set up software audio decode callback when MP2 WASM URL is configured


### PR DESCRIPTION
## Summary

Improve bitrate reporting for MPEG-TS live and catch-up playback. The player now measures transport-stream bitrate from byte positions against the PCR media timeline, so the result reflects media bitrate instead of network delivery speed.

## Why

The previous calculation divided received bytes by wall-clock time. Server-side startup bursts therefore appeared as inflated bitrate, while long catch-up requests could delay bitrate publication until the request completed.

PCR-based sampling is independent of delivery speed and works for both continuous live TS and catch-up TS. The first measured value is published after 500 ms of media time and two PCR samples, then updated once per second over a rolling five-second window. HLS keeps its existing manifest and segment-duration behavior.

## Validation

Verified a fixed 6 Mbps MPEG-TS sample reports 6.000 Mbps even when read faster than real time. `pnpm run type-check:tsc`, `pnpm run lint:biome`, and the production Vite build all pass.