### PR TITLE
docs(installation): add Homebrew deployment instructions

### DIFF
--- a/docs/en/guide/installation.md
+++ b/docs/en/guide/installation.md
@@ -32,21 +32,19 @@ On macOS and Linux, you can install rtp2httpd using [Homebrew](https://brew.sh):
 brew install rtp2httpd
 ```
 
-The Homebrew package includes a service definition, so you do not need to create a service file manually. After installation, edit the configuration file at `$(brew --prefix)/etc/rtp2httpd.conf`, then start the service and enable it to launch when the current user logs in:
+After installation, edit the configuration file at `$(brew --prefix)/etc/rtp2httpd.conf`, then start the service (and register it to start automatically when the user logs in after boot):
 
 ```bash
 brew services start rtp2httpd
 ```
 
-To start automatically at system boot without requiring a user to log in, use a system service:
+To start automatically at system boot without requiring a user to log in, use sudo:
 
 ```bash
 # Stop the user service first if it was previously started to avoid duplicate instances
 brew services stop rtp2httpd
 sudo brew services start rtp2httpd
 ```
-
-`brew services start` both starts the service and registers it to launch automatically; no separate `enable` command is needed. Without `sudo`, it starts at login; with `sudo`, it starts at boot. Linux requires systemd. See the [Homebrew service management documentation](https://docs.brew.sh/Manpage#services-subcommand) for details.
 
 ## Static Binary Deployment
 
@@ -74,7 +72,7 @@ chmod +x rtp2httpd-X.Y.Z-x86_64
 > [!TIP]
 > You can use this example file [rtp2httpd.conf](https://github.com/stackia/rtp2httpd/blob/main/rtp2httpd.conf) as a base to modify your configuration. See [Configuration Reference](/en/reference/configuration) for details.
 
-Also note that rtp2httpd no longer supports running as a daemon on its own. On Debian/Ubuntu systems, you can create a systemd service unit by adding the following content to `/etc/systemd/system/rtp2httpd.service`. Other operating systems using systemd as the service manager can also refer to the configuration below.
+On systems using systemd, such as Debian/Ubuntu, you can create a systemd service unit by adding the following content to `/etc/systemd/system/rtp2httpd.service`.
 
 ```text
 [Unit]

--- a/docs/en/guide/installation.md
+++ b/docs/en/guide/installation.md
@@ -24,6 +24,20 @@ The following firmware distributions and platforms include rtp2httpd, or offer i
 - [AutoBuildImmortalWrt](https://github.com/wukongdaily/AutoBuildImmortalWrt): rtp2httpd is built into [store](https://github.com/wukongdaily/store) for easy builds
 - [Pandora QWRT for K2P](https://www.right.com.cn/forum/forum.php?mod=viewthread&tid=8346913&fromuid=402348): rtp2httpd is built in
 
+## Homebrew Deployment
+
+On macOS and Linux, you can install rtp2httpd using [Homebrew](https://brew.sh):
+
+```bash
+brew install rtp2httpd
+```
+
+After installation, edit the configuration file at `$(brew --prefix)/etc/rtp2httpd.conf`, then start the service:
+
+```bash
+brew services start rtp2httpd
+```
+
 ## Static Binary Deployment
 
 Download the static binary file `rtp2httpd-<version>-<arch>` for your architecture from the [Releases](https://github.com/stackia/rtp2httpd/releases) page, upload to your device, `chmod +x` and run.

--- a/docs/en/guide/installation.md
+++ b/docs/en/guide/installation.md
@@ -32,11 +32,21 @@ On macOS and Linux, you can install rtp2httpd using [Homebrew](https://brew.sh):
 brew install rtp2httpd
 ```
 
-After installation, edit the configuration file at `$(brew --prefix)/etc/rtp2httpd.conf`, then start the service:
+The Homebrew package includes a service definition, so you do not need to create a service file manually. After installation, edit the configuration file at `$(brew --prefix)/etc/rtp2httpd.conf`, then start the service and enable it to launch when the current user logs in:
 
 ```bash
 brew services start rtp2httpd
 ```
+
+To start automatically at system boot without requiring a user to log in, use a system service:
+
+```bash
+# Stop the user service first if it was previously started to avoid duplicate instances
+brew services stop rtp2httpd
+sudo brew services start rtp2httpd
+```
+
+`brew services start` both starts the service and registers it to launch automatically; no separate `enable` command is needed. Without `sudo`, it starts at login; with `sudo`, it starts at boot. Linux requires systemd. See the [Homebrew service management documentation](https://docs.brew.sh/Manpage#services-subcommand) for details.
 
 ## Static Binary Deployment
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -24,6 +24,20 @@ OpenWrt 是 rtp2httpd 的最佳运行环境。在中国大陆，通常需要先�
 - [AutoBuildImmortalWrt](https://github.com/wukongdaily/AutoBuildImmortalWrt)：[store](https://github.com/wukongdaily/store) 已内置 rtp2httpd，轻松构建
 - [潘多拉 QWRT for K2P](https://www.right.com.cn/forum/forum.php?mod=viewthread&tid=8346913&fromuid=402348)：已内置 rtp2httpd
 
+## Homebrew 部署
+
+在 macOS 和 Linux 上，可以通过 [Homebrew](https://brew.sh) 安装 rtp2httpd：
+
+```bash
+brew install rtp2httpd
+```
+
+安装后，编辑 `$(brew --prefix)/etc/rtp2httpd.conf` 配置文件，然后启动服务：
+
+```bash
+brew services start rtp2httpd
+```
+
 ## 静态二进制文件部署
 
 从 [Releases](https://github.com/stackia/rtp2httpd/releases) 页面下载对应架构的静态二进制文件 `rtp2httpd-<版本号>-<架构>`，上传到设备并 `chmod +x` 后即可运行。

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -32,21 +32,19 @@ OpenWrt 是 rtp2httpd 的最佳运行环境。在中国大陆，通常需要先�
 brew install rtp2httpd
 ```
 
-Homebrew 包已包含服务定义，无需手动创建服务文件。安装后，编辑 `$(brew --prefix)/etc/rtp2httpd.conf` 配置文件，然后启动服务并启用当前用户登录后自启：
+安装后，编辑 `$(brew --prefix)/etc/rtp2httpd.conf` 配置文件，然后启动服务（并注册开机用户登录后自启）：
 
 ```bash
 brew services start rtp2httpd
 ```
 
-如果需要在系统开机时自启（无需用户登录），使用系统级服务：
+如果需要在系统开机时自启（无需用户登录），需要使用 sudo：
 
 ```bash
 # 如果之前已启动用户级服务，先停止，避免重复运行
 brew services stop rtp2httpd
 sudo brew services start rtp2httpd
 ```
-
-`brew services start` 会同时启动服务并注册自启，无需额外执行 `enable`。不带 `sudo` 时为登录后自启，带 `sudo` 时为开机自启。Linux 上需要 systemd。详见 [Homebrew 服务管理文档](https://docs.brew.sh/Manpage#services-subcommand)。
 
 ## 静态二进制文件部署
 
@@ -74,7 +72,7 @@ chmod +x rtp2httpd-X.Y.Z-x86_64
 > [!TIP]
 > 你可以使用这个示例文件 [rtp2httpd.conf](https://github.com/stackia/rtp2httpd/blob/main/rtp2httpd.conf) 作为基础来修改配置。具体说明见 [配置参数详解](../reference/configuration.md)。
 
-另外 rtp2httpd 目前已不支持自身以守护进程方式运行。对于 Debian/Ubuntu 系统，您可以在 `/etc/systemd/system/rtp2httpd.service` 内添加以下内容以创建 systemd 服务单元。其他使用 systemd 作为服务管理器的操作系统也可以参考以下配置进行配置。
+对于 Debian/Ubuntu 等使用 systemd 的系统，您可以在 `/etc/systemd/system/rtp2httpd.service` 内添加以下内容以创建 systemd 服务单元。
 
 ```text
 [Unit]

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -32,11 +32,21 @@ OpenWrt 是 rtp2httpd 的最佳运行环境。在中国大陆，通常需要先�
 brew install rtp2httpd
 ```
 
-安装后，编辑 `$(brew --prefix)/etc/rtp2httpd.conf` 配置文件，然后启动服务：
+Homebrew 包已包含服务定义，无需手动创建服务文件。安装后，编辑 `$(brew --prefix)/etc/rtp2httpd.conf` 配置文件，然后启动服务并启用当前用户登录后自启：
 
 ```bash
 brew services start rtp2httpd
 ```
+
+如果需要在系统开机时自启（无需用户登录），使用系统级服务：
+
+```bash
+# 如果之前已启动用户级服务，先停止，避免重复运行
+brew services stop rtp2httpd
+sudo brew services start rtp2httpd
+```
+
+`brew services start` 会同时启动服务并注册自启，无需额外执行 `enable`。不带 `sudo` 时为登录后自启，带 `sudo` 时为开机自启。Linux 上需要 systemd。详见 [Homebrew 服务管理文档](https://docs.brew.sh/Manpage#services-subcommand)。
 
 ## 静态二进制文件部署
 


### PR DESCRIPTION
Add Homebrew installation, configuration, and service autostart instructions for macOS and Linux before static binary deployment. Clarify login versus boot startup, simplify the systemd introduction, and synchronize the English translation.

Validation: git diff --check passed; Homebrew installation and service commands verified against official documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to installation guides with no runtime or security impact.
> 
> **Overview**
> Adds a **Homebrew deployment** section to the Chinese and English installation guides, placed before static binary deployment. It documents `brew install rtp2httpd`, editing `$(brew --prefix)/etc/rtp2httpd.conf`, and starting the service with `brew services`, including how to switch from user-level autostart to `sudo brew services` for boot without login (and stopping the user service to avoid duplicates).
> 
> The **systemd** paragraph under static binary deployment is shortened: it drops the note that rtp2httpd no longer self-daemonizes and instead directly tells Debian/Ubuntu (and other systemd) users how to add `/etc/systemd/system/rtp2httpd.service`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b8f3a9f575b3122d7e205bd6af7ca89ad7c967. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->