### PR TITLE
perf(web-player): stream worker-parsed EPG in chunks to avoid main-thread freeze

### DIFF
--- a/web-ui/src/lib/epg-loader.ts
+++ b/web-ui/src/lib/epg-loader.ts
@@ -1,38 +1,50 @@
 import type { EPGData } from "./epg-parser";
+import { createEPGReassembler, type EPGCatchupChannel, type EPGWorkerMessage, type EPGWorkerRequest } from "./epg-wire";
 import EPGWorker from "./epg-worker.ts?worker&inline";
-
-interface EPGWorkerRequest {
-  url: string;
-  validChannelIds?: string[];
-}
-
-type EPGWorkerResponse = { type: "success"; epg: EPGData } | { type: "error"; message: string };
 
 let inFlight: Promise<EPGData> | null = null;
 
 /**
  * Fetch and parse an XMLTV EPG in a Web Worker so the main thread stays responsive.
+ * The worker streams the parsed result back in small chunks (see epg-wire.ts);
+ * reassembling one chunk per message task avoids the single long
+ * deserialization freeze a monolithic postMessage would cause.
  * The player loads EPG once; overlapping calls share the same in-flight job
  * (React StrictMode remount) instead of starting a second parse.
  */
-export function loadEPG(url: string, validChannelIds?: Set<string>): Promise<EPGData> {
+export function loadEPG(
+  url: string,
+  validChannelIds?: Set<string>,
+  catchupChannels?: EPGCatchupChannel[],
+): Promise<EPGData> {
   if (inFlight) {
     return inFlight;
   }
 
   const worker = new EPGWorker();
   inFlight = new Promise((resolve, reject) => {
+    const reassembler = createEPGReassembler();
     const finish = () => {
       worker.terminate();
     };
 
-    worker.onmessage = (event: MessageEvent<EPGWorkerResponse>) => {
-      finish();
-      if (event.data.type === "success") {
-        resolve(event.data.epg);
-        return;
+    worker.onmessage = (event: MessageEvent<EPGWorkerMessage>) => {
+      try {
+        const message = event.data;
+        if (message.type === "chunk") {
+          reassembler.applyChunk(message.channels);
+          return;
+        }
+        finish();
+        if (message.type === "done") {
+          resolve(reassembler.finish(message.aliases));
+          return;
+        }
+        reject(new Error(message.message));
+      } catch (error) {
+        finish();
+        reject(error);
       }
-      reject(new Error(event.data.message));
     };
 
     worker.onerror = (event) => {
@@ -44,6 +56,7 @@ export function loadEPG(url: string, validChannelIds?: Set<string>): Promise<EPG
       // Inline blob workers resolve relative URLs against `blob:`, so make this absolute first.
       url: new URL(url, document.baseURI).href,
       validChannelIds: validChannelIds ? Array.from(validChannelIds) : undefined,
+      catchupChannels,
     };
     worker.postMessage(request);
   });

--- a/web-ui/src/lib/epg-parser.ts
+++ b/web-ui/src/lib/epg-parser.ts
@@ -334,45 +334,60 @@ export function fillEPGGaps(
       continue;
     }
 
-    // Get the EPG channel ID using fallback logic
-    const epgChannelId =
-      channel.tvgId && filledData[channel.tvgId]
-        ? channel.tvgId
-        : channel.tvgName && filledData[channel.tvgName]
-          ? channel.tvgName
-          : channel.name && filledData[channel.name]
-            ? channel.name
-            : null;
-
-    let existingPrograms: EPGProgram[] = [];
-    const targetChannelId = epgChannelId || channel.tvgId || channel.tvgName || channel.name;
-
-    if (epgChannelId) {
-      existingPrograms = filledData[epgChannelId] || [];
-    }
-
-    // Generate fallback programs for gaps
-    const fallbackPrograms = generateFallbackPrograms(existingPrograms, targetChannelId, lookbackHours);
-
-    if (fallbackPrograms.length > 0) {
-      // Merge existing and fallback programs, then sort by start time
-      const mergedPrograms = [...existingPrograms, ...fallbackPrograms].sort(
-        (a, b) => a.start.getTime() - b.start.getTime(),
-      );
-
-      // Ensure all possible channel ID keys point to the same array
-      filledData[targetChannelId] = mergedPrograms;
-      if (channel.tvgId && channel.tvgId !== targetChannelId) {
-        filledData[channel.tvgId] = mergedPrograms;
-      }
-      if (channel.tvgName && channel.tvgName !== targetChannelId) {
-        filledData[channel.tvgName] = mergedPrograms;
-      }
-      if (channel.name !== targetChannelId) {
-        filledData[channel.name] = mergedPrograms;
-      }
-    }
+    fillChannelEPGGaps(filledData, channel, lookbackHours);
   }
 
   return filledData;
+}
+
+/**
+ * Fill gaps for a single catchup-capable channel, mutating filledData in place
+ */
+export function fillChannelEPGGaps(
+  filledData: EPGData,
+  channel: {
+    tvgId?: string;
+    tvgName?: string;
+    name: string;
+  },
+  lookbackHours: number = 72,
+): void {
+  // Get the EPG channel ID using fallback logic
+  const epgChannelId =
+    channel.tvgId && filledData[channel.tvgId]
+      ? channel.tvgId
+      : channel.tvgName && filledData[channel.tvgName]
+        ? channel.tvgName
+        : channel.name && filledData[channel.name]
+          ? channel.name
+          : null;
+
+  let existingPrograms: EPGProgram[] = [];
+  const targetChannelId = epgChannelId || channel.tvgId || channel.tvgName || channel.name;
+
+  if (epgChannelId) {
+    existingPrograms = filledData[epgChannelId] || [];
+  }
+
+  // Generate fallback programs for gaps
+  const fallbackPrograms = generateFallbackPrograms(existingPrograms, targetChannelId, lookbackHours);
+
+  if (fallbackPrograms.length > 0) {
+    // Merge existing and fallback programs, then sort by start time
+    const mergedPrograms = [...existingPrograms, ...fallbackPrograms].sort(
+      (a, b) => a.start.getTime() - b.start.getTime(),
+    );
+
+    // Ensure all possible channel ID keys point to the same array
+    filledData[targetChannelId] = mergedPrograms;
+    if (channel.tvgId && channel.tvgId !== targetChannelId) {
+      filledData[channel.tvgId] = mergedPrograms;
+    }
+    if (channel.tvgName && channel.tvgName !== targetChannelId) {
+      filledData[channel.tvgName] = mergedPrograms;
+    }
+    if (channel.name !== targetChannelId) {
+      filledData[channel.name] = mergedPrograms;
+    }
+  }
 }

--- a/web-ui/src/lib/epg-wire.ts
+++ b/web-ui/src/lib/epg-wire.ts
@@ -1,0 +1,161 @@
+import type { EPGProgram } from "../types/player";
+import type { EPGData } from "./epg-parser";
+
+/**
+ * Wire protocol between the EPG Web Worker and the main thread.
+ *
+ * A parsed EPG can hold 100k+ programmes. Posting it as one message makes the
+ * main thread deserialize the whole object graph in a single synchronous task,
+ * which freezes the page. Instead the worker streams the result as small
+ * chunks — each `message` task stays short, so input and rendering can
+ * interleave — and the loader reassembles them incrementally.
+ *
+ * Programmes travel as [startMs, endMs, title] tuples rather than EPGProgram
+ * objects: positional arrays avoid per-object property names and Date wrappers
+ * in the structured clone, which is the dominant per-programme cost.
+ */
+export type EPGWireProgram = [startMs: number, endMs: number, title: string | undefined];
+
+/** Catchup-capable channel the worker should gap-fill with fallback programmes. */
+export interface EPGCatchupChannel {
+  tvgId?: string;
+  tvgName?: string;
+  name: string;
+}
+
+export interface EPGWorkerRequest {
+  url: string;
+  validChannelIds?: string[];
+  catchupChannels?: EPGCatchupChannel[];
+}
+
+export interface EPGChunkChannel {
+  key: string;
+  programs: EPGWireProgram[];
+}
+
+export type EPGWorkerMessage =
+  | { type: "chunk"; channels: EPGChunkChannel[] }
+  | { type: "done"; aliases: [alias: string, primary: string][] }
+  | { type: "error"; message: string };
+
+/**
+ * Programmes per chunk. Sized so deserializing and rehydrating one chunk takes
+ * a few ms even on low-power devices (smart TVs), keeping the page responsive.
+ */
+export const EPG_CHUNK_SIZE = 2000;
+
+/**
+ * Split EPG data into unique programme arrays plus an alias map.
+ * EPGData aliases the same array under several keys (tvgId / tvgName / name);
+ * sending each array once under its first key keeps the payload minimal, and
+ * the aliases restore the remaining keys on the receiving side.
+ */
+export function splitEPGAliases(epg: EPGData): {
+  unique: [key: string, programs: EPGProgram[]][];
+  aliases: [alias: string, primary: string][];
+} {
+  const seen = new Map<EPGProgram[], string>();
+  const unique: [string, EPGProgram[]][] = [];
+  const aliases: [string, string][] = [];
+
+  for (const key of Object.keys(epg)) {
+    const programs = epg[key];
+    const primary = seen.get(programs);
+    if (primary !== undefined) {
+      aliases.push([key, primary]);
+    } else {
+      seen.set(programs, key);
+      unique.push([key, programs]);
+    }
+  }
+
+  return { unique, aliases };
+}
+
+/**
+ * Serialize unique programme arrays into chunks of roughly `chunkSize`
+ * programmes. A channel's programmes may span consecutive chunks; the receiver
+ * appends them in order (postMessage is FIFO).
+ */
+export function* chunkEPGPrograms(
+  unique: [key: string, programs: EPGProgram[]][],
+  chunkSize: number = EPG_CHUNK_SIZE,
+): Generator<{ channels: EPGChunkChannel[] }, void, void> {
+  let channels: EPGChunkChannel[] = [];
+  let count = 0;
+
+  for (const [key, programs] of unique) {
+    if (programs.length === 0) {
+      channels.push({ key, programs: [] });
+      continue;
+    }
+
+    let offset = 0;
+    while (offset < programs.length) {
+      const take = Math.min(chunkSize - count, programs.length - offset);
+      const wire: EPGWireProgram[] = new Array(take);
+      for (let i = 0; i < take; i++) {
+        const program = programs[offset + i];
+        wire[i] = [program.start.getTime(), program.end.getTime(), program.title];
+      }
+      channels.push({ key, programs: wire });
+      count += take;
+      offset += take;
+
+      if (count >= chunkSize) {
+        yield { channels };
+        channels = [];
+        count = 0;
+      }
+    }
+  }
+
+  if (channels.length > 0) {
+    yield { channels };
+  }
+}
+
+export interface EPGReassembler {
+  applyChunk(channels: EPGChunkChannel[]): void;
+  finish(aliases: [alias: string, primary: string][]): EPGData;
+}
+
+/**
+ * Incrementally rebuild EPGData from wire chunks. Runs on the main thread, one
+ * call per worker message, so the per-chunk work stays small. Programme IDs
+ * are recomputed from the channel key and start time, matching the format the
+ * parser produces (`${channelId}-${startMs}`).
+ */
+export function createEPGReassembler(): EPGReassembler {
+  const epg: EPGData = {};
+
+  return {
+    applyChunk(channels) {
+      for (const { key, programs } of channels) {
+        let bucket = epg[key];
+        if (!bucket) {
+          bucket = [];
+          epg[key] = bucket;
+        }
+        for (const [startMs, endMs, title] of programs) {
+          bucket.push({
+            id: `${key}-${startMs}`,
+            title,
+            start: new Date(startMs),
+            end: new Date(endMs),
+          });
+        }
+      }
+    },
+    finish(aliases) {
+      for (const [alias, primary] of aliases) {
+        const programs = epg[primary];
+        if (programs) {
+          epg[alias] = programs;
+        }
+      }
+      return epg;
+    },
+  };
+}

--- a/web-ui/src/lib/epg-worker.ts
+++ b/web-ui/src/lib/epg-worker.ts
@@ -1,18 +1,12 @@
-import { parseEPG } from "./epg-parser";
+import { fillChannelEPGGaps, parseEPG } from "./epg-parser";
+import { chunkEPGPrograms, type EPGWorkerMessage, type EPGWorkerRequest, splitEPGAliases } from "./epg-wire";
 
-interface EPGWorkerRequest {
-  url: string;
-  validChannelIds?: string[];
-}
-
-type EPGWorkerResponse = { type: "success"; epg: ReturnType<typeof parseEPG> } | { type: "error"; message: string };
-
-function post(message: EPGWorkerResponse): void {
+function post(message: EPGWorkerMessage): void {
   (self as unknown as { postMessage(msg: unknown): void }).postMessage(message);
 }
 
 self.addEventListener("message", async (event: MessageEvent<EPGWorkerRequest>) => {
-  const { url, validChannelIds } = event.data;
+  const { url, validChannelIds, catchupChannels } = event.data;
   try {
     const response = await fetch(url);
     if (!response.ok) {
@@ -20,7 +14,21 @@ self.addEventListener("message", async (event: MessageEvent<EPGWorkerRequest>) =
     }
     const xmlText = await response.text();
     const epg = parseEPG(xmlText, validChannelIds ? new Set(validChannelIds) : undefined);
-    post({ type: "success", epg });
+
+    // Gap-fill here so the main thread never pays for it when the result lands.
+    if (catchupChannels?.length) {
+      for (const channel of catchupChannels) {
+        fillChannelEPGGaps(epg, channel);
+      }
+    }
+
+    // Stream the result in chunks: one giant message would deserialize in a
+    // single synchronous main-thread task and freeze the page.
+    const { unique, aliases } = splitEPGAliases(epg);
+    for (const chunk of chunkEPGPrograms(unique)) {
+      post({ type: "chunk", channels: chunk.channels });
+    }
+    post({ type: "done", aliases });
   } catch (error) {
     post({
       type: "error",

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -428,12 +428,16 @@ function PlayerPage() {
           validChannelIds.add(channel.name);
         }
 
+        // The worker gap-fills catchup channels before streaming the result back.
+        const catchupChannels = parsed.channels
+          .filter((channel) => channel.sources.some((s) => s.catchup && s.catchupSource))
+          .map((channel) => ({ tvgId: channel.tvgId, tvgName: channel.tvgName, name: channel.name }));
+
         const epgUrl = parsed.tvgUrl.replace(".gz", "");
-        const channels = parsed.channels;
-        void loadEPG(epgUrl, validChannelIds)
+        void loadEPG(epgUrl, validChannelIds, catchupChannels)
           .then((epg) => {
             startTransition(() => {
-              setEpgData(fillEPGGaps(epg, channels));
+              setEpgData(epg);
             });
           })
           .catch((err) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #727. When the EPG worker finishes parsing, the result no longer returns to the main thread as one giant `postMessage`:

- **Chunked transfer**: the worker streams the parsed EPG as ~2000-programme chunks (`EPG_CHUNK_SIZE`). Each `message` task on the main thread deserializes only one small chunk, so input handling and rendering interleave instead of freezing for the whole deserialization.
- **Cheaper wire format**: programmes travel as flat `[startMs, endMs, title]` tuples instead of objects with named properties and `Date` wrappers — the dominant per-programme structured-clone cost. Aliased programme arrays (`tvgId` / `tvgName` / `name` keys) are sent once under their primary key and re-linked on arrival.
- **Gap-filling moved into the worker**: `fillEPGGaps` for catchup channels now runs in the worker (`fillChannelEPGGaps` extracted from `fillEPGGaps`), so the main thread only reassembles chunks and applies one `setEpgData` inside `startTransition` (unchanged).

New module `web-ui/src/lib/epg-wire.ts` holds the shared protocol: chunk serializer, alias splitter, and the incremental reassembler.

## Performance measurement

Harness: 800 channels / 76,800 programmes / 13 MB XMLTV, served to the production-built player; main-thread `longtask` entries captured via `PerformanceObserver` in headless Chrome (3 runs each, consistent).

| Metric | Before (main) | After (this PR) |
|---|---|---|
| Max long task | **254–255 ms** (at EPG arrival) | 52–56 ms (initial page load only) |
| Long tasks at EPG arrival | 1 × ~255 ms | **none** |
| Total blocking time | ~205 ms | ~4 ms |
| Time until EPG visible | ~1125 ms | ~1105 ms (no regression) |

## Test plan

- [x] `pnpm run type-check` and `pnpm run lint:biome` pass
- [x] Wire-protocol round-trip test (parse → gap-fill → split → chunk → reassemble) produces data identical to the previous direct path, including alias identity, merged gap-fill programmes, and pure-fallback channels
- [x] `pnpm run web-ui:build` succeeds (inline worker bundles cleanly)
- [x] `./scripts/run-e2e.sh -p 1 test_epg.py test_pages.py` — 28 passed
- [x] Manual: real daemon serving the 800-channel playlist + 13 MB EPG; channel list stays scrollable while programme titles pop in, programme guide renders date-grouped programmes, clicking a past programme triggers catchup seek

Made with [Cursor](https://cursor.com)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9300081-493d-4b73-9874-3a992b0fb7ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9300081-493d-4b73-9874-3a992b0fb7ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

