### PR TITLE
chore(.gitignore): restrict build dir patterns to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,9 @@
 .cache/
 compile_commands.json
 
-# Build directories
-build/
-build-*/
-!.claude/skills/build-run/
+# Build directories (repo root only)
+/build/
+/build-*/
 
 # Toolchain directory (auto-downloaded)
 toolchain/


### PR DESCRIPTION
## Summary
Updated `.gitignore` patterns for build directories to only match at the repository root, allowing build directories to exist in subdirectories (e.g., `.claude/skills/build-run/`).

## Changes
- Changed `build/` → `/build/` to match only at repo root
- Changed `build-*/` → `/build-*/` to match only at repo root
- Removed the negation pattern `!.claude/skills/build-run/` (no longer needed with root-only matching)
- Updated comment to clarify scope: "Build directories (repo root only)"

## Details
The leading slash in gitignore patterns anchors them to the repository root, preventing unintended matches in subdirectories. This allows skill directories like `.claude/skills/build-run/` to maintain their own build artifacts without being ignored by the root-level gitignore rules.

https://claude.ai/code/session_01QUwQxU8nuPrjvVpgag57FZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Git ignore-only change with no runtime or security impact; only affects which local build artifacts may be tracked.
> 
> **Overview**
> **Build ignore rules** now apply only at the repository root: `build/` and `build-*/` become `/build/` and `/build-*/`, with a comment noting repo-root scope.
> 
> The **`!.claude/skills/build-run/`** exception is removed because root-anchored patterns no longer ignore nested `build/` folders under skills or other paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501cb1fb9a76e86b499a63c6f8cfdde318408cd2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->