### PR TITLE
fix(player): normalize TS timestamp continuity

### DIFF
--- a/tools/devlab/README.md
+++ b/tools/devlab/README.md
@@ -10,9 +10,12 @@ needs to support:
 | HLS-fMP4 live            | HTTP `.m3u8` + `.m4s`             | `/http`         | `h264-aac`, `hevc-aac`              |
 | HLS alternate audio      | HTTP master + split A/V playlists | `/http`         | AAC / MP2 / AC-3 (TS), AAC (fMP4)   |
 | HLS internal multi-audio | HTTP `.m3u8` + multi-PID `.ts`    | `/http`         | H.264 + AAC / MP2 / AC-3            |
+| HLS timestamp continuity | HTTP VOD with crafted `.ts` PTS   | `/http`         | H.264 + MP2                          |
+| HLS live packet loss     | HTTP `.m3u8` + damaged `.ts`      | `/http`         | H.264 + MP2                          |
 | HTTP internal multi-audio | continuous multi-PID MPEG-TS     | `/http`         | H.264 + AAC / MP2 / AC-3            |
 | HLS catchup              | HTTP HLS VOD (`playseek`)         | `/http`         | all of the above                    |
 | mpegts (RTSP)            | RTSP TS live + catchup            | `/rtsp`         | `h264-mp2`, `hevc-aac`              |
+| mpegts continuity faults | RTSP catchup + RTP packet loss    | `/rtsp`         | H.264 + MP2                          |
 | mpegts (multicast)       | RTP multicast live                | `/rtp`          | `h264-mp2`, `hevc-ac3`, `hevc-eac3` |
 | mpegts (scan)            | RTP multicast live                | `/rtp`          | 1080i / 1080p / 2160p (see below)   |
 | external file            | RTP multicast (looped)            | `/rtp`          | whatever the `.ts` file contains    |
@@ -37,6 +40,24 @@ The **internal multi-audio** channels carry those same three languages and
 tones as separate PIDs in one MPEG-TS program. One is segmented as HLS-TS and
 the other is a continuous HTTP TS response, covering both inputs accepted by
 the custom demux/transmux pipeline.
+
+The **HLS-TS continuity overlap gap restart** VOD has four six-second TS
+segments with deterministic timestamp starts: 0s, 5s, 13s, then 0s. This
+creates a one-second overlap, a two-second gap, and finally a greater-than-ten
+second timestamp restart. An `EXT-X-DISCONTINUITY` is also placed before the
+gap segment to prove that HLS-TS follows the timestamp policy instead of
+resetting its output timeline from playlist metadata.
+
+The two live packet-loss channels are deterministic fault injectors. HLS drops
+40 complete TS packets from every third segment; RTSP skips six consecutive RTP
+packets roughly every five seconds. The player should recover at the next valid
+sample/keyframe and keep its output timeline continuous.
+
+The **mpegts catchup gap** channel terminates every requested RTSP catchup
+window and advances the source timestamp offset by an extra two seconds for
+each subsequent request. Together with the normal RTSP catchup channel's
+one-second request overlap, these cover both overlap and gap handling across
+plain MPEG-TS URL boundaries.
 
 **HLS catchup** is a real HLS VOD: each `playseek` window returns an
 `index.m3u8` (`#EXT-X-PLAYLIST-TYPE:VOD`) listing fixed-duration `.ts` slices.
@@ -104,6 +125,21 @@ uv run tools/devlab/devlab.py
 # 3. open the player and pick a channel
 #    http://127.0.0.1:5140/player
 ```
+
+## Browser autoplay and audio prompts
+
+Browsers may show a **Click to Play** prompt because unmuted audio playback
+requires a trusted user gesture. Browser automation must handle this prompt
+according to what the scenario is testing:
+
+- If the test does not depend on audible output, mute the player and then
+  reload the page. The reload is required so playback starts in the muted
+  state and the automation can continue without the prompt.
+- If the test validates audio or audible track switching, stop the automation,
+  show the player to the user, and ask the user to click **Click to Play**.
+  Resume only after the user confirms the interaction. Do not attempt to clear
+  the prompt with a programmatic click: it does not provide the trusted user
+  gesture required to enable audio playback.
 
 Requires `ffmpeg` on PATH with `drawtext`, `libx264`, `libx265`, `aac`, and
 `mp2`. On macOS with Homebrew, install a full build:

--- a/tools/devlab/devlab.py
+++ b/tools/devlab/devlab.py
@@ -87,6 +87,7 @@ MCAST_SCAN_CHANNELS = (
 # Tuple: (channel_label, profile, seg_type, live_key).
 HLS_CHANNELS = (
     ("HLS-TS (h264-mp2)", "h264-mp2", "mpegts", "h264-mp2-ts"),
+    ("HLS-TS live packet loss", "h264-mp2", "mpegts", "h264-mp2-ts-loss"),
     ("HLS-TS (hevc-aac)", "hevc-aac", "mpegts", "hevc-aac-ts"),
     ("HLS-fMP4 (h264-aac)", "h264-aac", "fmp4", "h264-aac-fmp4"),
     ("HLS-fMP4 (hevc-aac)", "hevc-aac", "fmp4", "hevc-aac-fmp4"),
@@ -121,9 +122,17 @@ AUDIO_RENDITIONS = (
     AudioRendition("audio-es", "Español", "es", "spa", 1320, "h264-ac3", "ac3", "192k"),
 )
 
+MPEG_TS_PACKET_SIZE = 188
+RTP_TS_PAYLOAD_SIZE = 7 * MPEG_TS_PACKET_SIZE
+
 # ---------------------------------------------------------------------------
 # ffmpeg argument helpers
 # ---------------------------------------------------------------------------
+
+
+def mpegts_timestamp_args(offset: int) -> list[str]:
+    """Return ffmpeg arguments for deterministic zero-delay MPEG-TS timestamps."""
+    return ["-output_ts_offset", str(offset), "-muxdelay", "0", "-muxpreload", "0"]
 
 
 def resolve_font(path: str | None) -> str:
@@ -319,16 +328,11 @@ def _parse_time_token(tok: str) -> int:
     return int(time.time())
 
 
-def parse_playseek_begin(playseek: str) -> int:
-    """Return the begin time of a playseek value as a UTC epoch (seconds)."""
-    return _parse_time_token(playseek.split("-")[0]) if playseek else int(time.time())
-
-
 def parse_playseek_range(playseek: str) -> tuple[int, int]:
     """Return ``(begin, end)`` UTC epochs for a ``BEGIN-END`` playseek value.
 
     rtp2httpd forwards compact ``yyyyMMddHHmmss`` times (no internal dashes) so a
-    plain ``-`` split is safe. A missing/!invalid end defaults to begin + 60s.
+    plain ``-`` split is safe. A missing or invalid end defaults to begin + 60s.
     """
     toks = [t for t in playseek.split("-") if t.strip()] if playseek else []
     begin = _parse_time_token(toks[0]) if toks else int(time.time())
@@ -588,12 +592,65 @@ class CatchupHLS:
         ]
 
 
+class ContinuityHLS:
+    """Deterministic HLS-TS VOD with overlap, gap and a large timestamp restart."""
+
+    seg_dur = 6
+    timestamp_offsets = (0, 5, 13, 0)
+
+    def __init__(self, ffmpeg: str):
+        self.ffmpeg = ffmpeg
+
+    def playlist(self, base: str) -> str:
+        lines = [
+            "#EXTM3U",
+            "#EXT-X-VERSION:3",
+            f"#EXT-X-TARGETDURATION:{self.seg_dur}",
+            "#EXT-X-MEDIA-SEQUENCE:0",
+            "#EXT-X-PLAYLIST-TYPE:VOD",
+        ]
+        for idx in range(len(self.timestamp_offsets)):
+            if idx == 2:
+                # The TS path deliberately ignores this tag and follows the
+                # actual timestamp continuity policy instead.
+                lines.append("#EXT-X-DISCONTINUITY")
+            lines += [f"#EXTINF:{self.seg_dur}.000,", f"{base}/continuity-hls/{idx}.ts"]
+        lines.append("#EXT-X-ENDLIST")
+        return "\n".join(lines) + "\n"
+
+    def segment_cmd(self, idx: int) -> list[str]:
+        offset = self.timestamp_offsets[idx]
+        return [
+            self.ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            *lavfi_inputs(),
+            "-t",
+            str(self.seg_dur),
+            "-vf",
+            f"{live_filter('HLS continuity')},{_drawtext(f'SEG {idx} PTS {offset}s', 152, expansion=False)}",
+            *video_args("h264-mp2"),
+            *audio_args("h264-mp2"),
+            *mpegts_timestamp_args(offset),
+            "-f",
+            "mpegts",
+            "-",
+        ]
+
+
 # ---------------------------------------------------------------------------
 # HTTP origin server
 # ---------------------------------------------------------------------------
 
 
-def make_http_handler(host: str, port: int, live_root: str, catchup: CatchupHLS) -> type[BaseHTTPRequestHandler]:
+def make_http_handler(
+    host: str,
+    port: int,
+    live_root: str,
+    catchup: CatchupHLS,
+    continuity: ContinuityHLS,
+) -> type[BaseHTTPRequestHandler]:
     base = f"http://{host}:{port}"
 
     class Handler(BaseHTTPRequestHandler):
@@ -621,7 +678,18 @@ def make_http_handler(host: str, port: int, live_root: str, catchup: CatchupHLS)
             else:
                 ctype = "video/mp2t"
             with open(path, "rb") as fh:
-                self._send(200, ctype, fh.read())
+                body = fh.read()
+            if "h264-mp2-ts-loss" in path and path.endswith(".ts"):
+                try:
+                    segment_index = int(os.path.basename(path).removeprefix("seg_").removesuffix(".ts"))
+                except ValueError:
+                    segment_index = 0
+                if segment_index % 3 == 1:
+                    packet_count = len(body) // MPEG_TS_PACKET_SIZE
+                    drop_start = max(1, packet_count // 2)
+                    drop_end = min(packet_count, drop_start + 40)
+                    body = body[: drop_start * MPEG_TS_PACKET_SIZE] + body[drop_end * MPEG_TS_PACKET_SIZE :]
+            self._send(200, ctype, body)
 
         def _live(self, parts: list[str]) -> None:
             # /live/<profile>/<path...>
@@ -656,6 +724,26 @@ def make_http_handler(host: str, port: int, live_root: str, catchup: CatchupHLS)
             finally:
                 if proc.poll() is None:
                     proc.terminate()
+
+        def _continuity_playlist(self) -> None:
+            text = continuity.playlist(base)
+            self._send(200, "application/vnd.apple.mpegurl", text.encode())
+
+        def _continuity_seg(self, idx: int) -> None:
+            if idx < 0 or idx >= len(continuity.timestamp_offsets):
+                self._send(404, "text/plain", b"not found")
+                return
+            proc = subprocess.run(
+                continuity.segment_cmd(idx),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=30,
+                check=False,
+            )
+            if proc.returncode != 0:
+                self._send(500, "text/plain", proc.stderr[-4096:] or b"ffmpeg failed")
+                return
+            self._send(200, "video/mp2t", proc.stdout)
 
         def _multi_ts(self) -> None:
             self.send_response(200)
@@ -702,6 +790,10 @@ def make_http_handler(host: str, port: int, live_root: str, catchup: CatchupHLS)
                 elif len(parts) == 4 and parts[0] == "catchup-seg":
                     # /catchup-seg/<profile>/<begin>/<idx>.ts
                     self._catchup_seg(parts[1], int(parts[2]), int(parts[3].removesuffix(".ts")))
+                elif parts == ["continuity-hls", "index.m3u8"]:
+                    self._continuity_playlist()
+                elif len(parts) == 2 and parts[0] == "continuity-hls":
+                    self._continuity_seg(int(parts[1].removesuffix(".ts")))
                 elif parts == ["multi-audio.ts"]:
                     self._multi_ts()
                 else:
@@ -731,6 +823,8 @@ class RTSPOrigin:
         self._sock: socket.socket | None = None
         self._thread: threading.Thread | None = None
         self._stop = threading.Event()
+        self._catchup_gap_requests = 0
+        self._catchup_gap_lock = threading.Lock()
 
     def start(self) -> None:
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -765,10 +859,22 @@ class RTSPOrigin:
 
     def _ffmpeg_cmd(self, uri: str) -> list[str]:
         profile = self._profile_from_uri(uri)
-        qs = parse_qs(urlparse(uri).query)
+        parsed_uri = urlparse(uri)
+        qs = parse_qs(parsed_uri.query)
         playseek = (qs.get("playseek") or qs.get("tvdr") or [""])[0]
+        duration_args: list[str] = []
+        timestamp_args: list[str] = []
         if playseek:
-            vf = catchup_filter(profile, parse_playseek_begin(playseek))
+            begin, end = parse_playseek_range(playseek)
+            vf = catchup_filter(profile, begin)
+            duration_args = ["-t", str(end - begin)]
+            timeline_offset = begin % 86400
+            if "/catchup-gap/" in parsed_uri.path:
+                with self._catchup_gap_lock:
+                    request_index = self._catchup_gap_requests
+                    self._catchup_gap_requests += 1
+                timeline_offset += request_index * 2
+            timestamp_args = mpegts_timestamp_args(timeline_offset)
         else:
             vf = live_filter(profile)
         return [
@@ -778,10 +884,12 @@ class RTSPOrigin:
             "error",
             "-re",
             *lavfi_inputs(),
+            *duration_args,
             "-vf",
             vf,
             *video_args(profile),
             *audio_args(profile),
+            *timestamp_args,
             "-f",
             "mpegts",
             "-",
@@ -850,7 +958,8 @@ class RTSPOrigin:
         seq = 0
         ts = 0
         buf = b""
-        payload = 1316  # 7 * 188-byte TS packets per RTP datagram
+        payload = RTP_TS_PAYLOAD_SIZE
+        inject_packet_loss = "/live-loss/" in urlparse(uri).path
         try:
             while not self._stop.is_set():
                 chunk = proc.stdout.read(payload)
@@ -861,7 +970,9 @@ class RTSPOrigin:
                     pkt, buf = buf[:payload], buf[payload:]
                     header = struct.pack("!BBHII", 0x80, 33, seq & 0xFFFF, ts & 0xFFFFFFFF, 0x0DEFACED)
                     rtp = header + pkt
-                    conn.sendall(b"\x24" + struct.pack("!BH", 0, len(rtp)) + rtp)
+                    drop_for_fault = inject_packet_loss and 500 <= seq % 1000 < 506
+                    if not drop_for_fault:
+                        conn.sendall(b"\x24" + struct.pack("!BH", 0, len(rtp)) + rtp)
                     seq += 1
                     ts += 3600
         except BrokenPipeError, ConnectionError, OSError:
@@ -908,7 +1019,7 @@ class MulticastLive:
 
     def _cmd(self) -> list[str]:
         common = [self.ffmpeg, "-hide_banner", "-loglevel", "error"]
-        out = f"{self.url()}?ttl=1&pkt_size=1316"
+        out = f"{self.url()}?ttl=1&pkt_size={RTP_TS_PAYLOAD_SIZE}"
         if self.ts_file:
             # Stream-copy the original bitstream so the exact codecs are relayed.
             return [*common, "-re", "-stream_loop", "-1", "-i", self.ts_file, "-c", "copy", "-f", "rtp_mpegts", out]
@@ -976,6 +1087,10 @@ def build_services_m3u(http_hostport: str, rtsp_hostport: str, mcast_channels: l
             f'#EXTINF:-1 group-title="HLS" catchup="default" catchup-source="{src}",{label}',
             f"http://{http_hostport}/live/{key}/index.m3u8",
         ]
+    lines += [
+        '#EXTINF:-1 group-title="HLS",HLS-TS continuity overlap gap restart',
+        f"http://{http_hostport}/continuity-hls/index.m3u8",
+    ]
     for label, _seg_type, key in ALT_AUDIO_HLS_CHANNELS:
         lines += [
             f'#EXTINF:-1 group-title="HLS",{label}',
@@ -1000,6 +1115,13 @@ def build_services_m3u(http_hostport: str, rtsp_hostport: str, mcast_channels: l
             extinf,
             f"rtsp://{rtsp_hostport}/live/{prof}",
         ]
+    gap_src = f"rtsp://{rtsp_hostport}/catchup-gap/h264-mp2?{tpl}"
+    lines += [
+        f'#EXTINF:-1 group-title="mpegts (RTSP)" catchup="default" catchup-source="{gap_src}",mpegts catchup gap',
+        f"rtsp://{rtsp_hostport}/live/h264-mp2",
+        '#EXTINF:-1 group-title="mpegts (RTSP)",mpegts live packet loss',
+        f"rtsp://{rtsp_hostport}/live-loss/h264-mp2",
+    ]
     for group_title, name, rtp_url in mcast_channels:
         lines += [f'#EXTINF:-1 group-title="{group_title}",{name}', rtp_url]
     return "\n".join(lines) + "\n"
@@ -1093,7 +1215,8 @@ def main() -> int:
         return 1
 
     catchup = CatchupHLS(args.ffmpeg)
-    handler = make_http_handler(args.host, args.http_port, live_root, catchup)
+    continuity = ContinuityHLS(args.ffmpeg)
+    handler = make_http_handler(args.host, args.http_port, live_root, catchup, continuity)
     httpd = ThreadingHTTPServer((args.host, args.http_port), handler)
     threading.Thread(target=httpd.serve_forever, daemon=True).start()
 

--- a/web-ui/src/playback-engine/demux/ts-demuxer.ts
+++ b/web-ui/src/playback-engine/demux/ts-demuxer.ts
@@ -184,6 +184,12 @@ export interface TSAudioTrackInfo {
 
 export type OnAudioTracksCallback = (tracks: TSAudioTrackInfo[], selectedPid: number | undefined) => void;
 
+export interface RawMp2AudioFrame {
+  codec: "mp2";
+  data: Uint8Array;
+  pts?: number;
+}
+
 class TSDemuxer {
   private readonly TAG: string = "TSDemuxer";
 
@@ -194,7 +200,7 @@ class TSDemuxer {
   public onPcr: OnPcrCallback | null = null;
   public onAudioTracks: OnAudioTracksCallback | null = null;
   /** Software audio decode support (MP2) */
-  public onRawAudioData: ((frame: { codec: "mp2"; data: Uint8Array; pts: number }) => void) | null = null;
+  public onRawAudioData: ((frame: RawMp2AudioFrame) => void) | null = null;
 
   private ts_packet_size_: number;
   private sync_offset_: number;
@@ -1940,7 +1946,7 @@ class TSDemuxer {
 
       // Dispatch the raw payload for software decoding (the WASM decoder
       // splits it into frames and carries partial frames across payloads)
-      const pts_ms = (pts ?? 0) / this.timescale_;
+      const pts_ms = pts === undefined ? undefined : pts / this.timescale_;
       this.onRawAudioData({ codec: "mp2", data, pts: pts_ms });
 
       // Don't push samples to audio track — the remuxer generates

--- a/web-ui/src/playback-engine/hls/hls-source.ts
+++ b/web-ui/src/playback-engine/hls/hls-source.ts
@@ -145,7 +145,7 @@ export class HlsSource implements SegmentSource {
         const meta = this.segments[this.nextIndex++];
         if (this.resetPending) {
           this.resetPending = false;
-          return { ...meta, resetRemuxer: true };
+          return { ...meta, resetReason: "initial" };
         }
         return meta;
       }
@@ -248,7 +248,7 @@ export class HlsSource implements SegmentSource {
         url: seg.url,
         start: this.timelinePos,
         duration: seg.duration,
-        resetRemuxer: seg.discontinuity || skipped,
+        resetReason: seg.discontinuity || skipped ? "playlist-reset" : undefined,
         initUrl: seg.initUrl,
       });
       this.timelinePos += seg.duration;

--- a/web-ui/src/playback-engine/remux/mp4-remuxer.ts
+++ b/web-ui/src/playback-engine/remux/mp4-remuxer.ts
@@ -1,3 +1,4 @@
+import { classifyTimestampOverlap, mapContinuousPcmRange } from "../timeline/ts-continuity";
 import { isFirefox } from "../utils/browser";
 import { IllegalStateException } from "../utils/exception";
 import Log from "../utils/logger";
@@ -97,7 +98,7 @@ interface TrackTimingState {
   durationResidual: number;
 }
 
-type PcmTimestampMapping = { action: "drop" } | { action: "emit"; time: number; trimStartMs: number };
+type PcmTimestampMapping = { action: "drop" } | { action: "emit"; time: number; trimStartFrames: number };
 
 type InitSegmentCallback = (type: string, segment: InitSegment) => void;
 type MediaSegmentCallback = (type: string, segment: MediaSegment) => void;
@@ -136,6 +137,7 @@ class MP4Remuxer {
   private _audioTiming: TrackTimingState;
   private _videoTiming: TrackTimingState;
   private _pcmTiming: TrackTimingState;
+  private _pcmNextDts: number | undefined;
   private _videoPresentationOffset: number | undefined;
   private _videoInitialPresentationOffset: number | undefined;
   private _videoInitialOutputTime: number | undefined;
@@ -151,7 +153,6 @@ class MP4Remuxer {
   private _silentAudioMode: boolean;
   private _silentAudioLastDts: number | undefined;
   private _silentAudioDurationResidual: number;
-  private _tsSegmentContinuityNormalization: boolean;
   private _mediaSegmentBatchDurationMs: number;
   private _mediaSegmentBatchMaxBytes: number;
   private _audioMediaSegmentEmitted: boolean;
@@ -173,6 +174,7 @@ class MP4Remuxer {
     this._audioTiming = this._createTrackTimingState();
     this._videoTiming = this._createTrackTimingState();
     this._pcmTiming = this._createTrackTimingState();
+    this._pcmNextDts = undefined;
     this._videoPresentationOffset = undefined;
     this._videoInitialPresentationOffset = undefined;
     this._videoInitialOutputTime = undefined;
@@ -189,7 +191,6 @@ class MP4Remuxer {
     this._silentAudioMode = false;
     this._silentAudioLastDts = undefined;
     this._silentAudioDurationResidual = 0;
-    this._tsSegmentContinuityNormalization = false;
     this._mediaSegmentBatchDurationMs = normalizeMediaBatchLimit(
       options.mediaSegmentBatchDurationMs,
       DEFAULT_MEDIA_SEGMENT_BATCH_DURATION_MS,
@@ -209,12 +210,12 @@ class MP4Remuxer {
     this._silentAudioMode = false;
     this._silentAudioLastDts = undefined;
     this._silentAudioDurationResidual = 0;
-    this._tsSegmentContinuityNormalization = false;
     this._audioMediaSegmentEmitted = false;
     this._videoMediaSegmentEmitted = false;
     this._audioTiming = this._createTrackTimingState();
     this._videoTiming = this._createTrackTimingState();
     this._pcmTiming = this._createTrackTimingState();
+    this._pcmNextDts = undefined;
     this._videoPresentationOffset = undefined;
     this._videoInitialPresentationOffset = undefined;
     this._videoInitialOutputTime = undefined;
@@ -256,7 +257,6 @@ class MP4Remuxer {
   }
 
   insertDiscontinuity(): void {
-    this._audioNextDts = this._videoNextDts = undefined;
     this._silentAudioLastDts = undefined;
     this._silentAudioDurationResidual = 0;
     this._videoPresentationOffset = undefined;
@@ -272,6 +272,7 @@ class MP4Remuxer {
     this._audioStashedLastSample = null;
     this._audioTiming = this._createTrackTimingState();
     this._pcmTiming = this._createTrackTimingState();
+    this._pcmNextDts = nextDtsMs;
     this._audioMeta = null;
     this._silentAudioMode = false;
     this._silentAudioLastDts = undefined;
@@ -302,10 +303,6 @@ class MP4Remuxer {
         flags: { isLeading: 0, dependsOn: 1, isDependedOn: 0, hasRedundancy: 0 },
       },
     ]);
-  }
-
-  setTsSegmentContinuityNormalization(enabled: boolean): void {
-    this._tsSegmentContinuityNormalization = enabled;
   }
 
   private _createTrackTimingState(): TrackTimingState {
@@ -359,20 +356,25 @@ class MP4Remuxer {
     timing: TrackTimingState,
     mdatBytes: number,
   ): number {
-    if (!this._tsSegmentContinuityNormalization) {
-      return mdatBytes;
-    }
-
     const lastOriginalDts = timing.lastOriginalDts;
     if (lastOriginalDts === undefined) {
       return mdatBytes;
     }
 
+    const firstOriginalDts = samples[0].dts - this._dtsBase;
+    const decision = classifyTimestampOverlap(firstOriginalDts, lastOriginalDts);
+    if (decision === "restart") {
+      Log.w(this.TAG, `Keeping samples after ${Math.round(lastOriginalDts - firstOriginalDts)}ms timestamp restart`);
+      timing.lastOriginalDts = undefined;
+      timing.lastOriginalEndDts = undefined;
+      timing.durationResidual = 0;
+      return mdatBytes;
+    }
+    if (decision !== "skip") return mdatBytes;
+
     while (samples.length > 0) {
       const originalDts = samples[0].dts - this._dtsBase;
-      if (originalDts > lastOriginalDts) {
-        break;
-      }
+      if (originalDts > lastOriginalDts) break;
 
       const sample = samples.shift() as T;
       mdatBytes -= sample.length;
@@ -640,17 +642,21 @@ class MP4Remuxer {
     return this._videoInitialOutputTime ?? 0;
   }
 
-  mapPcmTimestamp(ptsMs: number, durationMs: number): PcmTimestampMapping | undefined {
+  mapPcmTimestamp(ptsMs: number, frameCount: number, sampleRate: number): PcmTimestampMapping | undefined {
     if (!this._dtsBaseInited) {
       return undefined;
     }
 
     const originalTime = ptsMs - this._dtsBase;
-    const duration = Math.max(0, durationMs);
+    const totalFrames = Math.max(0, frameCount);
+    const duration = (totalFrames / sampleRate) * 1000;
     let outputTime: number;
-    let trimStartMs = 0;
+    let trimStartFrames = 0;
 
-    if (this._pcmTiming.lastOriginalEndDts === undefined || this._pcmTiming.lastOutputEndDts === undefined) {
+    if (this._pcmNextDts !== undefined) {
+      outputTime = this._pcmNextDts;
+      this._pcmNextDts = undefined;
+    } else if (this._pcmTiming.lastOriginalEndDts === undefined || this._pcmTiming.lastOutputEndDts === undefined) {
       if (
         this._videoDtsBase !== Infinity &&
         (this._videoInitialPresentationOffset === undefined || this._videoInitialOutputTime === undefined)
@@ -666,17 +672,25 @@ class MP4Remuxer {
         return { action: "drop" };
       }
 
-      trimStartMs = Math.max(0, presentationFloor - presentationStart);
+      trimStartFrames = Math.min(
+        totalFrames,
+        Math.ceil((Math.max(0, presentationFloor - presentationStart) * sampleRate) / 1000 - 1e-9),
+      );
       outputTime = Math.max(presentationFloor, presentationStart);
     } else {
-      const distance = originalTime - this._pcmTiming.lastOriginalEndDts;
-      outputTime = this._pcmTiming.lastOutputEndDts + (distance > 0 ? 0 : distance);
-      if (distance > 0) {
-        Log.v(this.TAG, `PCM: bridging ${Math.round(distance)}ms timestamp hole`);
-      }
+      const mapping = mapContinuousPcmRange({
+        originalStartMs: originalTime,
+        frameCount: totalFrames,
+        sampleRate,
+        lastOriginalEndMs: this._pcmTiming.lastOriginalEndDts,
+        lastOutputEndMs: this._pcmTiming.lastOutputEndDts,
+      });
+      if (mapping.action === "drop") return mapping;
+      outputTime = mapping.outputStartMs;
+      trimStartFrames = mapping.trimStartFrames;
     }
 
-    const emittedDuration = duration - trimStartMs;
+    const emittedDuration = ((totalFrames - trimStartFrames) / sampleRate) * 1000;
     if (emittedDuration <= 0) {
       return { action: "drop" };
     }
@@ -684,7 +698,7 @@ class MP4Remuxer {
     this._pcmTiming.lastOriginalEndDts = originalTime + duration;
     this._pcmTiming.lastOutputEndDts = outputTime + emittedDuration;
     this._pcmTiming.lastOutputDuration = emittedDuration;
-    return { action: "emit", time: outputTime / 1000, trimStartMs };
+    return { action: "emit", time: outputTime / 1000, trimStartFrames };
   }
 
   flushStashedSamples(): void {
@@ -974,8 +988,9 @@ class MP4Remuxer {
       const isKeyframe = sample.isKeyframe;
 
       const dts = nextOutputDts;
-      const originalPts = originalDts + sample.cts;
-      const correctedPtsBase = this._tsSegmentContinuityNormalization ? originalPts - dtsCorrection : originalPts;
+      // Apply the exact DTS translation to PTS as well. This keeps CTS stable
+      // when a TS segment gap or overlap is collapsed onto the output timeline.
+      const correctedPtsBase = dts + sample.cts;
       if (this._videoPresentationOffset === undefined) {
         this._videoPresentationOffset = correctedPtsBase - dts;
         if (this._videoInitialPresentationOffset === undefined) {

--- a/web-ui/src/playback-engine/timeline/ts-continuity.ts
+++ b/web-ui/src/playback-engine/timeline/ts-continuity.ts
@@ -1,0 +1,45 @@
+const OVERLAP_SKIP_LIMIT_MS = 10_000;
+
+type TimestampOverlapDecision = "none" | "skip" | "restart";
+
+export function classifyTimestampOverlap(currentMs: number, previousMs: number): TimestampOverlapDecision {
+  if (currentMs > previousMs) return "none";
+  return previousMs - currentMs > OVERLAP_SKIP_LIMIT_MS ? "restart" : "skip";
+}
+
+interface ContinuousPcmRange {
+  originalStartMs: number;
+  frameCount: number;
+  sampleRate: number;
+  lastOriginalEndMs: number;
+  lastOutputEndMs: number;
+}
+
+type ContinuousPcmMapping =
+  | { action: "drop" }
+  | {
+      action: "emit";
+      outputStartMs: number;
+      trimStartFrames: number;
+    };
+
+/** Map one decoded PCM range after the first range has established both clocks. */
+export function mapContinuousPcmRange(input: ContinuousPcmRange): ContinuousPcmMapping {
+  const { originalStartMs, frameCount, sampleRate, lastOriginalEndMs, lastOutputEndMs } = input;
+  const overlapMs = lastOriginalEndMs - originalStartMs;
+  const overlapDecision = classifyTimestampOverlap(originalStartMs, lastOriginalEndMs);
+  let trimStartFrames = 0;
+
+  if (overlapDecision === "skip" && overlapMs > 0) {
+    // Ceil so the first retained frame is never earlier than the source range
+    // already emitted. The epsilon avoids rounding an exact frame boundary up.
+    trimStartFrames = Math.min(frameCount, Math.ceil((overlapMs * sampleRate) / 1000 - 1e-9));
+    if (trimStartFrames >= frameCount) return { action: "drop" };
+  }
+
+  return {
+    action: "emit",
+    outputStartMs: lastOutputEndMs,
+    trimStartFrames,
+  };
+}

--- a/web-ui/src/playback-engine/worker/pipeline.ts
+++ b/web-ui/src/playback-engine/worker/pipeline.ts
@@ -1,7 +1,7 @@
 import type { PlayerConfig } from "../config";
 import { createDefaultConfig } from "../config";
 import { WorkerAudioDecoder } from "../decoder/worker-audio-decoder";
-import TSDemuxer, { type TSAudioTrackInfo } from "../demux/ts-demuxer";
+import TSDemuxer, { type RawMp2AudioFrame, type TSAudioTrackInfo } from "../demux/ts-demuxer";
 import { type DemuxErrorDetail, type LoaderErrorDetail, PlayerErrors } from "../errors";
 import {
   containsMoov,
@@ -171,6 +171,7 @@ class Pipeline {
   private _fmp4Timescales = new Map<number, number>();
   private _fmp4TimestampOffsetWarningLogged = false;
   private _timelineAnchorSent = false;
+  private _resetAudioParserAtNextTsBoundary = false;
 
   // --- player-facing media metadata ---
   private _mediaInfo: PlayerMediaInfo = {};
@@ -199,7 +200,6 @@ class Pipeline {
     channels: number;
     sampleRate: number;
     ptsMs: number;
-    durationMs: number;
   }> = [];
   /** Incremented on audio timing resets to invalidate decode callbacks queued before the reset. */
   private _audioGen = 0;
@@ -559,6 +559,7 @@ class Pipeline {
     this._fmp4Timescales = new Map();
     this._fmp4TimestampOffsetWarningLogged = false;
     this._timelineAnchorSent = false;
+    this._resetAudioParserAtNextTsBoundary = false;
     this._paused = false;
     this._sourceMode = "static-ts-list";
     this._resumeGate?.();
@@ -625,7 +626,7 @@ class Pipeline {
       }
 
       try {
-        if (meta.resetRemuxer) {
+        if (this._shouldResetTransmux(meta)) {
           const initSegmentChanged = meta.initUrl !== undefined && meta.initUrl !== this._lastInitUrl;
           this._resetTransmux(meta.start, !this._fmp4Mode || initSegmentChanged);
         }
@@ -687,8 +688,12 @@ class Pipeline {
     this._resetAudioDecodeState();
   }
 
+  private _shouldResetTransmux(meta: SegmentMeta): boolean {
+    return meta.resetReason === "initial" || (meta.resetReason === "playlist-reset" && this._fmp4Mode);
+  }
+
   private _shouldAnchorSegment(meta: SegmentMeta): boolean {
-    return meta.resetRemuxer || !this._hlsSource;
+    return this._shouldResetTransmux(meta) || !this._hlsSource;
   }
 
   private _finishTsInputBoundary(): void {
@@ -696,7 +701,6 @@ class Pipeline {
     // remux batch is not mixed with the previous segment's tail.
     this._demuxer?.flushSegmentBoundary();
     this._remuxer?.flushStashedSamples();
-    this._resetAudioDecodeState();
   }
 
   private _prepareContinuousLiveTsRestart(meta: SegmentMeta, ioctl: FetchLoader): void {
@@ -705,6 +709,8 @@ class Pipeline {
     }
 
     this._finishTsInputBoundary();
+    this._resetAudioParserAtNextTsBoundary = true;
+    this._resetAudioDecodeState();
     this._fmp4Mode = false;
     this._fmp4Chunks = [];
     ioctl.onDataArrival = (data, byteStart) => this._onInputChunk(meta, data, byteStart);
@@ -819,11 +825,12 @@ class Pipeline {
     const canReuseHls = this._hlsSource !== null && !shouldAnchor && this._demuxer !== null && this._remuxer !== null;
     const canReuseTsInputBoundary = this._sourceMode !== "hls" && this._demuxer !== null && this._remuxer !== null;
     const canReuse = canReuseHls || canReuseTsInputBoundary;
+    const resetAudioParserState = this._resetAudioParserAtNextTsBoundary;
+    this._resetAudioParserAtNextTsBoundary = false;
     if (canReuse) {
       this._demuxer?.resetSegmentBoundary(probeData as ConstructorParameters<typeof TSDemuxer>[0], {
-        resetAudioParserState: canReuseTsInputBoundary,
+        resetAudioParserState,
       });
-      this._remuxer?.setTsSegmentContinuityNormalization(canReuseTsInputBoundary);
       return;
     }
 
@@ -848,8 +855,6 @@ class Pipeline {
       }
       this._pendingDtsOffsetMs = 0;
     }
-    this._remuxer.setTsSegmentContinuityNormalization(false);
-
     demuxer.onError = this._onDemuxException.bind(this);
     demuxer.timestampBase = 0;
     demuxer.onTrackDiscontinuity = (track) => {
@@ -1051,10 +1056,7 @@ class Pipeline {
 
   // ---- MP2 software audio decode ----
 
-  private _handleRawAudioFrame(
-    frame: { codec: "mp2"; data: Uint8Array; pts: number },
-    needsOwnTimelineBase: boolean,
-  ): void {
+  private _handleRawAudioFrame(frame: RawMp2AudioFrame, needsOwnTimelineBase: boolean): void {
     // Lazily create WorkerAudioDecoder on first raw audio frame
     if (!this._workerAudioDecoder) {
       const mp2Url = this._config.wasmDecoders.mp2;
@@ -1071,27 +1073,23 @@ class Pipeline {
       const result = this._workerAudioDecoder.decode(frame.data);
       if (!result) return;
 
-      // PTS extrapolation: anchor on the PES PTS, advance by decoded sample count.
-      // This gives every decoded chunk a jitter-free timestamp even when frames
-      // straddle PES boundaries or a PES contains multiple frames. Re-anchor only
-      // on genuine discontinuities (> 100ms deviation).
+      // A real PES PTS always wins so the continuity mapper can observe source
+      // gaps and overlaps. Sample-count extrapolation is used only when the PES
+      // genuinely carries no timestamp.
       const sr = result.sampleRate;
       const carriedSamples = Math.min(Math.max(0, result.samplesBeforeInput), result.samplesPerChannel);
-      const decodedStartPts = frame.pts - (carriedSamples / sr) * 1000;
+      const decodedStartPts = frame.pts === undefined ? undefined : frame.pts - (carriedSamples / sr) * 1000;
       if (this._audioAnchorPtsMs === null || this._audioSampleRate !== sr) {
+        if (decodedStartPts === undefined) {
+          Log.w(this.TAG, "Dropping decoded MP2 audio until the first timestamped PES");
+          return;
+        }
         this._audioAnchorPtsMs = decodedStartPts;
         this._audioSamplesSinceAnchor = 0;
         this._audioSampleRate = sr;
-      } else {
-        const extrapolatedMs = this._audioAnchorPtsMs + (this._audioSamplesSinceAnchor / sr) * 1000;
-        if (Math.abs(decodedStartPts - extrapolatedMs) > 100) {
-          Log.v(
-            this.TAG,
-            `Audio PTS discontinuity: decoded=${decodedStartPts.toFixed(1)}ms extrap=${extrapolatedMs.toFixed(1)}ms`,
-          );
-          this._audioAnchorPtsMs = decodedStartPts;
-          this._audioSamplesSinceAnchor = 0;
-        }
+      } else if (decodedStartPts !== undefined) {
+        this._audioAnchorPtsMs = decodedStartPts;
+        this._audioSamplesSinceAnchor = 0;
       }
       const ptsMs = this._audioAnchorPtsMs + (this._audioSamplesSinceAnchor / sr) * 1000;
       this._audioSamplesSinceAnchor += result.samplesPerChannel;
@@ -1112,9 +1110,8 @@ class Pipeline {
     ptsMs: number,
     needsOwnTimelineBase: boolean,
   ): void {
-    const durationMs = (Math.floor(pcm.length / channels) / sampleRate) * 1000;
     if (needsOwnTimelineBase) this._remuxer?.ensureAudioTimestampBase(ptsMs);
-    this._pendingPcm.push({ pcm, channels, sampleRate, ptsMs, durationMs });
+    this._pendingPcm.push({ pcm, channels, sampleRate, ptsMs });
 
     if (this._remuxer?.getTimestampBase() === undefined) {
       // Bound the queue: ~25s of audio at one payload per ~72ms is plenty
@@ -1129,7 +1126,8 @@ class Pipeline {
 
     for (let i = 0; i < pending.length; i++) {
       const item = pending[i];
-      const mapping = this._remuxer?.mapPcmTimestamp(item.ptsMs, item.durationMs);
+      const totalFrames = Math.floor(item.pcm.length / item.channels);
+      const mapping = this._remuxer?.mapPcmTimestamp(item.ptsMs, totalFrames, item.sampleRate);
       if (mapping === undefined) {
         this._pendingPcm.push(...pending.slice(i));
         if (this._pendingPcm.length > 512) {
@@ -1142,15 +1140,11 @@ class Pipeline {
       }
 
       let pcm = item.pcm;
-      if (mapping.trimStartMs > 0) {
-        const cutFrames = Math.round((mapping.trimStartMs / 1000) * item.sampleRate);
-        const totalFrames = Math.floor(pcm.length / item.channels);
-        if (cutFrames >= totalFrames) {
+      if (mapping.trimStartFrames > 0) {
+        if (mapping.trimStartFrames >= totalFrames) {
           continue;
         }
-        if (cutFrames > 0) {
-          pcm = pcm.slice(cutFrames * item.channels);
-        }
+        pcm = pcm.slice(mapping.trimStartFrames * item.channels);
       }
       if (this._forcedTrack === "audio") {
         this._remuxer?.remuxSilentAudioRange(

--- a/web-ui/src/playback-engine/worker/segment-source.ts
+++ b/web-ui/src/playback-engine/worker/segment-source.ts
@@ -6,8 +6,8 @@ export interface SegmentMeta {
   start: number;
   /** Segment duration in seconds (0 if unknown / live). */
   duration: number;
-  /** Destroy and recreate the remuxer before this segment, re-anchoring output at `start` (HLS discontinuity / seek). */
-  resetRemuxer: boolean;
+  /** Why the transmuxer may need resetting. MPEG-TS ignores playlist resets; fMP4 keeps its period reset. */
+  resetReason?: "initial" | "playlist-reset";
   /** fMP4 initialization segment URL (HLS EXT-X-MAP), if any. */
   initUrl?: string;
 }
@@ -30,7 +30,6 @@ export class StaticSegmentSource implements SegmentSource {
         url: seg.url,
         start,
         duration: seg.duration ?? 0,
-        resetRemuxer: false,
       };
       start += seg.duration ?? 0;
       return meta;
@@ -56,7 +55,6 @@ export class ContinuousLiveSegmentSource implements SegmentSource {
       url: segment.url,
       start: 0,
       duration: 0,
-      resetRemuxer: false,
     };
   }
 


### PR DESCRIPTION
## Summary

Normalize MPEG-TS timestamps across HLS segments and continuous TS input boundaries so playback remains continuous when upstream segments contain timestamp gaps, small overlaps, or large backward jumps.

The player now:

- removes timestamp gaps of any size and appends samples to the existing output timeline
- skips duplicate samples for overlaps up to and including 10 seconds
- retains samples after backward jumps larger than 10 seconds and rebases them onto the continuous output timeline
- applies the same policy to remuxed audio/video and software-decoded MP2 PCM
- ignores HLS playlist discontinuity metadata for TS timeline normalization while preserving explicit reset behavior for fMP4 periods

## Root cause

TS timestamp continuity handling was split between segment-boundary orchestration, remuxing, and PCM scheduling. HLS segment resets could discard continuity state, while decoded PCM extrapolation could hide real source gaps and overlaps. This caused later HLS TS segments to stall or diverge from the media timeline even though the first segment played normally.

## Implementation

The shared overlap decision and PCM range mapping live in a focused timeline module. Segment metadata now describes reset intent instead of directly commanding a remuxer reset, allowing the pipeline to distinguish TS and fMP4 behavior. MP2 raw frame typing and parser reset boundaries were also consolidated.

DevLab adds deterministic HLS and RTSP overlap, gap, restart, and packet-loss scenarios. Its README documents how browser automation must handle trusted user gestures for audible playback.

## Validation

- `pnpm run type-check`
- `pnpm run lint`
- `pnpm run web-ui:build`
- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AGGRESSIVE_OPT=ON`
- `cmake --build build -j "$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu)"`
- `git diff --check`
