### PR TITLE
ci(release): add powerpc_464fp OpenWrt architecture

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,6 +165,7 @@ jobs:
           - mipsel_24kc_24kf
           - mipsel_74kc
           - mipsel_mips32
+          - powerpc_464fp
 
         sdk:
           - "24.10.8" # For IPK


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `powerpc_464fp` to the OpenWrt release matrix so GitHub Releases include IPK (24.10.8) and APK (25.12.5) packages for `apm821xx` devices.

This matches the architecture reported in https://github.com/stackia/rtp2httpd/issues/757. Official OpenWrt SDK images exist for both versions we already build:

- `openwrt/sdk:powerpc_464fp-24.10.8`
- `openwrt/sdk:powerpc_464fp-25.12.5`

The install script already reads `DISTRIB_ARCH` from `/etc/openwrt_release`, so no extra mapping is required once the packages are uploaded.

## Verification

The release workflow only runs on published tags, so this PR does not itself produce the new packages. The package was cross-compiled locally with the official OpenWrt 24.10.8 `apm821xx/nand` SDK:

- `CONFIG_TARGET_ARCH_PACKAGES=powerpc_464fp`
- Resulting IPK: `rtp2httpd_20260909-r1_powerpc_464fp.ipk`
- Binary: ELF 32-bit MSB PowerPC, `ld-musl-powerpc.so.1`

The next published release will upload `rtp2httpd_*_powerpc_464fp.ipk` and `rtp2httpd-*_powerpc_464fp.apk`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64749119-a5e9-4311-ad4c-44441e4f96db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64749119-a5e9-4311-ad4c-44441e4f96db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

