### PR TITLE
fix(player): split catchup segments on EPG boundaries

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,3 +27,4 @@ jobs:
 
       - run: pnpm run type-check
       - run: pnpm run lint
+      - run: pnpm run web-ui:test

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "web-ui:build": "vite build web-ui && node scripts/embed-dist.js web-ui/dist src/embedded_web_data.h",
     "web-ui:build:debug": "vite build web-ui --mode=development && node scripts/embed-dist.js web-ui/dist src/embedded_web_data.h",
     "web-ui:preview": "vite preview web-ui",
+    "web-ui:test": "vitest run --root web-ui",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
@@ -45,6 +46,7 @@
     "vite": "^8.2.1",
     "vite-bundle-analyzer": "^1.3.9",
     "vitepress": "2.0.0-alpha.19",
-    "vitepress-plugin-llms": "^1.13.4"
+    "vitepress-plugin-llms": "^1.13.4",
+    "vitest": "^4.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       vitepress-plugin-llms:
         specifier: ^1.13.4
         version: 1.13.4
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
 
 packages:
 
@@ -309,6 +312,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
@@ -403,8 +409,17 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
@@ -584,6 +599,35 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
   '@vue/compiler-core@3.5.41':
     resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
 
@@ -689,6 +733,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -705,6 +753,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -735,6 +787,9 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -777,6 +832,9 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -787,6 +845,13 @@ packages:
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -1151,6 +1216,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
@@ -1163,6 +1232,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -1239,12 +1311,21 @@ packages:
     resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1270,9 +1351,20 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   tokenx@1.6.0:
     resolution: {integrity: sha512-CKTjk345ajvBAUp5xUI9a5KKN0zU0lBueVHQbCskH1Hp6WkUKsPW2qGCYNs0pxNyfzxfo+IIjdt2W4sMbw/qBw==}
@@ -1384,6 +1476,47 @@ packages:
       postcss:
         optional: true
 
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.5.41:
     resolution: {integrity: sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==}
     peerDependencies:
@@ -1391,6 +1524,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -1594,6 +1732,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -1662,9 +1802,18 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 8.2.1(@types/node@26.2.0)(jiti@2.7.0)
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.5':
     dependencies:
@@ -1774,6 +1923,47 @@ snapshots:
       vite: 8.2.1(@types/node@26.2.0)(jiti@2.7.0)
       vue: 3.5.41(typescript@7.0.2)
 
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@26.2.0)(jiti@2.7.0)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@vue/compiler-core@3.5.41':
     dependencies:
       '@babel/parser': 7.29.8
@@ -1872,6 +2062,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -1883,6 +2075,8 @@ snapshots:
       balanced-match: 4.0.4
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -1909,6 +2103,8 @@ snapshots:
   color-name@1.1.4: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -1939,11 +2135,19 @@ snapshots:
 
   entities@7.0.1: {}
 
+  es-module-lexer@2.3.2: {}
+
   escalade@3.2.0: {}
 
   escape-string-regexp@5.0.0: {}
 
   estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
 
   extend-shallow@2.0.1:
     dependencies:
@@ -2366,6 +2570,8 @@ snapshots:
 
   nanoid@3.3.18: {}
 
+  obug@2.1.4: {}
+
   oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@4.3.6:
@@ -2377,6 +2583,8 @@ snapshots:
   path-expression-matcher@1.6.2: {}
 
   path-to-regexp@6.3.0: {}
+
+  pathe@2.0.3: {}
 
   perfect-debounce@2.1.0: {}
 
@@ -2486,9 +2694,15 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -2515,10 +2729,16 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   tokenx@1.6.0: {}
 
@@ -2684,6 +2904,33 @@ snapshots:
       - universal-cookie
       - yaml
 
+  vitest@4.1.11(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@26.2.0)(jiti@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+    transitivePeerDependencies:
+      - msw
+
   vue@3.5.41(typescript@7.0.2):
     dependencies:
       '@vue/compiler-dom': 3.5.41
@@ -2693,6 +2940,11 @@ snapshots:
       '@vue/shared': 3.5.41
     optionalDependencies:
       typescript: 7.0.2
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "exclude": ["build/", "build-*/", "**/*.test.ts"]
+  "exclude": ["build/", "build-*/"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "exclude": ["build/", "build-*/"]
+  "exclude": ["build/", "build-*/", "**/*.test.ts"]
 }

--- a/web-ui/src/components/player/video-player.tsx
+++ b/web-ui/src/components/player/video-player.tsx
@@ -65,6 +65,8 @@ interface VideoPlayerProps {
   locale: Locale;
   currentProgram?: EPGProgram | null;
   onSeek?: (seekTime: Date, goingLive: boolean) => void;
+  /** Channel EPG programmes used to split catchup playseek windows and to rebuild URLs on retry. */
+  catchupPrograms?: readonly Pick<EPGProgram, "start" | "end">[];
   /** Recalibrate MSE t=0 → wall-clock mapping (live mode). */
   onStreamStartTimeChange?: (time: Date) => void;
   streamStartTime: Date;
@@ -250,6 +252,7 @@ function VideoPlayerComponent({
   locale,
   playMode,
   currentProgram = null,
+  catchupPrograms = [],
   onSeek,
   onStreamStartTimeChange,
   streamStartTime,
@@ -687,6 +690,7 @@ function VideoPlayerComponent({
       const seekTime = mseToWallClock(currentVideoTimeRef.current, streamStartTime);
       return buildCatchupSegments(source, seekTime, {
         overlapMs: playbackBackendKind === "native" ? 0 : undefined,
+        programs: catchupPrograms,
       });
     }
     return segments;

--- a/web-ui/src/lib/catchup-windows.test.ts
+++ b/web-ui/src/lib/catchup-windows.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  CATCHUP_FUTURE_HORIZON_MS,
+  CATCHUP_LIVE_SPLIT_OFFSET_MS,
+  CATCHUP_MAX_SEGMENT_MS,
+  CATCHUP_MIN_DURATION_MS,
+  clampCatchupStartTime,
+  planCatchupSegmentWindows,
+} from "./catchup-windows.ts";
+
+const NOW = new Date("2026-09-02T12:00:00.000Z");
+const MINUTES = 60 * 1000;
+const HOURS = 60 * MINUTES;
+
+function at(offsetMs: number): Date {
+  return new Date(NOW.getTime() + offsetMs);
+}
+
+function windowTimes(startTime: Date, programs?: Parameters<typeof planCatchupSegmentWindows>[2]) {
+  return planCatchupSegmentWindows(startTime, NOW, programs).map((window) => ({
+    start: window.start.toISOString(),
+    end: window.end.toISOString(),
+    durationMs: window.end.getTime() - window.start.getTime(),
+  }));
+}
+
+describe("clampCatchupStartTime", () => {
+  it("pulls a near-live seek back to the minimum catchup window", () => {
+    const clamped = clampCatchupStartTime(at(-5_000), NOW);
+    assert.equal(clamped.getTime(), NOW.getTime() - CATCHUP_MIN_DURATION_MS);
+  });
+
+  it("leaves an older seek unchanged", () => {
+    const seek = at(-2 * HOURS);
+    assert.equal(clampCatchupStartTime(seek, NOW).getTime(), seek.getTime());
+  });
+});
+
+describe("planCatchupSegmentWindows without EPG", () => {
+  it("keeps the previous duration-based split: one past chunk then half-duration future chunks", () => {
+    const start = at(-2 * HOURS);
+    const windows = planCatchupSegmentWindows(start, NOW);
+    const splitPoint = at(-CATCHUP_LIVE_SPLIT_OFFSET_MS);
+    const endingFuture = at(CATCHUP_FUTURE_HORIZON_MS);
+    const pastDurationMs = splitPoint.getTime() - start.getTime();
+    const futureChunkMs = (NOW.getTime() - start.getTime()) / 2;
+
+    assert.equal(windows[0].start.getTime(), start.getTime());
+    assert.equal(windows[0].end.getTime(), splitPoint.getTime());
+    assert.equal(windows[0].end.getTime() - windows[0].start.getTime(), pastDurationMs);
+
+    for (let i = 1; i < windows.length - 1; i++) {
+      assert.equal(windows[i].end.getTime() - windows[i].start.getTime(), futureChunkMs);
+      assert.equal(windows[i].start.getTime(), windows[i - 1].end.getTime());
+    }
+    assert.equal(windows[windows.length - 1].end.getTime(), endingFuture.getTime());
+  });
+
+  it("caps long catchup at 5 hours before the live edge", () => {
+    const start = at(-10 * HOURS);
+    const windows = planCatchupSegmentWindows(start, NOW);
+    const splitPointMs = NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS;
+    const pastWindows = windows.filter((window) => window.start.getTime() < splitPointMs);
+
+    assert.equal(pastWindows[0].end.getTime() - pastWindows[0].start.getTime(), CATCHUP_MAX_SEGMENT_MS);
+    assert.ok(pastWindows.every((window) => window.end.getTime() - window.start.getTime() <= CATCHUP_MAX_SEGMENT_MS));
+  });
+});
+
+describe("planCatchupSegmentWindows with EPG", () => {
+  const programs = [
+    { start: at(-3 * HOURS), end: at(-90 * MINUTES) }, // 09:00-10:30
+    { start: at(-90 * MINUTES), end: at(-30 * MINUTES) }, // 10:30-11:30
+    { start: at(-30 * MINUTES), end: at(30 * MINUTES) }, // 11:30-12:30 (current)
+    { start: at(30 * MINUTES), end: at(90 * MINUTES) }, // 12:30-13:30
+  ];
+
+  it("splits past and future windows on programme boundaries and the live edge", () => {
+    const start = at(-2 * HOURS); // 10:00, mid first overlapping programme
+    const windows = windowTimes(start, programs);
+    const splitPoint = at(-CATCHUP_LIVE_SPLIT_OFFSET_MS).toISOString();
+
+    assert.deepEqual(
+      windows.slice(0, 5).map((window) => [window.start, window.end]),
+      [
+        [start.toISOString(), at(-90 * MINUTES).toISOString()], // remainder of 09:00-10:30
+        [at(-90 * MINUTES).toISOString(), at(-30 * MINUTES).toISOString()], // 10:30-11:30
+        [at(-30 * MINUTES).toISOString(), splitPoint], // current programme up to live edge
+        [splitPoint, at(30 * MINUTES).toISOString()], // rest of current programme
+        [at(30 * MINUTES).toISOString(), at(90 * MINUTES).toISOString()], // next programme
+      ],
+    );
+  });
+
+  it("does not slice the near-live past window on EPG edges", () => {
+    const windows = planCatchupSegmentWindows(at(-5_000), NOW, programs);
+    const splitPointMs = NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS;
+
+    assert.equal(windows[0].start.getTime(), NOW.getTime() - CATCHUP_MIN_DURATION_MS);
+    assert.equal(windows[0].end.getTime(), splitPointMs);
+    assert.equal(
+      windows[0].end.getTime() - windows[0].start.getTime(),
+      CATCHUP_MIN_DURATION_MS - CATCHUP_LIVE_SPLIT_OFFSET_MS,
+    );
+    // The current programme continues after the live edge instead of using half-hour chunks.
+    assert.equal(windows[1].start.getTime(), splitPointMs);
+    assert.equal(windows[1].end.getTime(), at(30 * MINUTES).getTime());
+  });
+
+  it("still enforces the minimum catchup start when seeking into a programme that just started", () => {
+    const justStarted = [{ start: at(-8_000), end: at(30 * MINUTES) }];
+    const windows = planCatchupSegmentWindows(at(-8_000), NOW, justStarted);
+    assert.equal(windows[0].start.getTime(), NOW.getTime() - CATCHUP_MIN_DURATION_MS);
+    assert.equal(windows[0].end.getTime(), NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS);
+    assert.equal(windows[1].start.getTime(), NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS);
+    assert.equal(windows[1].end.getTime(), at(30 * MINUTES).getTime());
+  });
+
+  it("caps a single oversized EPG slot at 5 hours", () => {
+    const longProgram = [{ start: at(-2 * HOURS), end: at(8 * HOURS) }];
+    const windows = planCatchupSegmentWindows(at(-2 * HOURS), NOW, longProgram);
+    assert.ok(windows.some((window) => window.end.getTime() - window.start.getTime() === CATCHUP_MAX_SEGMENT_MS));
+    assert.ok(windows.every((window) => window.end.getTime() - window.start.getTime() <= CATCHUP_MAX_SEGMENT_MS));
+  });
+
+  it("ignores malformed programmes whose end precedes their start", () => {
+    const windows = planCatchupSegmentWindows(at(-2 * HOURS), NOW, [
+      { start: at(-90 * MINUTES), end: at(-2 * HOURS) },
+      ...programs,
+    ]);
+    const withoutMalformed = planCatchupSegmentWindows(at(-2 * HOURS), NOW, programs);
+    assert.deepEqual(
+      windows.map((window) => [window.start.getTime(), window.end.getTime()]),
+      withoutMalformed.map((window) => [window.start.getTime(), window.end.getTime()]),
+    );
+  });
+});

--- a/web-ui/src/lib/catchup-windows.test.ts
+++ b/web-ui/src/lib/catchup-windows.test.ts
@@ -1,5 +1,4 @@
-import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, expect, it } from "vitest";
 import {
   CATCHUP_FUTURE_HORIZON_MS,
   CATCHUP_LIVE_SPLIT_OFFSET_MS,
@@ -7,7 +6,7 @@ import {
   CATCHUP_MIN_DURATION_MS,
   clampCatchupStartTime,
   planCatchupSegmentWindows,
-} from "./catchup-windows.ts";
+} from "./catchup-windows";
 
 const NOW = new Date("2026-09-02T12:00:00.000Z");
 const MINUTES = 60 * 1000;
@@ -28,12 +27,12 @@ function windowTimes(startTime: Date, programs?: Parameters<typeof planCatchupSe
 describe("clampCatchupStartTime", () => {
   it("pulls a near-live seek back to the minimum catchup window", () => {
     const clamped = clampCatchupStartTime(at(-5_000), NOW);
-    assert.equal(clamped.getTime(), NOW.getTime() - CATCHUP_MIN_DURATION_MS);
+    expect(clamped.getTime()).toBe(NOW.getTime() - CATCHUP_MIN_DURATION_MS);
   });
 
   it("leaves an older seek unchanged", () => {
     const seek = at(-2 * HOURS);
-    assert.equal(clampCatchupStartTime(seek, NOW).getTime(), seek.getTime());
+    expect(clampCatchupStartTime(seek, NOW).getTime()).toBe(seek.getTime());
   });
 });
 
@@ -46,15 +45,15 @@ describe("planCatchupSegmentWindows without EPG", () => {
     const pastDurationMs = splitPoint.getTime() - start.getTime();
     const futureChunkMs = (NOW.getTime() - start.getTime()) / 2;
 
-    assert.equal(windows[0].start.getTime(), start.getTime());
-    assert.equal(windows[0].end.getTime(), splitPoint.getTime());
-    assert.equal(windows[0].end.getTime() - windows[0].start.getTime(), pastDurationMs);
+    expect(windows[0].start.getTime()).toBe(start.getTime());
+    expect(windows[0].end.getTime()).toBe(splitPoint.getTime());
+    expect(windows[0].end.getTime() - windows[0].start.getTime()).toBe(pastDurationMs);
 
     for (let i = 1; i < windows.length - 1; i++) {
-      assert.equal(windows[i].end.getTime() - windows[i].start.getTime(), futureChunkMs);
-      assert.equal(windows[i].start.getTime(), windows[i - 1].end.getTime());
+      expect(windows[i].end.getTime() - windows[i].start.getTime()).toBe(futureChunkMs);
+      expect(windows[i].start.getTime()).toBe(windows[i - 1].end.getTime());
     }
-    assert.equal(windows[windows.length - 1].end.getTime(), endingFuture.getTime());
+    expect(windows[windows.length - 1].end.getTime()).toBe(endingFuture.getTime());
   });
 
   it("caps long catchup at 5 hours before the live edge", () => {
@@ -63,8 +62,10 @@ describe("planCatchupSegmentWindows without EPG", () => {
     const splitPointMs = NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS;
     const pastWindows = windows.filter((window) => window.start.getTime() < splitPointMs);
 
-    assert.equal(pastWindows[0].end.getTime() - pastWindows[0].start.getTime(), CATCHUP_MAX_SEGMENT_MS);
-    assert.ok(pastWindows.every((window) => window.end.getTime() - window.start.getTime() <= CATCHUP_MAX_SEGMENT_MS));
+    expect(pastWindows[0].end.getTime() - pastWindows[0].start.getTime()).toBe(CATCHUP_MAX_SEGMENT_MS);
+    for (const window of pastWindows) {
+      expect(window.end.getTime() - window.start.getTime()).toBeLessThanOrEqual(CATCHUP_MAX_SEGMENT_MS);
+    }
   });
 });
 
@@ -81,47 +82,47 @@ describe("planCatchupSegmentWindows with EPG", () => {
     const windows = windowTimes(start, programs);
     const splitPoint = at(-CATCHUP_LIVE_SPLIT_OFFSET_MS).toISOString();
 
-    assert.deepEqual(
-      windows.slice(0, 5).map((window) => [window.start, window.end]),
-      [
-        [start.toISOString(), at(-90 * MINUTES).toISOString()], // remainder of 09:00-10:30
-        [at(-90 * MINUTES).toISOString(), at(-30 * MINUTES).toISOString()], // 10:30-11:30
-        [at(-30 * MINUTES).toISOString(), splitPoint], // current programme up to live edge
-        [splitPoint, at(30 * MINUTES).toISOString()], // rest of current programme
-        [at(30 * MINUTES).toISOString(), at(90 * MINUTES).toISOString()], // next programme
-      ],
-    );
+    expect(windows.slice(0, 5).map((window) => [window.start, window.end])).toEqual([
+      [start.toISOString(), at(-90 * MINUTES).toISOString()], // remainder of 09:00-10:30
+      [at(-90 * MINUTES).toISOString(), at(-30 * MINUTES).toISOString()], // 10:30-11:30
+      [at(-30 * MINUTES).toISOString(), splitPoint], // current programme up to live edge
+      [splitPoint, at(30 * MINUTES).toISOString()], // rest of current programme
+      [at(30 * MINUTES).toISOString(), at(90 * MINUTES).toISOString()], // next programme
+    ]);
   });
 
   it("does not slice the near-live past window on EPG edges", () => {
     const windows = planCatchupSegmentWindows(at(-5_000), NOW, programs);
     const splitPointMs = NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS;
 
-    assert.equal(windows[0].start.getTime(), NOW.getTime() - CATCHUP_MIN_DURATION_MS);
-    assert.equal(windows[0].end.getTime(), splitPointMs);
-    assert.equal(
-      windows[0].end.getTime() - windows[0].start.getTime(),
+    expect(windows[0].start.getTime()).toBe(NOW.getTime() - CATCHUP_MIN_DURATION_MS);
+    expect(windows[0].end.getTime()).toBe(splitPointMs);
+    expect(windows[0].end.getTime() - windows[0].start.getTime()).toBe(
       CATCHUP_MIN_DURATION_MS - CATCHUP_LIVE_SPLIT_OFFSET_MS,
     );
     // The current programme continues after the live edge instead of using half-hour chunks.
-    assert.equal(windows[1].start.getTime(), splitPointMs);
-    assert.equal(windows[1].end.getTime(), at(30 * MINUTES).getTime());
+    expect(windows[1].start.getTime()).toBe(splitPointMs);
+    expect(windows[1].end.getTime()).toBe(at(30 * MINUTES).getTime());
   });
 
   it("still enforces the minimum catchup start when seeking into a programme that just started", () => {
     const justStarted = [{ start: at(-8_000), end: at(30 * MINUTES) }];
     const windows = planCatchupSegmentWindows(at(-8_000), NOW, justStarted);
-    assert.equal(windows[0].start.getTime(), NOW.getTime() - CATCHUP_MIN_DURATION_MS);
-    assert.equal(windows[0].end.getTime(), NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS);
-    assert.equal(windows[1].start.getTime(), NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS);
-    assert.equal(windows[1].end.getTime(), at(30 * MINUTES).getTime());
+    expect(windows[0].start.getTime()).toBe(NOW.getTime() - CATCHUP_MIN_DURATION_MS);
+    expect(windows[0].end.getTime()).toBe(NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS);
+    expect(windows[1].start.getTime()).toBe(NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS);
+    expect(windows[1].end.getTime()).toBe(at(30 * MINUTES).getTime());
   });
 
   it("caps a single oversized EPG slot at 5 hours", () => {
     const longProgram = [{ start: at(-2 * HOURS), end: at(8 * HOURS) }];
     const windows = planCatchupSegmentWindows(at(-2 * HOURS), NOW, longProgram);
-    assert.ok(windows.some((window) => window.end.getTime() - window.start.getTime() === CATCHUP_MAX_SEGMENT_MS));
-    assert.ok(windows.every((window) => window.end.getTime() - window.start.getTime() <= CATCHUP_MAX_SEGMENT_MS));
+    expect(windows.some((window) => window.end.getTime() - window.start.getTime() === CATCHUP_MAX_SEGMENT_MS)).toBe(
+      true,
+    );
+    for (const window of windows) {
+      expect(window.end.getTime() - window.start.getTime()).toBeLessThanOrEqual(CATCHUP_MAX_SEGMENT_MS);
+    }
   });
 
   it("ignores malformed programmes whose end precedes their start", () => {
@@ -130,8 +131,7 @@ describe("planCatchupSegmentWindows with EPG", () => {
       ...programs,
     ]);
     const withoutMalformed = planCatchupSegmentWindows(at(-2 * HOURS), NOW, programs);
-    assert.deepEqual(
-      windows.map((window) => [window.start.getTime(), window.end.getTime()]),
+    expect(windows.map((window) => [window.start.getTime(), window.end.getTime()])).toEqual(
       withoutMalformed.map((window) => [window.start.getTime(), window.end.getTime()]),
     );
   });

--- a/web-ui/src/lib/catchup-windows.test.ts
+++ b/web-ui/src/lib/catchup-windows.test.ts
@@ -77,50 +77,60 @@ describe("planCatchupSegmentWindows with EPG", () => {
     { start: at(30 * MINUTES), end: at(90 * MINUTES) }, // 12:30-13:30
   ];
 
-  it("splits past and future windows on programme boundaries and the live edge", () => {
+  it("splits recorded windows on programme boundaries, then uses half-duration chunks after the live edge", () => {
     const start = at(-2 * HOURS); // 10:00, mid first overlapping programme
     const windows = windowTimes(start, programs);
     const splitPoint = at(-CATCHUP_LIVE_SPLIT_OFFSET_MS).toISOString();
+    const futureChunkMs = (NOW.getTime() - start.getTime()) / 2;
 
-    expect(windows.slice(0, 5).map((window) => [window.start, window.end])).toEqual([
+    expect(windows.slice(0, 3).map((window) => [window.start, window.end])).toEqual([
       [start.toISOString(), at(-90 * MINUTES).toISOString()], // remainder of 09:00-10:30
       [at(-90 * MINUTES).toISOString(), at(-30 * MINUTES).toISOString()], // 10:30-11:30
       [at(-30 * MINUTES).toISOString(), splitPoint], // current programme up to live edge
-      [splitPoint, at(30 * MINUTES).toISOString()], // rest of current programme
-      [at(30 * MINUTES).toISOString(), at(90 * MINUTES).toISOString()], // next programme
     ]);
+    expect(windows[3].start).toBe(splitPoint);
+    expect(windows[3].durationMs).toBe(futureChunkMs);
+    expect(windows[3].end).not.toBe(at(30 * MINUTES).toISOString());
   });
 
-  it("does not slice the near-live past window on EPG edges", () => {
-    const windows = planCatchupSegmentWindows(at(-5_000), NOW, programs);
+  it("matches the original near-live plan instead of extending playseek to the current programme end", () => {
+    const withEpg = planCatchupSegmentWindows(at(-5_000), NOW, programs);
+    const withoutEpg = planCatchupSegmentWindows(at(-5_000), NOW);
     const splitPointMs = NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS;
+    const futureChunkMs = CATCHUP_MIN_DURATION_MS / 2;
 
-    expect(windows[0].start.getTime()).toBe(NOW.getTime() - CATCHUP_MIN_DURATION_MS);
-    expect(windows[0].end.getTime()).toBe(splitPointMs);
-    expect(windows[0].end.getTime() - windows[0].start.getTime()).toBe(
-      CATCHUP_MIN_DURATION_MS - CATCHUP_LIVE_SPLIT_OFFSET_MS,
+    expect(withEpg.map((window) => [window.start.getTime(), window.end.getTime()])).toEqual(
+      withoutEpg.map((window) => [window.start.getTime(), window.end.getTime()]),
     );
-    // The current programme continues after the live edge instead of using half-hour chunks.
-    expect(windows[1].start.getTime()).toBe(splitPointMs);
-    expect(windows[1].end.getTime()).toBe(at(30 * MINUTES).getTime());
+    expect(withEpg[0].start.getTime()).toBe(NOW.getTime() - CATCHUP_MIN_DURATION_MS);
+    expect(withEpg[0].end.getTime()).toBe(splitPointMs);
+    expect(withEpg[1].start.getTime()).toBe(splitPointMs);
+    expect(withEpg[1].end.getTime() - withEpg[1].start.getTime()).toBe(futureChunkMs);
+    expect(withEpg[1].end.getTime()).toBeLessThan(at(30 * MINUTES).getTime());
   });
 
   it("still enforces the minimum catchup start when seeking into a programme that just started", () => {
     const justStarted = [{ start: at(-8_000), end: at(30 * MINUTES) }];
     const windows = planCatchupSegmentWindows(at(-8_000), NOW, justStarted);
+    const withoutEpg = planCatchupSegmentWindows(at(-8_000), NOW);
+    expect(windows.map((window) => [window.start.getTime(), window.end.getTime()])).toEqual(
+      withoutEpg.map((window) => [window.start.getTime(), window.end.getTime()]),
+    );
     expect(windows[0].start.getTime()).toBe(NOW.getTime() - CATCHUP_MIN_DURATION_MS);
     expect(windows[0].end.getTime()).toBe(NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS);
-    expect(windows[1].start.getTime()).toBe(NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS);
-    expect(windows[1].end.getTime()).toBe(at(30 * MINUTES).getTime());
+    expect(windows[1].end.getTime()).toBeLessThan(at(30 * MINUTES).getTime());
   });
 
-  it("caps a single oversized EPG slot at 5 hours", () => {
-    const longProgram = [{ start: at(-2 * HOURS), end: at(8 * HOURS) }];
-    const windows = planCatchupSegmentWindows(at(-2 * HOURS), NOW, longProgram);
-    expect(windows.some((window) => window.end.getTime() - window.start.getTime() === CATCHUP_MAX_SEGMENT_MS)).toBe(
+  it("caps a single oversized recorded EPG slot at 5 hours", () => {
+    const longProgram = [{ start: at(-8 * HOURS), end: at(-1 * HOURS) }];
+    const windows = planCatchupSegmentWindows(at(-8 * HOURS), NOW, longProgram);
+    const splitPointMs = NOW.getTime() - CATCHUP_LIVE_SPLIT_OFFSET_MS;
+    const pastWindows = windows.filter((window) => window.start.getTime() < splitPointMs);
+
+    expect(pastWindows.some((window) => window.end.getTime() - window.start.getTime() === CATCHUP_MAX_SEGMENT_MS)).toBe(
       true,
     );
-    for (const window of windows) {
+    for (const window of pastWindows) {
       expect(window.end.getTime() - window.start.getTime()).toBeLessThanOrEqual(CATCHUP_MAX_SEGMENT_MS);
     }
   });

--- a/web-ui/src/lib/catchup-windows.ts
+++ b/web-ui/src/lib/catchup-windows.ts
@@ -35,10 +35,11 @@ function addBoundary(boundaries: Set<number>, timeMs: number, rangeStartMs: numb
 /**
  * Plan consecutive catchup playseek windows from `startTimeArg` through an 8-hour future horizon.
  *
- * When `programs` are provided, windows split on EPG start/end times (and still at the live
- * edge). Near-live requests keep a single past window of at least {@link CATCHUP_MIN_DURATION_MS}
- * so short playseek ranges do not fail. Without EPG data the previous duration-based chunking
- * is used: up to 5 hours before the live edge, half that after it.
+ * Recorded time (before the live edge) splits on EPG start/end when programmes are available.
+ * After the live edge, windows always use the original half-duration chunks — never a future
+ * programme end — because upstream catchup servers often reject playseek ranges that end in
+ * the future. Near-live requests skip EPG splits entirely and match the no-EPG plan: a single
+ * past window of at least {@link CATCHUP_MIN_DURATION_MS}, then half-duration chunks.
  */
 export function planCatchupSegmentWindows(
   startTimeArg: Date,
@@ -58,31 +59,29 @@ export function planCatchupSegmentWindows(
   const boundaries = new Set<number>([startMs, endingFutureMs]);
   addBoundary(boundaries, splitPointMs, startMs, endingFutureMs);
 
-  const hasEpgSplits = Boolean(programs && programs.length > 0);
   const pastWindowMs = Math.max(0, splitPointMs - startMs);
   const nearLiveCatchup = pastWindowMs <= CATCHUP_MIN_DURATION_MS;
-  // Near-live: keep one min-duration past window and only split on EPG after `now`.
-  const epgSplitAfterMs = nearLiveCatchup ? nowMs : startMs;
+  const useEpgPastSplits = Boolean(programs && programs.length > 0) && !nearLiveCatchup;
 
-  if (programs && programs.length > 0) {
+  if (useEpgPastSplits && programs) {
     for (const program of programs) {
       const programStartMs = program.start.getTime();
       const programEndMs = program.end.getTime();
       if (!Number.isFinite(programStartMs) || !Number.isFinite(programEndMs) || programEndMs <= programStartMs) {
         continue;
       }
-      if (programEndMs <= startMs || programStartMs >= endingFutureMs) {
+      if (programEndMs <= startMs || programStartMs >= splitPointMs) {
         continue;
       }
-      addBoundary(boundaries, programStartMs, epgSplitAfterMs, endingFutureMs);
-      addBoundary(boundaries, programEndMs, epgSplitAfterMs, endingFutureMs);
+      addBoundary(boundaries, programStartMs, startMs, splitPointMs);
+      addBoundary(boundaries, programEndMs, startMs, splitPointMs);
     }
   }
 
   const times = [...boundaries].sort((a, b) => a - b);
   const fallbackDurationMs = Math.min(Math.max(nowMs - startMs, CATCHUP_MIN_DURATION_MS), CATCHUP_MAX_SEGMENT_MS);
-  const pastCapMs = hasEpgSplits ? CATCHUP_MAX_SEGMENT_MS : fallbackDurationMs;
-  const futureCapMs = hasEpgSplits ? CATCHUP_MAX_SEGMENT_MS : fallbackDurationMs / 2;
+  const pastCapMs = useEpgPastSplits ? CATCHUP_MAX_SEGMENT_MS : fallbackDurationMs;
+  const futureCapMs = fallbackDurationMs / 2;
 
   const windows: CatchupTimeWindow[] = [];
   for (let i = 0; i < times.length - 1; i++) {

--- a/web-ui/src/lib/catchup-windows.ts
+++ b/web-ui/src/lib/catchup-windows.ts
@@ -1,0 +1,107 @@
+/** Minimum catchup window (ms). Shorter playseek ranges can fail on some servers. */
+export const CATCHUP_MIN_DURATION_MS = 30_000;
+
+/** End recorded-style replay chunks this far before local `now` to tolerate upstream clock skew. */
+export const CATCHUP_LIVE_SPLIT_OFFSET_MS = 10_000;
+
+/** How far past `now` to pre-build catchup URLs so playback can continue without going live. */
+export const CATCHUP_FUTURE_HORIZON_MS = 8 * 60 * 60 * 1000;
+
+/** Safety cap for a single playseek window (also the no-EPG fallback chunk size). */
+export const CATCHUP_MAX_SEGMENT_MS = 5 * 60 * 60 * 1000;
+
+export interface CatchupProgramBound {
+  start: Date;
+  end: Date;
+}
+
+export interface CatchupTimeWindow {
+  start: Date;
+  end: Date;
+}
+
+/** Clamp catchup start so the window back to `now` is at least {@link CATCHUP_MIN_DURATION_MS}. */
+export function clampCatchupStartTime(seekTime: Date, now = new Date()): Date {
+  const minStartMs = now.getTime() - CATCHUP_MIN_DURATION_MS;
+  return new Date(Math.min(seekTime.getTime(), minStartMs));
+}
+
+function addBoundary(boundaries: Set<number>, timeMs: number, rangeStartMs: number, rangeEndMs: number): void {
+  if (timeMs > rangeStartMs && timeMs < rangeEndMs) {
+    boundaries.add(timeMs);
+  }
+}
+
+/**
+ * Plan consecutive catchup playseek windows from `startTimeArg` through an 8-hour future horizon.
+ *
+ * When `programs` are provided, windows split on EPG start/end times (and still at the live
+ * edge). Near-live requests keep a single past window of at least {@link CATCHUP_MIN_DURATION_MS}
+ * so short playseek ranges do not fail. Without EPG data the previous duration-based chunking
+ * is used: up to 5 hours before the live edge, half that after it.
+ */
+export function planCatchupSegmentWindows(
+  startTimeArg: Date,
+  now: Date,
+  programs?: readonly CatchupProgramBound[],
+): CatchupTimeWindow[] {
+  const startTime = clampCatchupStartTime(startTimeArg, now);
+  const startMs = startTime.getTime();
+  const nowMs = now.getTime();
+  const splitPointMs = nowMs - CATCHUP_LIVE_SPLIT_OFFSET_MS;
+  const endingFutureMs = nowMs + CATCHUP_FUTURE_HORIZON_MS;
+
+  if (endingFutureMs <= startMs) {
+    return [];
+  }
+
+  const boundaries = new Set<number>([startMs, endingFutureMs]);
+  addBoundary(boundaries, splitPointMs, startMs, endingFutureMs);
+
+  const hasEpgSplits = Boolean(programs && programs.length > 0);
+  const pastWindowMs = Math.max(0, splitPointMs - startMs);
+  const nearLiveCatchup = pastWindowMs <= CATCHUP_MIN_DURATION_MS;
+  // Near-live: keep one min-duration past window and only split on EPG after `now`.
+  const epgSplitAfterMs = nearLiveCatchup ? nowMs : startMs;
+
+  if (programs && programs.length > 0) {
+    for (const program of programs) {
+      const programStartMs = program.start.getTime();
+      const programEndMs = program.end.getTime();
+      if (!Number.isFinite(programStartMs) || !Number.isFinite(programEndMs) || programEndMs <= programStartMs) {
+        continue;
+      }
+      if (programEndMs <= startMs || programStartMs >= endingFutureMs) {
+        continue;
+      }
+      addBoundary(boundaries, programStartMs, epgSplitAfterMs, endingFutureMs);
+      addBoundary(boundaries, programEndMs, epgSplitAfterMs, endingFutureMs);
+    }
+  }
+
+  const times = [...boundaries].sort((a, b) => a - b);
+  const fallbackDurationMs = Math.min(Math.max(nowMs - startMs, CATCHUP_MIN_DURATION_MS), CATCHUP_MAX_SEGMENT_MS);
+  const pastCapMs = hasEpgSplits ? CATCHUP_MAX_SEGMENT_MS : fallbackDurationMs;
+  const futureCapMs = hasEpgSplits ? CATCHUP_MAX_SEGMENT_MS : fallbackDurationMs / 2;
+
+  const windows: CatchupTimeWindow[] = [];
+  for (let i = 0; i < times.length - 1; i++) {
+    const rangeStartMs = times[i];
+    const rangeEndMs = times[i + 1];
+    if (rangeEndMs <= rangeStartMs) {
+      continue;
+    }
+
+    const capMs = rangeStartMs >= splitPointMs ? futureCapMs : pastCapMs;
+    let cursorMs = rangeStartMs;
+    while (cursorMs < rangeEndMs) {
+      const nextMs = Math.min(cursorMs + capMs, rangeEndMs);
+      if (nextMs > cursorMs) {
+        windows.push({ start: new Date(cursorMs), end: new Date(nextMs) });
+      }
+      cursorMs = nextMs;
+    }
+  }
+
+  return windows;
+}

--- a/web-ui/src/lib/m3u-parser.ts
+++ b/web-ui/src/lib/m3u-parser.ts
@@ -1,6 +1,9 @@
 import type { PlayerSegment } from "../playback-engine";
 import type { Channel, M3UMetadata, Source } from "../types/player";
+import { type CatchupProgramBound, clampCatchupStartTime, planCatchupSegmentWindows } from "./catchup-windows";
 import { toPlaylistRelativePath } from "./url";
+
+export { CATCHUP_MIN_DURATION_MS, clampCatchupStartTime } from "./catchup-windows";
 
 /**
  * Parse M3U playlist content
@@ -177,18 +180,14 @@ function mergeChannelSources(channels: Channel[]): Channel[] {
   return merged;
 }
 
-/** Minimum catchup window (ms). Shorter playseek ranges can fail on some servers. */
-export const CATCHUP_MIN_DURATION_MS = 30_000;
 const CATCHUP_SEGMENT_OVERLAP_MS = 1_000;
 
 export interface CatchupSegmentOptions {
   overlapMs?: number;
-}
-
-/** Clamp catchup start so the window back to `now` is at least {@link CATCHUP_MIN_DURATION_MS}. */
-export function clampCatchupStartTime(seekTime: Date, now = new Date()): Date {
-  const minStartMs = now.getTime() - CATCHUP_MIN_DURATION_MS;
-  return new Date(Math.min(seekTime.getTime(), minStartMs));
+  /** EPG programmes for the channel; windows split on their start/end times when present. */
+  programs?: readonly CatchupProgramBound[];
+  /** Override wall clock (tests). */
+  now?: Date;
 }
 
 /**
@@ -207,9 +206,8 @@ export function buildCatchupSegments(
   }
 
   const catchupMode = source.catchup || "default";
-  const now = new Date();
+  const now = options.now ?? new Date();
   const startTime = clampCatchupStartTime(startTimeArg, now);
-  const endingFuture = new Date(now.getTime() + 8 * 60 * 60 * 1000);
   const segments: PlayerSegment[] = [];
   const overlapMs = Math.max(0, options.overlapMs ?? CATCHUP_SEGMENT_OVERLAP_MS);
 
@@ -491,11 +489,6 @@ export function buildCatchupSegments(
     }
   };
 
-  // Segment duration: (now - startTime) in both seconds and milliseconds
-  const segmentDurationMs = Math.min(
-    Math.max(now.getTime() - startTime.getTime(), CATCHUP_MIN_DURATION_MS),
-    5 * 60 * 60 * 1000, // max 5 hours
-  );
   const buildOverlappedSegmentUrl = (segmentStartTime: Date, segmentEndTime: Date): string => {
     const requestStartTime =
       segments.length === 0
@@ -504,33 +497,11 @@ export function buildCatchupSegments(
     return buildCatchupUrl(requestStartTime, segmentEndTime);
   };
 
-  // Build segments from startTime to now (catchup/replay segments)
-  let currentTime = new Date(startTime.getTime());
-  // End replay chunks at (now - 10s): avoid passing local `now` to servers that may
-  // be clock-skewed and reject requests whose end time looks like the future.
-  const splitPoint = new Date(now.getTime() - 10000);
-
-  while (currentTime < splitPoint) {
-    const segmentEndTime = new Date(Math.min(currentTime.getTime() + segmentDurationMs, splitPoint.getTime()));
-
+  for (const timeWindow of planCatchupSegmentWindows(startTimeArg, now, options.programs)) {
     segments.push({
-      duration: (segmentEndTime.getTime() - currentTime.getTime()) / 1000,
-      url: buildOverlappedSegmentUrl(currentTime, segmentEndTime),
+      duration: (timeWindow.end.getTime() - timeWindow.start.getTime()) / 1000,
+      url: buildOverlappedSegmentUrl(timeWindow.start, timeWindow.end),
     });
-
-    currentTime = segmentEndTime;
-  }
-
-  // Build segments from splitPoint to future (half-duration live segments)
-  while (currentTime < endingFuture) {
-    const segmentEndTime = new Date(Math.min(currentTime.getTime() + segmentDurationMs / 2, endingFuture.getTime()));
-
-    segments.push({
-      duration: (segmentEndTime.getTime() - currentTime.getTime()) / 1000,
-      url: buildOverlappedSegmentUrl(currentTime, segmentEndTime),
-    });
-
-    currentTime = segmentEndTime;
   }
 
   return segments;

--- a/web-ui/src/pages/player.tsx
+++ b/web-ui/src/pages/player.tsx
@@ -20,7 +20,7 @@ import { usePlayerTranslation } from "../hooks/use-player-translation";
 import { useTheme } from "../hooks/use-theme";
 import { isDocumentPictureInPictureSupported } from "../lib/document-picture-in-picture";
 import { loadEPG } from "../lib/epg-loader";
-import { type EPGChannelDescriptor, type EPGData, getEPGChannelId } from "../lib/epg-parser";
+import { type EPGChannelDescriptor, type EPGData, getAllChannelPrograms, getEPGChannelId } from "../lib/epg-parser";
 import type { Locale } from "../lib/locale";
 import { buildCatchupSegments, clampCatchupStartTime, parseM3U } from "../lib/m3u-parser";
 import { isLGWebOS } from "../lib/platform";
@@ -140,6 +140,19 @@ function PlayerPage() {
   // Get the active source's URL and catchupSource
   const activeSource = currentChannel?.sources[activeSourceIndex] ?? currentChannel?.sources[0];
 
+  // EPG channel ID for the current channel using fallback logic (tvgId -> tvgName -> name)
+  const currentEpgChannelId = useMemo(
+    () => (currentChannel ? getEPGChannelId(currentChannel, epgData) : null),
+    [currentChannel, epgData],
+  );
+  const catchupPrograms = useMemo(
+    () => (currentEpgChannelId ? getAllChannelPrograms(currentEpgChannelId, epgData) : []),
+    [currentEpgChannelId, epgData],
+  );
+  // Seek/retry reads the latest EPG without rebuilding the catchup playlist when it first arrives.
+  const catchupProgramsRef = useRef(catchupPrograms);
+  catchupProgramsRef.current = catchupPrograms;
+
   // Track fullscreen state
   useEffect(() => {
     const handleFullscreenChange = () => {
@@ -196,6 +209,7 @@ function PlayerPage() {
       setPlaybackSegments(
         buildCatchupSegments(activeSource, streamStartTime, {
           overlapMs: playbackBackendKind === "native" ? 0 : undefined,
+          programs: catchupProgramsRef.current,
         }),
       );
       setPlayMode("catchup");
@@ -301,12 +315,6 @@ function PlayerPage() {
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
   }, [metadata, currentChannel, selectChannel]);
-
-  // EPG channel ID for the current channel using fallback logic (tvgId -> tvgName -> name)
-  const currentEpgChannelId = useMemo(
-    () => (currentChannel ? getEPGChannelId(currentChannel, epgData) : null),
-    [currentChannel, epgData],
-  );
 
   // Programme at the current playback position (stream start + media clock)
   const currentVideoProgram = useCurrentVideoProgram(playbackClock, currentEpgChannelId, epgData, streamStartTime);
@@ -581,6 +589,7 @@ function PlayerPage() {
               onError={handleVideoError}
               locale={locale}
               currentProgram={currentVideoProgram}
+              catchupPrograms={catchupPrograms}
               onSeek={handleVideoSeek}
               onStreamStartTimeChange={setStreamStartTime}
               streamStartTime={streamStartTime}

--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { resolve } from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -30,6 +31,9 @@ export default defineConfig(({ mode }) => {
         // "^/%E8%B6%85%E9%AB%98%E6%B8%85/.*": "http://router.ccca.cc:5140",
         // "^/%E9%AB%98%E6%B8%85/.*": "http://router.ccca.cc:5140",
       },
+    },
+    test: {
+      include: ["src/**/*.test.ts"],
     },
   };
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Catchup playback used to stitch `playseek` windows from a fixed duration (capped at 5 hours, halved after the live edge) measured from the seek time and local `now`. That ignored EPG programme boundaries, so a single request could span multiple shows.

Catchup segments now split on EPG start/end times **only in the recorded window** (before the live edge, 10s before `now`). After the live edge, windows keep the original half-duration chunks so a near-live seek (for example 30s back) does not send a playseek range that ends at the current programme’s future stop time.

Near-live seeks skip EPG splits entirely and match the previous no-EPG plan, including the 30s minimum window. Without EPG data the previous duration-based chunking is unchanged.

Frontend unit tests run under Vitest (`pnpm run web-ui:test`).

## Changes

- Add `planCatchupSegmentWindows()` to derive consecutive playseek ranges.
- Recorded time splits on EPG bounds; after the live edge, use original half-duration chunks.
- Near-live seeks (≤30s past window) match the no-EPG plan so upstream servers are not given a future programme end.
- Pass the current channel’s EPG programmes into `buildCatchupSegments` (seek and retry). Late EPG arrival does not rebuild an in-flight catchup playlist.
- Add Vitest 4.1 and run `pnpm run web-ui:test` in the lint CI job.

## Validation

- `pnpm run web-ui:test` (9 passed), including a case that a 5s/30s near-live seek with EPG is identical to the original plan and does not extend to the current programme end
- `pnpm run type-check:tsc`
- Devlab + browser: clicked **Feature Film (73m)** (07:04–08:17). Catchup overlay showed `SEEK 2026-09-02 07-04-00 UTC`

![Catchup started at Feature Film 07:04](https://cursor.com/artifacts/c/art-d96ee515-bc41-42d5-a1a4-3e76ba1c5972)
<a href="https://cursor.com/agents/bc-78618982-e22c-492e-a3ab-9c23234eeeed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fepg-catchup-feature-film.mp4"><img src="https://cursor.com/artifacts/c/art-0ece132a-534d-49a6-9189-957c64f4eda6" alt="epg-catchup-feature-film.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78618982-e22c-492e-a3ab-9c23234eeeed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78618982-e22c-492e-a3ab-9c23234eeeed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

