### PR TITLE
fix(http-proxy): preserve m3u redirect semantics

### DIFF
--- a/e2e/test_http_proxy_m3u_rewrite.py
+++ b/e2e/test_http_proxy_m3u_rewrite.py
@@ -688,6 +688,36 @@ class TestM3URewriteContentType:
         finally:
             upstream.stop()
 
+    def test_m3u_url_redirect_keeps_http_redirect_semantics(self, shared_r2h):
+        """A redirect from an M3U URL should rewrite Location, not its HTML body."""
+        redirect_body = b"<html>redirecting</html>\n"
+        upstream = MockHTTPUpstream(
+            routes={
+                "/archive/index.m3u8": {
+                    "status": 302,
+                    "body": redirect_body,
+                    "headers": {
+                        "Content-Type": "text/html",
+                        "Location": "http://10.0.0.1:8080/final/index.m3u8",
+                    },
+                },
+            }
+        )
+        upstream.start()
+        try:
+            status, hdrs, body = http_get(
+                "127.0.0.1",
+                shared_r2h.port,
+                f"/http/127.0.0.1:{upstream.port}/archive/index.m3u8",
+                timeout=_TIMEOUT,
+            )
+
+            assert status == 302
+            assert get_header(hdrs, "Location") == "/http/10.0.0.1:8080/final/index.m3u8"
+            assert body == redirect_body
+        finally:
+            upstream.stop()
+
 
 # ---------------------------------------------------------------------------
 # Complex / realistic playlists

--- a/src/http_proxy.c
+++ b/src/http_proxy.c
@@ -1133,14 +1133,17 @@ static int http_proxy_parse_response_headers(http_proxy_session_t *session) {
 
   session->headers_received = 1;
 
-  /* Check if response body needs rewriting (M3U content). URL extension takes
-   * precedence; fall back to Content-Type only when the URL is not M3U-like.
+  /* Check if a successful response body needs rewriting (M3U content). URL
+   * extension takes precedence; fall back to Content-Type only when the URL
+   * is not M3U-like. Non-2xx responses must retain normal HTTP semantics,
+   * especially redirect Location rewriting and error response passthrough.
    * Skip for HEAD requests — there is no body to rewrite. */
   int is_m3u_response = rewrite_is_m3u_url(session->target_path);
   if (!is_m3u_response)
     is_m3u_response = rewrite_is_m3u_content_type(session->response_content_type);
 
-  if (is_m3u_response && strcasecmp(session->method, "HEAD") != 0) {
+  if (session->response_status_code >= 200 && session->response_status_code < 300 && is_m3u_response &&
+      strcasecmp(session->method, "HEAD") != 0) {
     if (session->transfer_encoding_seen && (!session->response_is_chunked || session->unsupported_transfer_coding)) {
       logger(LOG_ERROR, "HTTP Proxy: Unsupported Transfer-Encoding for M3U rewrite");
       return -1;


### PR DESCRIPTION
## Summary

- restrict M3U response body rewriting to successful 2xx responses
- preserve normal HTTP redirect handling for M3U and M3U8 request paths
- add an end-to-end regression test covering a 302 M3U8 response with an HTML body

## Root cause

M3U detection by URL extension ran for every response status. A 302 response from a path ending in .m3u8 therefore entered the playlist body rewrite path, which bypassed the existing Location header rewrite and treated the redirect body as playlist content. Clients could then be redirected directly to an IPTV-only upstream address that they could not access.

## Impact

Redirects and error responses from M3U endpoints now retain normal HTTP semantics. Successful playlist responses continue to be decoded and rewritten as before.

## Validation

- Release CMake build
- pnpm run lint:clang
- uv run ruff check e2e
- ./scripts/run-e2e.sh -p 1 test_http_proxy_m3u_rewrite.py — 52 passed
- ./scripts/run-e2e.sh -p 1 test_http_proxy.py — 19 passed
- ./scripts/run-e2e.sh -p 1 test_url_template_m3u.py — 19 passed
- uv run pytest e2e --collect-only -q — 540 tests collected
- ./scripts/run-e2e.sh --co — 540 tests collected
- git diff --check