### PR TITLE
docs(installation): add systemd service unit sample

### DIFF
--- a/docs/en/guide/installation.md
+++ b/docs/en/guide/installation.md
@@ -50,6 +50,45 @@ chmod +x rtp2httpd-X.Y.Z-x86_64
 > [!TIP]
 > You can use this example file [rtp2httpd.conf](https://github.com/stackia/rtp2httpd/blob/main/rtp2httpd.conf) as a base to modify your configuration. See [Configuration Reference](/en/reference/configuration) for details.
 
+Also note that rtp2httpd no longer supports running as a daemon on its own. On Debian/Ubuntu systems, you can create a systemd service unit by adding the following content to `/etc/systemd/system/rtp2httpd.service`. Other operating systems using systemd as the service manager can also refer to the configuration below.
+
+```text
+[Unit]
+Description=rtp2httpd - Multicast RTP/RTSP to Unicast HTTP stream converter
+Documentation=https://github.com/stackia/rtp2httpd
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=10
+
+[Service]
+Type=simple
+# The path in ExecStart must match the actual installation location; you can verify it with `command -v rtp2httpd` or `which rtp2httpd`.
+# ExecStart=/usr/local/bin/rtp2httpd --config /etc/rtp2httpd.conf
+ExecStart=/opt/rtp2httpd/rtp2httpd --config /opt/rtp2httpd/rtp2httpd.conf
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+RestartSec=3s
+# It is recommended to run as a dedicated non-root user, which can be created via `useradd --system --no-create-home --shell /usr/sbin/nologin rtp2httpd`
+User=rtp2httpd
+Group=rtp2httpd
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+LimitMEMLOCK=infinity
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Once the file has been created, use the following commands to start the rtp2httpd service.
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now rtp2httpd
+sudo systemctl status rtp2httpd
+```
+
 ## Docker Container Deployment
 
 Suitable for Docker-capable devices. **Requires host network mode** to properly receive multicast streams.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -50,6 +50,45 @@ chmod +x rtp2httpd-X.Y.Z-x86_64
 > [!TIP]
 > 你可以使用这个示例文件 [rtp2httpd.conf](https://github.com/stackia/rtp2httpd/blob/main/rtp2httpd.conf) 作为基础来修改配置。具体说明见 [配置参数详解](../reference/configuration.md)。
 
+另外 rtp2httpd 目前已不支持自身以守护进程方式运行。对于 Debian/Ubuntu 系统，您可以在 `/etc/systemd/system/rtp2httpd.service` 内添加以下内容以创建 systemd 服务单元。其他使用 systemd 作为服务管理器的操作系统也可以参考以下配置进行配置。
+
+```text
+[Unit]
+Description=rtp2httpd - Multicast RTP/RTSP to Unicast HTTP stream converter
+Documentation=https://github.com/stackia/rtp2httpd
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=10
+
+[Service]
+Type=simple
+# ExecStart 中的路径需与实际安装位置一致，可用 `command -v rtp2httpd` 或 `which rtp2httpd` 确认。
+# ExecStart=/usr/local/bin/rtp2httpd --config /etc/rtp2httpd.conf
+ExecStart=/opt/rtp2httpd/rtp2httpd --config /opt/rtp2httpd/rtp2httpd.conf
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+RestartSec=3s
+# 建议以非 root 专用用户运行，可通过 `useradd --system --no-create-home --shell /usr/sbin/nologin rtp2httpd` 创建用户
+User=rtp2httpd
+Group=rtp2httpd
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+LimitMEMLOCK=infinity
+
+[Install]
+WantedBy=multi-user.target
+```
+
+文件创建完成后使用以下指令启动 rtp2httpd 服务。
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now rtp2httpd
+sudo systemctl status rtp2httpd
+```
+
 ## Docker 容器部署
 
 适用于支持 Docker 的设备。**需要使用 host 网络模式**以正确接收组播流。


### PR DESCRIPTION
在文档中新增了关于 systemd 服务单元的示例文件，从而完善 #96 #177 中提到的关于后台驻留运行方案中 systemd 方案的细节。