### PR TITLE
docs(related-resources): add LiteTV and refresh player list

### DIFF
--- a/.agents/skills/translate-docs-zh-en/references/translation-memory.md
+++ b/.agents/skills/translate-docs-zh-en/references/translation-memory.md
@@ -4,7 +4,7 @@
 
 ### Preserved Product/Technical Names
 
-- rtp2httpd, udpxy, msd_lite, FFmpeg, APTV, TiviMate, Wireshark
+- rtp2httpd, udpxy, msd_lite, FFmpeg, APTV, TiviMate, LiteTV, Wireshark
 - FCC (Fast Channel Change) - expand on first use
 - FEC (Forward Error Correction) - expand on first use
 - VA-API, V4L2, QSV - hardware acceleration names

--- a/docs/en/guide/video-snapshot.md
+++ b/docs/en/guide/video-snapshot.md
@@ -3,7 +3,7 @@
 rtp2httpd supports generating video stream snapshots using FFmpeg. Players that integrate this feature achieve extremely fast channel preview loading.
 
 > [!IMPORTANT]
-> This feature requires player support. Currently, the only known player that supports rtp2httpd video snapshots is [mytv-android](https://github.com/mytv-android/mytv-android).
+> This feature requires player support. Currently known players that support rtp2httpd video snapshots are [mytv-android](https://github.com/mytv-android/mytv-android) and [SrcBox](https://github.com/CGG888/SrcBox).
 
 ## Features
 

--- a/docs/en/reference/related-resources.md
+++ b/docs/en/reference/related-resources.md
@@ -40,9 +40,13 @@ If you are new to setting up IPTV multicast forwarding services and unfamiliar w
 
 - Project: <https://github.com/mytv-android/mytv-android>
 
-Android IPTV player with support for M3U playlists, FCC fast channel switching, EPG electronic program guide, time-shift playback, and more.
+Android IPTV player with support for M3U playlists, FCC fast channel switching, EPG electronic program guide, time-shift playback, rtp2httpd [video snapshots](../guide/video-snapshot.md), and more.
 
-Currently the only player supporting rtp2httpd [video snapshots](../guide/video-snapshot.md).
+#### LiteTV
+
+- Project: <https://github.com/vibe4free/LiteTV>
+
+Minimal IPTV live player for Android TV / Google TV, deeply optimized for remote control and close to native set-top box operation. Supports M3U / TXT playlists, EPG, channel groups and favorites, plus a built-in web UI for configuring live sources and EPG. Channel switching reuses the player instance, with start and switch speed close to rtp2httpd's built-in web player.
 
 #### APTV
 
@@ -54,18 +58,7 @@ IPTV M3U player with a polished Apple ecosystem experience, covering iPhone, iPa
 
 - Project: <https://github.com/CGG888/SrcBox>
 
-Windows IPTV player based on libmpv playback engine and WPF native interface. Supports M3U playlists, FCC fast channel switching, EPG electronic program guide, time-shift playback, UDP multicast optimization, and more.
-
-#### IPTVnator (CGG888 fork)
-
-- Project: <https://github.com/CGG888/iptvnator>
-
-Cross-platform (Windows / macOS / Linux) IPTV player. This fork is enhanced for mainland China IPTV scenarios. Main features:
-
-- Automatically identifies multicast/unicast sources and selects the best playback engine (mpegts.js for multicast, hls.js for unicast)
-- Supports time-shift playback
-- 4K/HD/SD quality strategy, channels with the same name prioritized by quality
-- Smart EPG channel name matching and Chinese localization
+Windows IPTV player based on libmpv playback engine and WPF native interface. Supports M3U playlists, FCC fast channel switching, EPG electronic program guide, time-shift playback, UDP multicast optimization, rtp2httpd [video snapshots](../guide/video-snapshot.md), and more.
 
 #### iptvys
 

--- a/docs/guide/video-snapshot.md
+++ b/docs/guide/video-snapshot.md
@@ -3,7 +3,7 @@
 rtp2httpd 支持使用 FFmpeg 来生成视频流的快照（snapshot）功能。如果播放器集成了此功能，将会获得极快的频道预览图加载速度。
 
 > [!IMPORTANT]
-> 此功能需要播放器支持，目前已知支持 rtp2httpd 视频快照的播放器只有 [mytv-android](https://github.com/mytv-android/mytv-android)。
+> 此功能需要播放器支持，目前已知支持 rtp2httpd 视频快照的播放器有 [mytv-android](https://github.com/mytv-android/mytv-android) 和 [SrcBox](https://github.com/CGG888/SrcBox)。
 
 ## 功能特点
 

--- a/docs/reference/related-resources.md
+++ b/docs/reference/related-resources.md
@@ -40,9 +40,13 @@
 
 - 项目地址：<https://github.com/mytv-android/mytv-android>
 
-Android 平台 IPTV 播放器，支持 M3U 播放列表、FCC 快速换台、EPG 电子节目单、时移回看等功能。
+Android 平台 IPTV 播放器，支持 M3U 播放列表、FCC 快速换台、EPG 电子节目单、时移回看、rtp2httpd [视频快照](../guide/video-snapshot.md) 等功能。
 
-目前唯一支持 rtp2httpd [视频快照](../guide/video-snapshot.md) 的播放器。
+#### LiteTV
+
+- 项目地址：<https://github.com/vibe4free/LiteTV>
+
+面向 Android TV / Google TV 的极简 IPTV 直播播放器，针对遥控器操作深度优化，交互接近机顶盒原版习惯。支持 M3U / TXT 播放列表、EPG 电子节目单、频道分组与收藏，可通过网页远程配置直播源和 EPG。换台复用播放器实例，起播与切换速度接近 rtp2httpd 内置 Web 播放器。
 
 #### APTV
 
@@ -54,18 +58,7 @@ Android 平台 IPTV 播放器，支持 M3U 播放列表、FCC 快速换台、EPG
 
 - 项目地址：<https://github.com/CGG888/SrcBox>
 
-Windows 平台 IPTV 播放器，基于 libmpv 播放内核和 WPF 原生界面。支持 M3U 播放列表、FCC 快速切台、EPG 电子节目单、时移回看、UDP 组播优化等功能。
-
-#### IPTVnator (CGG888 fork)
-
-- 项目地址：<https://github.com/CGG888/iptvnator>
-
-Windows / macOS / Linux 跨平台 IPTV 播放器，此 fork 针对中国大陆 IPTV 场景增强，主要特性：
-
-- 自动识别组播/单播来源，选择最佳播放内核（组播用 mpegts.js，单播用 hls.js）
-- 支持时移回看
-- 4K/高清/标清画质策略，同名频道按质量优先排序
-- EPG 频道名称智能匹配与中文化
+Windows 平台 IPTV 播放器，基于 libmpv 播放内核和 WPF 原生界面。支持 M3U 播放列表、FCC 快速切台、EPG 电子节目单、时移回看、UDP 组播优化、rtp2httpd [视频快照](../guide/video-snapshot.md) 等功能。
 
 #### IPTV 影视 iptvys
 


### PR DESCRIPTION
## Summary
- Add [LiteTV](https://github.com/vibe4free/LiteTV) to related software recommendations ([#699](https://github.com/stackia/rtp2httpd/issues/699)).
- Note that both mytv-android and SrcBox support rtp2httpd video snapshots.
- Remove the unmaintained IPTVnator (CGG888 fork) entry.

## Test plan
- [x] Check the related software section in Chinese and English docs
- [x] Confirm video snapshot docs list both mytv-android and SrcBox