### PR TITLE
Check allocation before response initialization

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -934,6 +934,8 @@ int parse_config_file(const char *path) {
 bindaddr_t *new_empty_bindaddr(void) {
   bindaddr_t *ba;
   ba = malloc(sizeof(bindaddr_t));
+  if (!ba)
+      return NULL;
   memset(ba, 0, sizeof(*ba));
   ba->type = BIND_ADDR_TCP;
   ba->service = strdup("5140");


### PR DESCRIPTION
## Summary

- check the allocation result before initializing the newly allocated response buffer
- return the existing empty-result sentinel when allocation cannot be satisfied

## Validation

- configured and built the project with six parallel jobs
- ran the built executable's help smoke check
- reran the independent path analysis; the reported unchecked-allocation path is no longer present

