### PR TITLE
feat(player): marquee current program titles

### DIFF
--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -1,6 +1,6 @@
 import { clsx } from "clsx";
 import { History } from "lucide-react";
-import { forwardRef, memo, type MouseEvent as ReactMouseEvent, useCallback } from "react";
+import { forwardRef, memo, type MouseEvent as ReactMouseEvent, useCallback, useEffect, useRef } from "react";
 import { usePlayerTranslation } from "../../hooks/use-player-translation";
 import type { Locale } from "../../lib/locale";
 import { isMiddleMouseButton } from "../../lib/media-direct-link";
@@ -21,6 +21,57 @@ interface ChannelListItemProps {
   onCopyMediaLink: (channel: Channel) => void;
   locale: Locale;
   currentProgram?: string;
+}
+
+function CurrentProgramTitle({ title }: { title: string }) {
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const textRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const text = textRef.current;
+    if (!container || !text) return;
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let animation: Animation | undefined;
+    const updateAnimation = () => {
+      animation?.cancel();
+      const overflow = text.scrollWidth - container.clientWidth;
+      if (overflow <= 0 || container.clientWidth === 0 || reducedMotion.matches) return;
+
+      // Move at 30px/s with a pause at each end before reversing.
+      const travelTime = (overflow / 30) * 1000;
+      const duration = travelTime + 3000;
+      animation = text.animate(
+        [
+          { transform: "translateX(0)", offset: 0 },
+          { transform: "translateX(0)", offset: 1500 / duration },
+          { transform: `translateX(-${overflow}px)`, offset: 1 - 1500 / duration },
+          { transform: `translateX(-${overflow}px)`, offset: 1 },
+        ],
+        { duration, iterations: Infinity, direction: "alternate", easing: "linear" },
+      );
+    };
+
+    const observer = new ResizeObserver(updateAnimation);
+    observer.observe(container);
+    observer.observe(text);
+    reducedMotion.addEventListener("change", updateAnimation);
+    updateAnimation();
+    return () => {
+      animation?.cancel();
+      observer.disconnect();
+      reducedMotion.removeEventListener("change", updateAnimation);
+    };
+  }, []);
+
+  return (
+    <span ref={containerRef} className="min-w-0 flex-1 overflow-hidden" title={title}>
+      <span ref={textRef} className="block w-max whitespace-nowrap">
+        {title}
+      </span>
+    </span>
+  );
 }
 
 const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemProps>(
@@ -85,12 +136,31 @@ const ChannelListItemComponent = forwardRef<HTMLButtonElement, ChannelListItemPr
               </span>
             )}
           </div>
-          <div className="mt-0.5 truncate text-[10px] text-slate-500 leading-4 dark:text-slate-400 md:text-xs">
-            {groupLabel}
-            {currentProgram && (
+          <div
+            className={clsx(
+              "mt-0.5 text-[10px] text-slate-500 leading-4 dark:text-slate-400 md:text-xs",
+              isCurrentChannel && currentProgram ? "flex items-center" : "truncate",
+            )}
+          >
+            {isCurrentChannel && currentProgram ? (
               <>
-                {groupLabel && <span className="mx-1">·</span>}
-                <span>{currentProgram}</span>
+                {groupLabel && (
+                  <>
+                    <span className="max-w-1/2 truncate">{groupLabel}</span>
+                    <span className="mx-1 shrink-0">·</span>
+                  </>
+                )}
+                <CurrentProgramTitle key={currentProgram} title={currentProgram} />
+              </>
+            ) : (
+              <>
+                {groupLabel}
+                {currentProgram && (
+                  <>
+                    {groupLabel && <span className="mx-1">·</span>}
+                    <span>{currentProgram}</span>
+                  </>
+                )}
               </>
             )}
           </div>

--- a/web-ui/src/components/player/channel-list-item.tsx
+++ b/web-ui/src/components/player/channel-list-item.tsx
@@ -34,22 +34,32 @@ function CurrentProgramTitle({ title }: { title: string }) {
 
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     let animation: Animation | undefined;
+    let previousDistance = 0;
     const updateAnimation = () => {
-      animation?.cancel();
-      const overflow = text.scrollWidth - container.clientWidth;
-      if (overflow <= 0 || container.clientWidth === 0 || reducedMotion.matches) return;
+      const distance =
+        container.clientWidth === 0 || reducedMotion.matches
+          ? 0
+          : Math.max(0, text.scrollWidth - container.clientWidth);
+      if (distance === previousDistance) return;
+      previousDistance = distance;
 
-      // Move at 30px/s with a pause at each end before reversing.
-      const travelTime = (overflow / 30) * 1000;
-      const duration = travelTime + 3000;
+      animation?.cancel();
+      animation = undefined;
+      if (distance === 0) return;
+
+      // One complete round trip at 30px/s, with a 1.5s pause at each end.
+      const pauseTime = 1500;
+      const travelTime = (distance / 30) * 1000;
+      const duration = 2 * (travelTime + pauseTime);
       animation = text.animate(
         [
           { transform: "translateX(0)", offset: 0 },
-          { transform: "translateX(0)", offset: 1500 / duration },
-          { transform: `translateX(-${overflow}px)`, offset: 1 - 1500 / duration },
-          { transform: `translateX(-${overflow}px)`, offset: 1 },
+          { transform: "translateX(0)", offset: pauseTime / duration },
+          { transform: `translateX(-${distance}px)`, offset: (pauseTime + travelTime) / duration },
+          { transform: `translateX(-${distance}px)`, offset: (2 * pauseTime + travelTime) / duration },
+          { transform: "translateX(0)", offset: 1 },
         ],
-        { duration, iterations: Infinity, direction: "alternate", easing: "linear" },
+        { duration, iterations: Infinity, easing: "linear" },
       );
     };
 
@@ -67,7 +77,7 @@ function CurrentProgramTitle({ title }: { title: string }) {
 
   return (
     <span ref={containerRef} className="min-w-0 flex-1 overflow-hidden" title={title}>
-      <span ref={textRef} className="block w-max whitespace-nowrap">
+      <span ref={textRef} className="block w-max whitespace-nowrap motion-reduce:w-auto motion-reduce:truncate">
         {title}
       </span>
     </span>


### PR DESCRIPTION
## Summary

- Add animated horizontal scrolling for truncated current-program titles.
- Pause at both ends and animate at a steady 30px/s.
- Respect reduced-motion preferences and respond to container/text resizing.
- Preserve group labels and existing behavior for non-current channels.

## Testing

- Not run (not requested).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Player list UI-only change with no auth, data, or API impact; animation is gated by reduced-motion and cleaned up on unmount.
> 
> **Overview**
> For the **currently selected** channel, long **current program** titles now **scroll horizontally** instead of being clipped by a single `truncate` on the whole subtitle row.
> 
> A new `CurrentProgramTitle` component drives a **round-trip marquee** via the Web Animations API (**30px/s**, **1.5s pauses** at each end). It **recomputes on resize** (`ResizeObserver`), **honors `prefers-reduced-motion`** (static truncate), and **resets when the program string changes** (`key={currentProgram}`). The subtitle row becomes a **flex layout**: group label stays **truncated** (max half width) with a separator, and the program title gets the remaining space.
> 
> **Non-current** channels and rows **without** a current program keep the **previous truncate** behavior for group + program text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0bebf63362d01a653ed828849bf1a9e6814b49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->