### PR TITLE
fix(installer): restart running service after OpenWrt updates

### DIFF
--- a/scripts/install-openwrt.sh
+++ b/scripts/install-openwrt.sh
@@ -26,6 +26,9 @@ TMP_DIR="/tmp/rtp2httpd_install"
 # Whether to use prerelease version
 USE_PRERELEASE=false
 
+# Preserve the service's runtime state across package installation.
+SERVICE_WAS_RUNNING=false
+
 # Language: zh (default) or en
 LANG_CODE="zh"
 
@@ -384,6 +387,34 @@ install_package() {
     return 0
 }
 
+# Restart a previously running service after a successful installation.
+restart_service() {
+    if [ "$SERVICE_WAS_RUNNING" != true ]; then
+        return 0
+    fi
+
+    print_info "$(msg '重启 rtp2httpd 服务以应用更新（当前播放会短暂中断）...' 'Restarting rtp2httpd to apply the update (active playback will briefly disconnect)...')"
+
+    if ! /etc/init.d/rtp2httpd restart; then
+        print_error "$(msg '软件包已安装，但服务重启失败。请检查日志并手动执行 /etc/init.d/rtp2httpd restart' 'Packages installed, but service restart failed. Check the logs and run /etc/init.d/rtp2httpd restart manually.')"
+        return 1
+    fi
+
+    # procd starts services asynchronously; allow time for the instance to appear.
+    local attempts=0
+    while [ "$attempts" -lt 10 ]; do
+        sleep 1
+        if /etc/init.d/rtp2httpd running >/dev/null 2>&1; then
+            print_info "$(msg 'rtp2httpd 服务已重启' 'rtp2httpd service restarted')"
+            return 0
+        fi
+        attempts=$((attempts + 1))
+    done
+
+    print_error "$(msg '软件包已安装，但未检测到服务运行。请使用 logread -e rtp2httpd 检查日志，并手动执行 /etc/init.d/rtp2httpd restart' 'Packages installed, but the service is not running. Check logs with logread -e rtp2httpd and run /etc/init.d/rtp2httpd restart manually.')"
+    return 1
+}
+
 # Clean up temporary files
 cleanup() {
     if [ -d "$TMP_DIR" ]; then
@@ -535,6 +566,12 @@ main() {
 
     INSTALL_SUCCESS=true
 
+    # Capture this before package hooks can stop or restart the old process.
+    if [ -x /etc/init.d/rtp2httpd ] && /etc/init.d/rtp2httpd running >/dev/null 2>&1; then
+        SERVICE_WAS_RUNNING=true
+        print_info "$(msg '服务正在运行，安装成功后将自动重启（当前播放会短暂中断）' 'The service is running and will restart after installation (active playback will briefly disconnect)')"
+    fi
+
     for package in $PACKAGES; do
         package_file="${TMP_DIR}/${package}"
 
@@ -553,6 +590,8 @@ main() {
         exit 1
     fi
 
+    restart_service
+
     # Installation successful
     print_info ""
     print_info "=========================================="
@@ -565,7 +604,11 @@ main() {
     print_info "$(msg '1. 访问 LuCI 管理界面' '1. Access the LuCI admin interface')"
     print_info "$(msg "2. 在 '服务' 菜单中找到 'rtp2httpd'" "2. Find 'rtp2httpd' in the 'Services' menu")"
     print_info "$(msg '3. 根据需要配置服务参数' '3. Configure the service parameters as needed')"
-    print_info "$(msg '4. 启动服务' '4. Start the service')"
+    if [ "$SERVICE_WAS_RUNNING" = true ]; then
+        print_info "$(msg '4. 服务已自动重启，刷新状态面板查看版本' '4. The service has restarted; refresh the status page to check the version')"
+    else
+        print_info "$(msg '4. 启动服务' '4. Start the service')"
+    fi
     print_info ""
     print_info "$(msg '更多信息请访问' 'For more info visit'): https://github.com/${REPO_OWNER}/${REPO_NAME}"
     print_info ""


### PR DESCRIPTION
Updating with the OpenWrt installer could leave the old process running, so the status page continued to show the previous version. Capture the service state before package installation and restart previously running services after all packages install successfully.

Wait up to 10 seconds for procd to report a running instance. Restart failures and startup timeouts return an error with recovery instructions. Fresh installations and previously stopped services retain manual-start instructions.

Validation: shell syntax and diff checks, plus 12 mocked shell scenarios covering opkg/apk, running/stopped services, asynchronous startup, restart failure, startup timeout, and package failure. Not yet tested on a physical OpenWrt device.

Fixes #762

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Installer-only behavior change with no auth or data-path impact; main risk is a brief service interruption or a failed restart after packages already installed.
> 
> **Overview**
> The OpenWrt quick installer now **records whether `rtp2httpd` was running before `opkg`/`apk` installs**, then **restarts it after a successful upgrade** so the new binary actually runs (fixing stale version on the status page).
> 
> A new **`restart_service`** path runs `/etc/init.d/rtp2httpd restart`, polls for up to **10 seconds** for procd to report running, and surfaces bilingual errors with manual recovery steps if restart or startup fails. Users are warned that **active playback may briefly disconnect**; fresh installs or stopped services still get the manual “start the service” next step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e49cc902986932519f1b13c6c4a6d853c82862a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->